### PR TITLE
segfault

### DIFF
--- a/networkmanager.cpp
+++ b/networkmanager.cpp
@@ -4,6 +4,7 @@
 #include "debug_functions.h"
 #include "lobby.h"
 
+#include <cstring>
 
 NetworkManager::NetworkManager(AOApplication *parent) : QObject(parent)
 {
@@ -75,8 +76,9 @@ void NetworkManager::ship_server_packet(QString p_packet)
 
 void NetworkManager::handle_ms_packet()
 {
-  char buffer[16384] = {0};
-  ms_socket->read(buffer, ms_socket->bytesAvailable());
+  char buffer[buffer_max_size];
+  std::memset(buffer, 0, buffer_max_size);
+  ms_socket->read(buffer, buffer_max_size);
 
   QString in_data = buffer;
 
@@ -100,7 +102,7 @@ void NetworkManager::handle_ms_packet()
   QStringList packet_list = in_data.split("%", QString::SplitBehavior(QString::SkipEmptyParts));
 
   for (QString packet : packet_list)
-  {    
+  {
     AOPacket *f_packet = new AOPacket(packet);
 
     ao_app->ms_packet_received(f_packet);
@@ -213,8 +215,9 @@ void NetworkManager::retry_ms_connect()
 
 void NetworkManager::handle_server_packet()
 {
-  char buffer[16384] = {0};
-  server_socket->read(buffer, server_socket->bytesAvailable());
+  char buffer[buffer_max_size];
+  std::memset(buffer, 0, buffer_max_size);
+  server_socket->read(buffer, buffer_max_size);
 
   QString in_data = buffer;
 

--- a/networkmanager.h
+++ b/networkmanager.h
@@ -48,6 +48,9 @@ public:
 
   const int ms_reconnect_delay_ms = 7000;
 
+  // kind of arbitrary max buffer size
+  const size_t buffer_max_size = 16384;
+
   bool ms_partial_packet = false;
   QString ms_temp_packet = "";
 


### PR DESCRIPTION
Fix segmentation fault crash when dealing with extremely large packets upon investigation of https://github.com/AttorneyOnline/AO2-Client/issues/17

The change is meant to preserve the original implementation rather than a new one while fixing the problem.