### PR TITLE
Loading progress bar fix on server join.

### DIFF
--- a/packet_distribution.cpp
+++ b/packet_distribution.cpp
@@ -272,6 +272,8 @@ void AOApplication::server_packet_received(AOPacket *p_packet)
     if (!courtroom_constructed)
       goto end;
 
+    int total_loading_size = char_list_size + evidence_list_size + music_list_size;
+
     for (int n_element = 0 ; n_element < f_contents.size() ; n_element += 2)
     {
       if (f_contents.at(n_element).toInt() != loaded_chars)
@@ -297,11 +299,10 @@ void AOApplication::server_packet_received(AOPacket *p_packet)
       w_lobby->set_loading_text("Loading chars:\n" + QString::number(loaded_chars) + "/" + QString::number(char_list_size));
 
       w_courtroom->append_char(f_char);
-    }
 
-    int total_loading_size = char_list_size + evidence_list_size + music_list_size;
-    int loading_value = (loaded_chars / static_cast<double>(total_loading_size)) * 100;
-    w_lobby->set_loading_value(loading_value);
+      int loading_value = (loaded_chars / static_cast<double>(total_loading_size)) * 100;
+      w_lobby->set_loading_value(loading_value);
+    }
 
     if (improved_loading_enabled)
       send_server_packet(new AOPacket("RE#%"));
@@ -355,6 +356,8 @@ void AOApplication::server_packet_received(AOPacket *p_packet)
     if (!courtroom_constructed)
       goto end;
 
+    int total_loading_size = char_list_size + evidence_list_size + music_list_size;
+
     for (int n_element = 0 ; n_element < f_contents.size() ; n_element += 2)
     {
       if (f_contents.at(n_element).toInt() != loaded_music)
@@ -370,12 +373,11 @@ void AOApplication::server_packet_received(AOPacket *p_packet)
       w_lobby->set_loading_text("Loading music:\n" + QString::number(loaded_music) + "/" + QString::number(music_list_size));
 
       w_courtroom->append_music(f_music);
+
+      int loading_value = ((loaded_chars + loaded_evidence + loaded_music) / static_cast<double>(total_loading_size)) * 100;
+      w_lobby->set_loading_value(loading_value);
+
     }
-
-    int total_loading_size = char_list_size + evidence_list_size + music_list_size;
-    int loading_value = ((loaded_chars + loaded_evidence + loaded_music) / static_cast<double>(total_loading_size)) * 100;
-    w_lobby->set_loading_value(loading_value);
-
     QString next_packet_number = QString::number(((loaded_music - 1) / 10) + 1);
     send_server_packet(new AOPacket("AM#" + next_packet_number + "#%"));
   }
@@ -398,6 +400,8 @@ void AOApplication::server_packet_received(AOPacket *p_packet)
     if (!courtroom_constructed)
       goto end;
 
+    int total_loading_size = char_list_size + evidence_list_size + music_list_size;
+
     for (int n_element = 0 ; n_element < f_contents.size() ; ++n_element)
     {
       QStringList sub_elements = f_contents.at(n_element).split("&");
@@ -415,11 +419,10 @@ void AOApplication::server_packet_received(AOPacket *p_packet)
       w_lobby->set_loading_text("Loading chars:\n" + QString::number(loaded_chars) + "/" + QString::number(char_list_size));
 
       w_courtroom->append_char(f_char);
-    }
 
-    int total_loading_size = char_list_size + evidence_list_size + music_list_size;
-    int loading_value = (loaded_chars / static_cast<double>(total_loading_size)) * 100;
-    w_lobby->set_loading_value(loading_value);
+      int loading_value = ((loaded_chars + loaded_evidence + loaded_music) / static_cast<double>(total_loading_size)) * 100;
+      w_lobby->set_loading_value(loading_value);
+    }
 
     send_server_packet(new AOPacket("RM#%"));
   }
@@ -428,6 +431,8 @@ void AOApplication::server_packet_received(AOPacket *p_packet)
     if (!courtroom_constructed)
       goto end;
 
+    int total_loading_size = char_list_size + evidence_list_size + music_list_size;
+
     for (int n_element = 0 ; n_element < f_contents.size() ; ++n_element)
     {
       ++loaded_music;
@@ -435,11 +440,10 @@ void AOApplication::server_packet_received(AOPacket *p_packet)
       w_lobby->set_loading_text("Loading music:\n" + QString::number(loaded_music) + "/" + QString::number(music_list_size));
 
       w_courtroom->append_music(f_contents.at(n_element));
-    }
 
-    int total_loading_size = char_list_size + evidence_list_size + music_list_size;
-    int loading_value = (loaded_chars / static_cast<double>(total_loading_size)) * 100;
-    w_lobby->set_loading_value(loading_value);
+      int loading_value = ((loaded_chars + loaded_evidence + loaded_music) / static_cast<double>(total_loading_size)) * 100;
+      w_lobby->set_loading_value(loading_value);
+    }
 
     send_server_packet(new AOPacket("RD#%"));
   }


### PR DESCRIPTION
Previously, the loading progress bar operated essentially in four different states:
- Nothing is loaded
- All possible characters are loaded
- The above, plus all evidence in the default area
- The above, plus all possible songs loaded.

In practice, the latter two were never even seen, since most servers don't leave evidence in their default areas, and the last step is equivalent to having everything loaded, so the player is booted to character selection screen.

This was because the loading bar calculations and updates existed outside the for loop that actually loaded characters / music, and were never updated until after everything has been loaded.

This pull request changes that by calculating the total before the for loops, and calculating the progress bar updates inside them.