### PR TITLE
Move most file access functions into a singleton of its own, have most objects access that instead of the AO app.

### DIFF
--- a/aoapplication.cpp
+++ b/aoapplication.cpp
@@ -10,7 +10,7 @@
 
 AOApplication::AOApplication(int &argc, char **argv) : QApplication(argc, argv)
 {
-  TextFileHandler::createInstance(this);
+  TextFileHandler::create_instance(this);
 
   net_manager = new NetworkManager();
   QObject::connect(net_manager->server_socket, SIGNAL(disconnected()), this, SLOT(server_disconnected()));
@@ -50,7 +50,7 @@ void AOApplication::construct_lobby()
   int y = (screenGeometry.height()-w_lobby->height()) / 2;
   w_lobby->move(x, y);
 
-  if (TextFileHandler::getInstance()->is_discord_enabled())
+  if (TextFileHandler::get_instance()->is_discord_enabled())
     discord->state_lobby();
 
   w_lobby->show();
@@ -109,7 +109,7 @@ QString AOApplication::get_version_string()
 
 void AOApplication::set_favorite_list()
 {
-  favorite_list = TextFileHandler::getInstance()->read_serverlist_txt();
+  favorite_list = TextFileHandler::get_instance()->read_serverlist_txt();
 }
 
 QString AOApplication::get_current_char()
@@ -131,7 +131,7 @@ void AOApplication::add_favorite_server(int p_server)
 
   QString server_line = fav_server.ip + ":" + str_port + ":" + fav_server.name;
 
-  TextFileHandler::getInstance()->write_to_serverlist_txt(server_line);
+  TextFileHandler::get_instance()->write_to_serverlist_txt(server_line);
 }
 
 void AOApplication::server_disconnected()

--- a/aoapplication.cpp
+++ b/aoapplication.cpp
@@ -10,7 +10,7 @@
 
 AOApplication::AOApplication(int &argc, char **argv) : QApplication(argc, argv)
 {
-  TextFileHandler::getInstance().give_ao_app_pointer(this);
+  TextFileHandler::createInstance(this);
 
   net_manager = new NetworkManager();
   QObject::connect(net_manager->server_socket, SIGNAL(disconnected()), this, SLOT(server_disconnected()));
@@ -50,7 +50,7 @@ void AOApplication::construct_lobby()
   int y = (screenGeometry.height()-w_lobby->height()) / 2;
   w_lobby->move(x, y);
 
-  if (TextFileHandler::getInstance().is_discord_enabled())
+  if (TextFileHandler::getInstance()->is_discord_enabled())
     discord->state_lobby();
 
   w_lobby->show();
@@ -109,7 +109,7 @@ QString AOApplication::get_version_string()
 
 void AOApplication::set_favorite_list()
 {
-  favorite_list = TextFileHandler::getInstance().read_serverlist_txt();
+  favorite_list = TextFileHandler::getInstance()->read_serverlist_txt();
 }
 
 QString AOApplication::get_current_char()
@@ -131,7 +131,7 @@ void AOApplication::add_favorite_server(int p_server)
 
   QString server_line = fav_server.ip + ":" + str_port + ":" + fav_server.name;
 
-  TextFileHandler::getInstance().write_to_serverlist_txt(server_line);
+  TextFileHandler::getInstance()->write_to_serverlist_txt(server_line);
 }
 
 void AOApplication::server_disconnected()

--- a/aoapplication.cpp
+++ b/aoapplication.cpp
@@ -40,6 +40,8 @@ void AOApplication::construct_lobby()
 
   w_lobby = new Lobby(this);
   connect(w_lobby, SIGNAL(cancel_clicked()), this, SLOT(loading_cancelled()));
+  connect(w_lobby, SIGNAL(send_server_packet(AOPacket*, bool)), this, SLOT(send_server_packet(AOPacket*, bool)));
+  connect(w_lobby, SIGNAL(send_ms_packet(AOPacket*)), this, SLOT(send_ms_packet(AOPacket*)));
 
   lobby_constructed = true;
 
@@ -75,6 +77,8 @@ void AOApplication::construct_courtroom()
   }
 
   w_courtroom = new Courtroom(this);
+  connect(w_courtroom, SIGNAL(send_server_packet(AOPacket*, bool)), this, SLOT(send_server_packet(AOPacket*, bool)));
+  connect(w_courtroom, SIGNAL(send_ms_packet(AOPacket*)), this, SLOT(send_ms_packet(AOPacket*)));
   courtroom_constructed = true;
 
   QRect screenGeometry = QApplication::desktop()->screenGeometry();
@@ -175,14 +179,15 @@ void AOApplication::ms_connect_finished(bool connected, bool will_retry)
 
 void AOApplication::call_settings_menu()
 {
-    AOOptionsDialog settings(nullptr, this);
+    AOOptionsDialog settings(nullptr, casing_alerts_enabled);
     settings.exec();
 }
 
-void AOApplication::call_announce_menu(Courtroom *court)
+void AOApplication::call_announce_menu()
 {
-    AOCaseAnnouncerDialog announcer(nullptr, court);
-    announcer.exec();
+    AOCaseAnnouncerDialog* announcer = new AOCaseAnnouncerDialog(nullptr);
+    QObject::connect(announcer, SIGNAL(announce_case(QString*, bool, bool, bool, bool, bool)), w_courtroom, SLOT(announce_case(QString*, bool, bool, bool, bool, bool)));
+    announcer->exec();
 }
 
 void AOApplication::force_process_events()

--- a/aoapplication.h
+++ b/aoapplication.h
@@ -49,9 +49,6 @@ public:
   void construct_courtroom();
   void destruct_courtroom();
 
-  void ms_packet_received(AOPacket *p_packet);
-  void server_packet_received(AOPacket *p_packet);
-
   void send_ms_packet(AOPacket *p_packet);
   void send_server_packet(AOPacket *p_packet, bool encoded = true);
 
@@ -108,194 +105,8 @@ public:
   void set_server_list();
   QVector<server_type>& get_server_list() {return server_list;}
 
-  //reads the theme from config.ini and sets it accordingly
-  void reload_theme();
-
   //Returns the character the player has currently selected
   QString get_current_char();
-
-  //implementation in path_functions.cpp
-  QString get_base_path();
-  QString get_data_path();
-  QString get_theme_path(QString p_file);
-  QString get_default_theme_path(QString p_file);
-  QString get_custom_theme_path(QString p_theme, QString p_file);
-  QString get_character_path(QString p_char, QString p_file);
-  QString get_sounds_path(QString p_file);
-  QString get_music_path(QString p_song);
-  QString get_background_path(QString p_file);
-  QString get_default_background_path(QString p_file);
-  QString get_evidence_path(QString p_file);
-  QString get_case_sensitive_path(QString p_file);
-
-  ////// Functions for reading and writing files //////
-  // Implementations file_functions.cpp
-
-  // Instead of reinventing the wheel, we'll use a QSettings class.
-  QSettings *configini;
-
-  //Reads the theme from config.ini and loads it into the current_theme variable
-  QString read_theme();
-
-  //Returns the value of ooc_name in config.ini
-  QString get_ooc_name();
-
-  //Returns the blip rate from config.ini
-  int read_blip_rate();
-
-  //Returns true if blank blips is enabled in config.ini and false otherwise
-  bool get_blank_blip();
-
-  //Returns the value of default_music in config.ini
-  int get_default_music();
-
-  //Returns the value of default_sfx in config.ini
-  int get_default_sfx();
-
-  //Returns the value of default_blip in config.ini
-  int get_default_blip();
-
-  // Returns the value of whether Discord should be enabled on startup
-  // from the config.ini.
-  bool is_discord_enabled();
-
-  // Returns the value of the maximum amount of lines the IC chatlog
-  // may contain, from config.ini.
-  int get_max_log_size();
-
-  // Returns whether the log should go upwards (new behaviour)
-  // or downwards (vanilla behaviour).
-  bool get_log_goes_downwards();
-
-  // Returns the username the user may have set in config.ini.
-  QString get_default_username();
-
-  // Returns the audio device used for the client.
-  QString get_audio_output_device();
-
-  // Returns whether the user would like to have custom shownames on by default.
-  bool get_showname_enabled_by_default();
-
-  //Returns the list of words in callwords.ini
-  QStringList get_call_words();
-
-  //Appends the argument string to serverlist.txt
-  void write_to_serverlist_txt(QString p_line);
-
-  //Returns the contents of serverlist.txt
-  QVector<server_type> read_serverlist_txt();
-
-  //Returns the value of p_identifier in the design.ini file in p_design_path
-  QString read_design_ini(QString p_identifier, QString p_design_path);
-
-  //Returns the coordinates of widget with p_identifier from p_file
-  QPoint get_button_spacing(QString p_identifier, QString p_file);
-
-  //Returns the dimensions of widget with specified identifier from p_file
-  pos_size_type get_element_dimensions(QString p_identifier, QString p_file);
-
-  //Returns the value of font_size with p_identifier from p_file
-  int get_font_size(QString p_identifier, QString p_file);
-
-  //Returns the color with p_identifier from p_file
-  QColor get_color(QString p_identifier, QString p_file);
-
-  // Returns the colour from the misc folder.
-  QColor get_chat_color(QString p_identifier, QString p_chat);
-
-  //Returns the sfx with p_identifier from sounds.ini in the current theme path
-  QString get_sfx(QString p_identifier);
-
-  //Figure out if we can opus this or if we should fall back to wav
-  QString get_sfx_suffix(QString sound_to_check);
-
-  // Can we use APNG for this? If not, fall back to a gif.
-  QString get_image_suffix(QString path_to_check);
-
-  //Returns the value of p_search_line within target_tag and terminator_tag
-  QString read_char_ini(QString p_char, QString p_search_line, QString target_tag);
-
-  //Returns the side of the p_char character from that characters ini file
-  QString get_char_side(QString p_char);
-
-  //Returns the showname from the ini of p_char
-  QString get_showname(QString p_char);
-
-  //Returns the value of chat from the specific p_char's ini file
-  QString get_chat(QString p_char);
-
-  //Returns the value of shouts from the specified p_char's ini file
-  QString get_char_shouts(QString p_char);
-
-  //Returns the preanim duration of p_char's p_emote
-  int get_preanim_duration(QString p_char, QString p_emote);
-
-  //Same as above, but only returns if it has a % in front(refer to Preanims section in the manual)
-  int get_ao2_preanim_duration(QString p_char, QString p_emote);
-
-  //Not in use
-  int get_text_delay(QString p_char, QString p_emote);
-
-  // Returns the custom realisation used by the character.
-  QString get_custom_realization(QString p_char);
-
-  //Returns the name of p_char
-  QString get_char_name(QString p_char);
-
-  //Returns the total amount of emotes of p_char
-  int get_emote_number(QString p_char);
-
-  //Returns the emote comment of p_char's p_emote
-  QString get_emote_comment(QString p_char, int p_emote);
-
-  //Returns the base name of p_char's p_emote
-  QString get_emote(QString p_char, int p_emote);
-
-  //Returns the preanimation name of p_char's p_emote
-  QString get_pre_emote(QString p_char, int p_emote);
-
-  //Returns the sfx of p_char's p_emote
-  QString get_sfx_name(QString p_char, int p_emote);
-
-  //Not in use
-  int get_sfx_delay(QString p_char, int p_emote);
-
-  //Returns the modifier for p_char's p_emote
-  int get_emote_mod(QString p_char, int p_emote);
-
-  //Returns the desk modifier for p_char's p_emote
-  int get_desk_mod(QString p_char, int p_emote);
-
-  //Returns p_char's gender
-  QString get_gender(QString p_char);
-
-  // ======
-  // These are all casing-related settings.
-  // ======
-
-  // Returns if the user has casing alerts enabled.
-  bool get_casing_enabled();
-
-  // Returns if the user wants to get alerts for the defence role.
-  bool get_casing_defence_enabled();
-
-  // Same for prosecution.
-  bool get_casing_prosecution_enabled();
-
-  // Same for judge.
-  bool get_casing_judge_enabled();
-
-  // Same for juror.
-  bool get_casing_juror_enabled();
-
-  // Same for steno.
-  bool get_casing_steno_enabled();
-
-  // Same for CM.
-  bool get_casing_cm_enabled();
-
-  // Get the message for the CM for casing alerts.
-  QString get_casing_can_host_cases();
 
 private:
   const int RELEASE = 2;
@@ -313,6 +124,11 @@ private slots:
 public slots:
   void server_disconnected();
   void loading_cancelled();
+
+  void ms_packet_received(AOPacket *p_packet);
+  void server_packet_received(AOPacket *p_packet);
+
+  void force_process_events();
 };
 
 #endif // AOAPPLICATION_H

--- a/aoapplication.h
+++ b/aoapplication.h
@@ -49,11 +49,8 @@ public:
   void construct_courtroom();
   void destruct_courtroom();
 
-  void send_ms_packet(AOPacket *p_packet);
-  void send_server_packet(AOPacket *p_packet, bool encoded = true);
-
   void call_settings_menu();
-  void call_announce_menu(Courtroom *court);
+  void call_announce_menu();
 
   /////////////////server metadata//////////////////
 
@@ -127,6 +124,9 @@ public slots:
 
   void ms_packet_received(AOPacket *p_packet);
   void server_packet_received(AOPacket *p_packet);
+
+  void send_ms_packet(AOPacket *p_packet);
+  void send_server_packet(AOPacket *p_packet, bool encoded = true);
 
   void force_process_events();
 };

--- a/aoblipplayer.cpp
+++ b/aoblipplayer.cpp
@@ -1,14 +1,14 @@
 #include "aoblipplayer.h"
+#include "text_file_functions.h"
 
 AOBlipPlayer::AOBlipPlayer(QWidget *parent)
 {
   m_parent = parent;
-  ao_app = p_ao_app;
 }
 
 void AOBlipPlayer::set_blips(QString p_sfx)
 {
-  QString f_path = ao_app->get_sounds_path(p_sfx);
+  QString f_path = TextFileHandler::getInstance().get_sounds_path(p_sfx);
 
   for (int n_stream = 0 ; n_stream < 5 ; ++n_stream)
   {
@@ -29,7 +29,7 @@ void AOBlipPlayer::blip_tick()
 
   HSTREAM f_stream = m_stream_list[f_cycle];
 
-  if (ao_app->get_audio_output_device() != "Default")
+  if (TextFileHandler::getInstance().get_audio_output_device() != "Default")
     BASS_ChannelSetDevice(f_stream, BASS_GetDevice());
   BASS_ChannelPlay(f_stream, false);
 }

--- a/aoblipplayer.cpp
+++ b/aoblipplayer.cpp
@@ -8,7 +8,7 @@ AOBlipPlayer::AOBlipPlayer(QWidget *parent)
 
 void AOBlipPlayer::set_blips(QString p_sfx)
 {
-  QString f_path = TextFileHandler::getInstance().get_sounds_path(p_sfx);
+  QString f_path = TextFileHandler::get_instance()->get_sounds_path(p_sfx);
 
   for (int n_stream = 0 ; n_stream < 5 ; ++n_stream)
   {
@@ -29,7 +29,7 @@ void AOBlipPlayer::blip_tick()
 
   HSTREAM f_stream = m_stream_list[f_cycle];
 
-  if (TextFileHandler::getInstance().get_audio_output_device() != "Default")
+  if (TextFileHandler::get_instance()->get_audio_output_device() != "Default")
     BASS_ChannelSetDevice(f_stream, BASS_GetDevice());
   BASS_ChannelPlay(f_stream, false);
 }

--- a/aoblipplayer.cpp
+++ b/aoblipplayer.cpp
@@ -1,6 +1,6 @@
 #include "aoblipplayer.h"
 
-AOBlipPlayer::AOBlipPlayer(QWidget *parent, AOApplication *p_ao_app)
+AOBlipPlayer::AOBlipPlayer(QWidget *parent)
 {
   m_parent = parent;
   ao_app = p_ao_app;

--- a/aoblipplayer.h
+++ b/aoblipplayer.h
@@ -2,7 +2,6 @@
 #define AOBLIPPLAYER_H
 
 #include "bass.h"
-#include "aoapplication.h"
 
 #include <QWidget>
 #include <string.h>
@@ -11,7 +10,7 @@
 class AOBlipPlayer
 {
 public:
-  AOBlipPlayer(QWidget *parent, AOApplication *p_ao_app);
+  AOBlipPlayer(QWidget *parent);
 
   void set_blips(QString p_sfx);
   void blip_tick();
@@ -21,7 +20,6 @@ public:
 
 private:
   QWidget *m_parent;
-  AOApplication *ao_app;
 
   int m_volume;
   HSTREAM m_stream_list[5];

--- a/aobutton.cpp
+++ b/aobutton.cpp
@@ -15,8 +15,8 @@ AOButton::~AOButton()
 
 void AOButton::set_image(QString p_image)
 {
-  QString image_path = TextFileHandler::getInstance().get_theme_path(p_image);
-  QString default_image_path = TextFileHandler::getInstance().get_default_theme_path(p_image);
+  QString image_path = TextFileHandler::get_instance()->get_theme_path(p_image);
+  QString default_image_path = TextFileHandler::get_instance()->get_default_theme_path(p_image);
 
   if (file_exists(image_path))
     this->setStyleSheet("border-image:url(\"" + image_path + "\")");

--- a/aobutton.cpp
+++ b/aobutton.cpp
@@ -3,7 +3,7 @@
 #include "debug_functions.h"
 #include "file_functions.h"
 
-AOButton::AOButton(QWidget *parent, AOApplication *p_ao_app) : QPushButton(parent)
+AOButton::AOButton(QWidget *parent) : QPushButton(parent)
 {
   ao_app = p_ao_app;
 }

--- a/aobutton.cpp
+++ b/aobutton.cpp
@@ -5,7 +5,7 @@
 
 AOButton::AOButton(QWidget *parent) : QPushButton(parent)
 {
-  ao_app = p_ao_app;
+
 }
 
 AOButton::~AOButton()
@@ -15,8 +15,8 @@ AOButton::~AOButton()
 
 void AOButton::set_image(QString p_image)
 {
-  QString image_path = ao_app->get_theme_path(p_image);
-  QString default_image_path = ao_app->get_default_theme_path(p_image);
+  QString image_path = TextFileHandler::getInstance().get_theme_path(p_image);
+  QString default_image_path = TextFileHandler::getInstance().get_default_theme_path(p_image);
 
   if (file_exists(image_path))
     this->setStyleSheet("border-image:url(\"" + image_path + "\")");

--- a/aobutton.h
+++ b/aobutton.h
@@ -1,8 +1,6 @@
 #ifndef AOBUTTON_H
 #define AOBUTTON_H
 
-#include "aoapplication.h"
-
 #include <QPushButton>
 #include <QDebug>
 
@@ -11,10 +9,8 @@ class AOButton : public QPushButton
   Q_OBJECT
 
 public:
-  AOButton(QWidget *parent, AOApplication *p_ao_app);
+  AOButton(QWidget *parent);
   ~AOButton();
-
-  AOApplication *ao_app;
 
   void set_image(QString p_image);
 };

--- a/aobutton.h
+++ b/aobutton.h
@@ -1,6 +1,8 @@
 #ifndef AOBUTTON_H
 #define AOBUTTON_H
 
+#include "text_file_functions.h"
+
 #include <QPushButton>
 #include <QDebug>
 

--- a/aocaseannouncerdialog.cpp
+++ b/aocaseannouncerdialog.cpp
@@ -1,10 +1,8 @@
 #include "aocaseannouncerdialog.h"
 
-AOCaseAnnouncerDialog::AOCaseAnnouncerDialog(QWidget *parent, Courtroom *p_court)
+AOCaseAnnouncerDialog::AOCaseAnnouncerDialog(QWidget *parent)
   : QDialog(parent)
 {
-  court = p_court;
-
   setWindowTitle(tr("Case Announcer"));
   resize(405, 235);
 
@@ -18,7 +16,7 @@ AOCaseAnnouncerDialog::AOCaseAnnouncerDialog(QWidget *parent, Courtroom *p_court
   ui_announcer_buttons->setOrientation(Qt::Horizontal);
   ui_announcer_buttons->setStandardButtons(QDialogButtonBox::Ok | QDialogButtonBox::Cancel);
 
-  QObject::connect(ui_announcer_buttons, SIGNAL(accepted()), this, SLOT(on_ok_pressed()));
+  QObject::connect(ui_announcer_buttons, SIGNAL(accepted()), this, SLOT(ok_pressed()));
   QObject::connect(ui_announcer_buttons, SIGNAL(rejected()), this, SLOT(cancel_pressed()));
 
   setUpdatesEnabled(false);
@@ -65,12 +63,13 @@ AOCaseAnnouncerDialog::AOCaseAnnouncerDialog(QWidget *parent, Courtroom *p_court
 
 void AOCaseAnnouncerDialog::ok_pressed()
 {
-  court->announce_case(ui_case_title_textbox->text(),
-                       ui_defense_needed->isChecked(),
-                       ui_prosecutor_needed->isChecked(),
-                       ui_judge_needed->isChecked(),
-                       ui_juror_needed->isChecked(),
-                       ui_steno_needed->isChecked());
+  QString title = ui_case_title_textbox->text();
+  announce_case(&title,
+                ui_defense_needed->isChecked(),
+                ui_prosecutor_needed->isChecked(),
+                ui_judge_needed->isChecked(),
+                ui_juror_needed->isChecked(),
+                ui_steno_needed->isChecked());
 
   done(0);
 }

--- a/aocaseannouncerdialog.cpp
+++ b/aocaseannouncerdialog.cpp
@@ -64,7 +64,7 @@ AOCaseAnnouncerDialog::AOCaseAnnouncerDialog(QWidget *parent)
 void AOCaseAnnouncerDialog::ok_pressed()
 {
   QString title = ui_case_title_textbox->text();
-  announce_case(&title,
+  emit announce_case(&title,
                 ui_defense_needed->isChecked(),
                 ui_prosecutor_needed->isChecked(),
                 ui_judge_needed->isChecked(),

--- a/aocaseannouncerdialog.cpp
+++ b/aocaseannouncerdialog.cpp
@@ -3,7 +3,6 @@
 AOCaseAnnouncerDialog::AOCaseAnnouncerDialog(QWidget *parent, Courtroom *p_court)
   : QDialog(parent)
 {
-  ao_app = p_ao_app;
   court = p_court;
 
   setWindowTitle(tr("Case Announcer"));

--- a/aocaseannouncerdialog.cpp
+++ b/aocaseannouncerdialog.cpp
@@ -1,6 +1,6 @@
 #include "aocaseannouncerdialog.h"
 
-AOCaseAnnouncerDialog::AOCaseAnnouncerDialog(QWidget *parent, AOApplication *p_ao_app, Courtroom *p_court)
+AOCaseAnnouncerDialog::AOCaseAnnouncerDialog(QWidget *parent, Courtroom *p_court)
   : QDialog(parent)
 {
   ao_app = p_ao_app;

--- a/aocaseannouncerdialog.h
+++ b/aocaseannouncerdialog.h
@@ -1,8 +1,6 @@
 #ifndef AOCASEANNOUNCERDIALOG_H
 #define AOCASEANNOUNCERDIALOG_H
 
-#include "courtroom.h"
-
 #include <QtWidgets/QDialog>
 #include <QDialogButtonBox>
 #include <QtWidgets/QVBoxLayout>
@@ -16,11 +14,9 @@ class AOCaseAnnouncerDialog : public QDialog
   Q_OBJECT
 
 public:
-  explicit AOCaseAnnouncerDialog(QWidget *parent = nullptr, Courtroom *p_court = nullptr);
+  explicit AOCaseAnnouncerDialog(QWidget *parent = nullptr);
 
 private:
-  Courtroom *court;
-
   QDialogButtonBox *ui_announcer_buttons;
 
   QVBoxLayout *ui_vbox_layout;
@@ -34,6 +30,9 @@ private:
   QCheckBox *ui_judge_needed;
   QCheckBox *ui_juror_needed;
   QCheckBox *ui_steno_needed;
+
+signals:
+  void announce_case(QString* title, bool def, bool pro, bool jud, bool jur, bool steno);
 
 public slots:
   void ok_pressed();

--- a/aocaseannouncerdialog.h
+++ b/aocaseannouncerdialog.h
@@ -1,7 +1,6 @@
 #ifndef AOCASEANNOUNCERDIALOG_H
 #define AOCASEANNOUNCERDIALOG_H
 
-#include "aoapplication.h"
 #include "courtroom.h"
 
 #include <QtWidgets/QDialog>
@@ -17,10 +16,9 @@ class AOCaseAnnouncerDialog : public QDialog
   Q_OBJECT
 
 public:
-  explicit AOCaseAnnouncerDialog(QWidget *parent = nullptr, AOApplication *p_ao_app = nullptr, Courtroom *p_court = nullptr);
+  explicit AOCaseAnnouncerDialog(QWidget *parent = nullptr, Courtroom *p_court = nullptr);
 
 private:
-  AOApplication *ao_app;
   Courtroom *court;
 
   QDialogButtonBox *ui_announcer_buttons;

--- a/aocharbutton.cpp
+++ b/aocharbutton.cpp
@@ -54,7 +54,7 @@ void AOCharButton::set_passworded()
 
 void AOCharButton::set_image(QString p_character)
 {
-  QString image_path = TextFileHandler::getInstance().get_character_path(p_character, "char_icon.png");
+  QString image_path = TextFileHandler::get_instance()->get_character_path(p_character, "char_icon.png");
 
   this->setText("");
 

--- a/aocharbutton.cpp
+++ b/aocharbutton.cpp
@@ -2,11 +2,9 @@
 
 #include "file_functions.h"
 
-AOCharButton::AOCharButton(QWidget *parent, AOApplication *p_ao_app, int x_pos, int y_pos, bool is_taken) : QPushButton(parent)
+AOCharButton::AOCharButton(QWidget *parent, int x_pos, int y_pos, bool is_taken) : QPushButton(parent)
 {
   m_parent = parent;
-
-  ao_app = p_ao_app;
 
   taken = is_taken;
 

--- a/aocharbutton.cpp
+++ b/aocharbutton.cpp
@@ -11,19 +11,19 @@ AOCharButton::AOCharButton(QWidget *parent, int x_pos, int y_pos, bool is_taken)
   this->resize(60, 60);
   this->move(x_pos, y_pos);
 
-  ui_taken = new AOImage(this, ao_app);
+  ui_taken = new AOImage(this);
   ui_taken->resize(60, 60);
   ui_taken->set_image("char_taken.png");
   ui_taken->setAttribute(Qt::WA_TransparentForMouseEvents);
   ui_taken->hide();
 
-  ui_passworded = new AOImage(this, ao_app);
+  ui_passworded = new AOImage(this);
   ui_passworded->resize(60, 60);
   ui_passworded->set_image("char_passworded");
   ui_passworded->setAttribute(Qt::WA_TransparentForMouseEvents);
   ui_passworded->hide();
 
-  ui_selector = new AOImage(parent, ao_app);
+  ui_selector = new AOImage(parent);
   ui_selector->resize(62, 62);
   ui_selector->move(x_pos - 1, y_pos - 1);
   ui_selector->set_image("char_selector.png");
@@ -54,7 +54,7 @@ void AOCharButton::set_passworded()
 
 void AOCharButton::set_image(QString p_character)
 {
-  QString image_path = ao_app->get_character_path(p_character, "char_icon.png");
+  QString image_path = TextFileHandler::getInstance().get_character_path(p_character, "char_icon.png");
 
   this->setText("");
 

--- a/aocharbutton.h
+++ b/aocharbutton.h
@@ -1,7 +1,6 @@
 #ifndef AOCHARBUTTON_H
 #define AOCHARBUTTON_H
 
-#include "aoapplication.h"
 #include "aoimage.h"
 
 #include <QPushButton>
@@ -14,9 +13,7 @@ class AOCharButton : public QPushButton
   Q_OBJECT
 
 public:
-  AOCharButton(QWidget *parent, AOApplication *p_ao_app, int x_pos, int y_pos, bool is_taken);
-
-  AOApplication *ao_app;
+  AOCharButton(QWidget *parent, int x_pos, int y_pos, bool is_taken);
 
   void refresh();
   void reset();

--- a/aocharmovie.cpp
+++ b/aocharmovie.cpp
@@ -17,7 +17,7 @@ AOCharMovie::AOCharMovie(QWidget *p_parent) : QLabel(p_parent)
 
 void AOCharMovie::play(QString p_char, QString p_emote, QString emote_prefix)
 {
-  TextFileHandler *filehandler = TextFileHandler::getInstance();
+  TextFileHandler *filehandler = TextFileHandler::get_instance();
 
   QString original_path = filehandler->get_character_path(p_char, emote_prefix + p_emote + ".gif");
   QString alt_path = filehandler->get_character_path(p_char, p_emote + ".png");
@@ -61,7 +61,7 @@ void AOCharMovie::play(QString p_char, QString p_emote, QString emote_prefix)
 
 void AOCharMovie::play_pre(QString p_char, QString p_emote, int duration)
 {
-  QString gif_path = TextFileHandler::getInstance()->get_character_path(p_char, p_emote);
+  QString gif_path = TextFileHandler::get_instance()->get_character_path(p_char, p_emote);
 
   m_movie->stop();
   this->clear();
@@ -116,7 +116,7 @@ void AOCharMovie::play_pre(QString p_char, QString p_emote, int duration)
 
 void AOCharMovie::play_talking(QString p_char, QString p_emote)
 {
-  QString gif_path = TextFileHandler::getInstance()->get_character_path(p_char, "(b)" + p_emote);
+  QString gif_path = TextFileHandler::get_instance()->get_character_path(p_char, "(b)" + p_emote);
 
   m_movie->stop();
   this->clear();
@@ -129,7 +129,7 @@ void AOCharMovie::play_talking(QString p_char, QString p_emote)
 
 void AOCharMovie::play_idle(QString p_char, QString p_emote)
 {
-  QString gif_path = TextFileHandler::getInstance()->get_character_path(p_char, "(a)" + p_emote);
+  QString gif_path = TextFileHandler::get_instance()->get_character_path(p_char, "(a)" + p_emote);
 
   m_movie->stop();
   this->clear();
@@ -191,5 +191,5 @@ void AOCharMovie::frame_change(int n_frame)
 void AOCharMovie::timer_done()
 {
 
-  done();
+  emit done();
 }

--- a/aocharmovie.cpp
+++ b/aocharmovie.cpp
@@ -2,12 +2,9 @@
 
 #include "misc_functions.h"
 #include "file_functions.h"
-#include "aoapplication.h"
 
-AOCharMovie::AOCharMovie(QWidget *p_parent, AOApplication *p_ao_app) : QLabel(p_parent)
+AOCharMovie::AOCharMovie(QWidget *p_parent) : QLabel(p_parent)
 {
-  ao_app = p_ao_app;
-
   m_movie = new QMovie(this);
 
   preanim_timer = new QTimer(this);

--- a/aocharmovie.cpp
+++ b/aocharmovie.cpp
@@ -17,11 +17,13 @@ AOCharMovie::AOCharMovie(QWidget *p_parent) : QLabel(p_parent)
 
 void AOCharMovie::play(QString p_char, QString p_emote, QString emote_prefix)
 {
-  QString original_path = TextFileHandler::getInstance().get_character_path(p_char, emote_prefix + p_emote + ".gif");
-  QString alt_path = TextFileHandler::getInstance().get_character_path(p_char, p_emote + ".png");
-  QString apng_path = TextFileHandler::getInstance().get_character_path(p_char, emote_prefix + p_emote + ".apng");
-  QString placeholder_path = TextFileHandler::getInstance().get_theme_path("placeholder.gif");
-  QString placeholder_default_path = TextFileHandler::getInstance().get_default_theme_path("placeholder.gif");
+  TextFileHandler *filehandler = TextFileHandler::getInstance();
+
+  QString original_path = filehandler->get_character_path(p_char, emote_prefix + p_emote + ".gif");
+  QString alt_path = filehandler->get_character_path(p_char, p_emote + ".png");
+  QString apng_path = filehandler->get_character_path(p_char, emote_prefix + p_emote + ".apng");
+  QString placeholder_path = filehandler->get_theme_path("placeholder.gif");
+  QString placeholder_default_path = filehandler->get_default_theme_path("placeholder.gif");
   QString gif_path;
 
   if (file_exists(apng_path))
@@ -59,7 +61,7 @@ void AOCharMovie::play(QString p_char, QString p_emote, QString emote_prefix)
 
 void AOCharMovie::play_pre(QString p_char, QString p_emote, int duration)
 {
-  QString gif_path = TextFileHandler::getInstance().get_character_path(p_char, p_emote);
+  QString gif_path = TextFileHandler::getInstance()->get_character_path(p_char, p_emote);
 
   m_movie->stop();
   this->clear();
@@ -114,7 +116,7 @@ void AOCharMovie::play_pre(QString p_char, QString p_emote, int duration)
 
 void AOCharMovie::play_talking(QString p_char, QString p_emote)
 {
-  QString gif_path = TextFileHandler::getInstance().get_character_path(p_char, "(b)" + p_emote);
+  QString gif_path = TextFileHandler::getInstance()->get_character_path(p_char, "(b)" + p_emote);
 
   m_movie->stop();
   this->clear();
@@ -127,7 +129,7 @@ void AOCharMovie::play_talking(QString p_char, QString p_emote)
 
 void AOCharMovie::play_idle(QString p_char, QString p_emote)
 {
-  QString gif_path = TextFileHandler::getInstance().get_character_path(p_char, "(a)" + p_emote);
+  QString gif_path = TextFileHandler::getInstance()->get_character_path(p_char, "(a)" + p_emote);
 
   m_movie->stop();
   this->clear();

--- a/aocharmovie.cpp
+++ b/aocharmovie.cpp
@@ -2,6 +2,7 @@
 
 #include "misc_functions.h"
 #include "file_functions.h"
+#include "text_file_functions.h"
 
 AOCharMovie::AOCharMovie(QWidget *p_parent) : QLabel(p_parent)
 {
@@ -16,11 +17,11 @@ AOCharMovie::AOCharMovie(QWidget *p_parent) : QLabel(p_parent)
 
 void AOCharMovie::play(QString p_char, QString p_emote, QString emote_prefix)
 {
-  QString original_path = ao_app->get_character_path(p_char, emote_prefix + p_emote + ".gif");
-  QString alt_path = ao_app->get_character_path(p_char, p_emote + ".png");
-  QString apng_path = ao_app->get_character_path(p_char, emote_prefix + p_emote + ".apng");
-  QString placeholder_path = ao_app->get_theme_path("placeholder.gif");
-  QString placeholder_default_path = ao_app->get_default_theme_path("placeholder.gif");
+  QString original_path = TextFileHandler::getInstance().get_character_path(p_char, emote_prefix + p_emote + ".gif");
+  QString alt_path = TextFileHandler::getInstance().get_character_path(p_char, p_emote + ".png");
+  QString apng_path = TextFileHandler::getInstance().get_character_path(p_char, emote_prefix + p_emote + ".apng");
+  QString placeholder_path = TextFileHandler::getInstance().get_theme_path("placeholder.gif");
+  QString placeholder_default_path = TextFileHandler::getInstance().get_default_theme_path("placeholder.gif");
   QString gif_path;
 
   if (file_exists(apng_path))
@@ -58,7 +59,7 @@ void AOCharMovie::play(QString p_char, QString p_emote, QString emote_prefix)
 
 void AOCharMovie::play_pre(QString p_char, QString p_emote, int duration)
 {
-  QString gif_path = ao_app->get_character_path(p_char, p_emote);
+  QString gif_path = TextFileHandler::getInstance().get_character_path(p_char, p_emote);
 
   m_movie->stop();
   this->clear();
@@ -113,7 +114,7 @@ void AOCharMovie::play_pre(QString p_char, QString p_emote, int duration)
 
 void AOCharMovie::play_talking(QString p_char, QString p_emote)
 {
-  QString gif_path = ao_app->get_character_path(p_char, "(b)" + p_emote);
+  QString gif_path = TextFileHandler::getInstance().get_character_path(p_char, "(b)" + p_emote);
 
   m_movie->stop();
   this->clear();
@@ -126,7 +127,7 @@ void AOCharMovie::play_talking(QString p_char, QString p_emote)
 
 void AOCharMovie::play_idle(QString p_char, QString p_emote)
 {
-  QString gif_path = ao_app->get_character_path(p_char, "(a)" + p_emote);
+  QString gif_path = TextFileHandler::getInstance().get_character_path(p_char, "(a)" + p_emote);
 
   m_movie->stop();
   this->clear();

--- a/aocharmovie.h
+++ b/aocharmovie.h
@@ -14,7 +14,7 @@ class AOCharMovie : public QLabel
   Q_OBJECT
 
 public:
-  AOCharMovie(QWidget *p_parent, AOApplication *p_ao_app);
+  AOCharMovie(QWidget *p_parent);
 
   void play(QString p_char, QString p_emote, QString emote_prefix);
   void play_pre(QString p_char, QString p_emote, int duration);
@@ -30,8 +30,6 @@ public:
   void combo_resize(int w, int h);
 
 private:
-  AOApplication *ao_app;
-
   QMovie *m_movie;
   QVector<QImage> movie_frames;
   QTimer *preanim_timer;

--- a/aoemotebutton.cpp
+++ b/aoemotebutton.cpp
@@ -2,10 +2,9 @@
 
 #include "file_functions.h"
 
-AOEmoteButton::AOEmoteButton(QWidget *p_parent, AOApplication *p_ao_app, int p_x, int p_y) : QPushButton(p_parent)
+AOEmoteButton::AOEmoteButton(QWidget *p_parent, int p_x, int p_y) : QPushButton(p_parent)
 {
   parent = p_parent;
-  ao_app = p_ao_app;
 
   this->move(p_x, p_y);
   this->resize(40, 40);

--- a/aoemotebutton.cpp
+++ b/aoemotebutton.cpp
@@ -1,6 +1,7 @@
 #include "aoemotebutton.h"
 
 #include "file_functions.h"
+#include "text_file_functions.h"
 
 AOEmoteButton::AOEmoteButton(QWidget *p_parent, int p_x, int p_y) : QPushButton(p_parent)
 {
@@ -15,7 +16,7 @@ AOEmoteButton::AOEmoteButton(QWidget *p_parent, int p_x, int p_y) : QPushButton(
 void AOEmoteButton::set_image(QString p_char, int p_emote, QString suffix)
 {
   QString emotion_number = QString::number(p_emote + 1);
-  QString image_path = ao_app->get_character_path(p_char, "emotions/button" + emotion_number + suffix);
+  QString image_path = TextFileHandler::getInstance().get_character_path(p_char, "emotions/button" + emotion_number + suffix);
 
   if (file_exists(image_path))
   {
@@ -24,7 +25,7 @@ void AOEmoteButton::set_image(QString p_char, int p_emote, QString suffix)
   }
   else
   {
-    this->setText(ao_app->get_emote_comment(p_char, p_emote));
+    this->setText(TextFileHandler::getInstance().get_emote_comment(p_char, p_emote));
     this->setStyleSheet("border-image:url(\"\")");
   }
 }

--- a/aoemotebutton.cpp
+++ b/aoemotebutton.cpp
@@ -16,7 +16,7 @@ AOEmoteButton::AOEmoteButton(QWidget *p_parent, int p_x, int p_y) : QPushButton(
 void AOEmoteButton::set_image(QString p_char, int p_emote, QString suffix)
 {
   QString emotion_number = QString::number(p_emote + 1);
-  QString image_path = TextFileHandler::getInstance().get_character_path(p_char, "emotions/button" + emotion_number + suffix);
+  QString image_path = TextFileHandler::get_instance()->get_character_path(p_char, "emotions/button" + emotion_number + suffix);
 
   if (file_exists(image_path))
   {
@@ -25,7 +25,7 @@ void AOEmoteButton::set_image(QString p_char, int p_emote, QString suffix)
   }
   else
   {
-    this->setText(TextFileHandler::getInstance().get_emote_comment(p_char, p_emote));
+    this->setText(TextFileHandler::get_instance()->get_emote_comment(p_char, p_emote));
     this->setStyleSheet("border-image:url(\"\")");
   }
 }

--- a/aoemotebutton.cpp
+++ b/aoemotebutton.cpp
@@ -32,5 +32,5 @@ void AOEmoteButton::set_image(QString p_char, int p_emote, QString suffix)
 
 void AOEmoteButton::on_clicked()
 {
-  emote_clicked(m_id);
+  emit emote_clicked(m_id);
 }

--- a/aoemotebutton.h
+++ b/aoemotebutton.h
@@ -1,8 +1,6 @@
 #ifndef AOEMOTEBUTTON_H
 #define AOEMOTEBUTTON_H
 
-#include "aoapplication.h"
-
 #include <QPushButton>
 #include <QDebug>
 
@@ -11,7 +9,7 @@ class AOEmoteButton : public QPushButton
   Q_OBJECT
 
 public:
-  AOEmoteButton(QWidget *p_parent, AOApplication *p_ao_app, int p_x, int p_y);
+  AOEmoteButton(QWidget *p_parent, int p_x, int p_y);
 
   //void set_on(QString p_char, int p_emote);
   //void set_off(QString p_char, int p_emote);
@@ -22,7 +20,6 @@ public:
 
 private:
   QWidget *parent;
-  AOApplication *ao_app;
 
   int m_id = 0;
 

--- a/aoevidencebutton.cpp
+++ b/aoevidencebutton.cpp
@@ -36,7 +36,7 @@ void AOEvidenceButton::reset()
 
 void AOEvidenceButton::set_image(QString p_image)
 {
-  QString image_path = TextFileHandler::getInstance().get_evidence_path(p_image);
+  QString image_path = TextFileHandler::get_instance()->get_evidence_path(p_image);
 
   if (file_exists(image_path))
   {
@@ -52,8 +52,8 @@ void AOEvidenceButton::set_image(QString p_image)
 
 void AOEvidenceButton::set_theme_image(QString p_image)
 {
-  QString theme_image_path = TextFileHandler::getInstance().get_theme_path(p_image);
-  QString default_image_path = TextFileHandler::getInstance().get_default_theme_path(p_image);
+  QString theme_image_path = TextFileHandler::get_instance()->get_theme_path(p_image);
+  QString default_image_path = TextFileHandler::get_instance()->get_default_theme_path(p_image);
 
   QString final_image_path;
 

--- a/aoevidencebutton.cpp
+++ b/aoevidencebutton.cpp
@@ -2,9 +2,8 @@
 
 #include "file_functions.h"
 
-AOEvidenceButton::AOEvidenceButton(QWidget *p_parent, AOApplication *p_ao_app, int p_x, int p_y) : QPushButton(p_parent)
+AOEvidenceButton::AOEvidenceButton(QWidget *p_parent, int p_x, int p_y) : QPushButton(p_parent)
 {
-  ao_app = p_ao_app;
   m_parent = p_parent;
 
   ui_selected = new AOImage(p_parent, ao_app);

--- a/aoevidencebutton.cpp
+++ b/aoevidencebutton.cpp
@@ -6,14 +6,14 @@ AOEvidenceButton::AOEvidenceButton(QWidget *p_parent, int p_x, int p_y) : QPushB
 {
   m_parent = p_parent;
 
-  ui_selected = new AOImage(p_parent, ao_app);
+  ui_selected = new AOImage(p_parent);
   ui_selected->resize(70, 70);
   ui_selected->move(p_x, p_y);
   ui_selected->set_image("evidence_selected.png");
   ui_selected->setAttribute(Qt::WA_TransparentForMouseEvents);
   ui_selected->hide();
 
-  ui_selector = new AOImage(p_parent, ao_app);
+  ui_selector = new AOImage(p_parent);
   ui_selector->resize(71, 71);
   ui_selector->move(p_x - 1, p_y - 1);
   ui_selector->set_image("evidence_selector.png");
@@ -36,7 +36,7 @@ void AOEvidenceButton::reset()
 
 void AOEvidenceButton::set_image(QString p_image)
 {
-  QString image_path = ao_app->get_evidence_path(p_image);
+  QString image_path = TextFileHandler::getInstance().get_evidence_path(p_image);
 
   if (file_exists(image_path))
   {
@@ -52,8 +52,8 @@ void AOEvidenceButton::set_image(QString p_image)
 
 void AOEvidenceButton::set_theme_image(QString p_image)
 {
-  QString theme_image_path = ao_app->get_theme_path(p_image);
-  QString default_image_path = ao_app->get_default_theme_path(p_image);
+  QString theme_image_path = TextFileHandler::getInstance().get_theme_path(p_image);
+  QString default_image_path = TextFileHandler::getInstance().get_default_theme_path(p_image);
 
   QString final_image_path;
 

--- a/aoevidencebutton.cpp
+++ b/aoevidencebutton.cpp
@@ -76,13 +76,13 @@ void AOEvidenceButton::set_selected(bool p_selected)
 
 void AOEvidenceButton::on_clicked()
 {
-  evidence_clicked(m_id);
+  emit evidence_clicked(m_id);
 }
 
 void AOEvidenceButton::mouseDoubleClickEvent(QMouseEvent *e)
 {
   QPushButton::mouseDoubleClickEvent(e);
-  evidence_double_clicked(m_id);
+  emit evidence_double_clicked(m_id);
 }
 
 void AOEvidenceButton::dragLeaveEvent(QMouseEvent *e)
@@ -103,7 +103,7 @@ void AOEvidenceButton::enterEvent(QEvent * e)
 {
   ui_selector->show();
 
-  on_hover(m_id, true);
+  emit on_hover(m_id, true);
 
   setFlat(false);
   QPushButton::enterEvent(e);
@@ -113,6 +113,6 @@ void AOEvidenceButton::leaveEvent(QEvent * e)
 {
   ui_selector->hide();
 
-  on_hover(m_id, false);
+  emit on_hover(m_id, false);
   QPushButton::leaveEvent(e);
 }

--- a/aoevidencebutton.h
+++ b/aoevidencebutton.h
@@ -1,7 +1,6 @@
 #ifndef AOEVIDENCEBUTTON_H
 #define AOEVIDENCEBUTTON_H
 
-#include "aoapplication.h"
 #include "aoimage.h"
 
 #include <QPushButton>
@@ -13,7 +12,7 @@ class AOEvidenceButton : public QPushButton
   Q_OBJECT
 
 public:
-  AOEvidenceButton(QWidget *p_parent, AOApplication *p_ao_app, int p_x, int p_y);
+  AOEvidenceButton(QWidget *p_parent, int p_x, int p_y);
 
   void reset();
   void set_image(QString p_image);
@@ -23,7 +22,6 @@ public:
   void set_selected(bool p_selected);
 
 private:
-  AOApplication *ao_app;
   QWidget *m_parent;
 
   AOImage *ui_selected;

--- a/aoevidencedisplay.cpp
+++ b/aoevidencedisplay.cpp
@@ -20,7 +20,7 @@ void AOEvidenceDisplay::show_evidence(QString p_evidence_image, bool is_left_sid
 
   sfx_player->set_volume(p_volume);
 
-  QString f_evidence_path = TextFileHandler::getInstance().get_evidence_path(p_evidence_image);
+  QString f_evidence_path = TextFileHandler::get_instance()->get_evidence_path(p_evidence_image);
 
   QPixmap f_pixmap(f_evidence_path);
 
@@ -39,15 +39,15 @@ void AOEvidenceDisplay::show_evidence(QString p_evidence_image, bool is_left_sid
     gif_name = "evidence_appear_right.gif";
   }
 
-  pos_size_type icon_dimensions = TextFileHandler::getInstance().get_element_dimensions(icon_identifier, "courtroom_design.ini");
+  pos_size_type icon_dimensions = TextFileHandler::get_instance()->get_element_dimensions(icon_identifier, "courtroom_design.ini");
 
   evidence_icon->move(icon_dimensions.x, icon_dimensions.y);
   evidence_icon->resize(icon_dimensions.width, icon_dimensions.height);
 
   evidence_icon->setPixmap(f_pixmap.scaled(evidence_icon->width(), evidence_icon->height(), Qt::IgnoreAspectRatio));
 
-  QString f_default_gif_path = TextFileHandler::getInstance().get_default_theme_path(gif_name);
-  QString f_gif_path = TextFileHandler::getInstance().get_theme_path(gif_name);
+  QString f_default_gif_path = TextFileHandler::get_instance()->get_default_theme_path(gif_name);
+  QString f_gif_path = TextFileHandler::get_instance()->get_theme_path(gif_name);
 
   if (file_exists(f_gif_path))
     final_gif_path = f_gif_path;
@@ -62,7 +62,7 @@ void AOEvidenceDisplay::show_evidence(QString p_evidence_image, bool is_left_sid
   this->setMovie(evidence_movie);
 
   evidence_movie->start();
-  sfx_player->play(TextFileHandler::getInstance().get_sfx("evidence_present"));
+  sfx_player->play(TextFileHandler::get_instance()->get_sfx("evidence_present"));
 }
 
 void AOEvidenceDisplay::frame_change(int p_frame)

--- a/aoevidencedisplay.cpp
+++ b/aoevidencedisplay.cpp
@@ -4,10 +4,8 @@
 #include "datatypes.h"
 #include "misc_functions.h"
 
-AOEvidenceDisplay::AOEvidenceDisplay(QWidget *p_parent, AOApplication *p_ao_app) : QLabel(p_parent)
+AOEvidenceDisplay::AOEvidenceDisplay(QWidget *p_parent) : QLabel(p_parent)
 {
-  ao_app = p_ao_app;
-
   evidence_movie = new QMovie(this);
   evidence_icon = new QLabel(this);
   sfx_player = new AOSfxPlayer(this, ao_app);

--- a/aoevidencedisplay.cpp
+++ b/aoevidencedisplay.cpp
@@ -3,12 +3,13 @@
 #include "file_functions.h"
 #include "datatypes.h"
 #include "misc_functions.h"
+#include "text_file_functions.h"
 
 AOEvidenceDisplay::AOEvidenceDisplay(QWidget *p_parent) : QLabel(p_parent)
 {
   evidence_movie = new QMovie(this);
   evidence_icon = new QLabel(this);
-  sfx_player = new AOSfxPlayer(this, ao_app);
+  sfx_player = new AOSfxPlayer(this);
 
   connect(evidence_movie, SIGNAL(frameChanged(int)), this, SLOT(frame_change(int)));
 }
@@ -19,7 +20,7 @@ void AOEvidenceDisplay::show_evidence(QString p_evidence_image, bool is_left_sid
 
   sfx_player->set_volume(p_volume);
 
-  QString f_evidence_path = ao_app->get_evidence_path(p_evidence_image);
+  QString f_evidence_path = TextFileHandler::getInstance().get_evidence_path(p_evidence_image);
 
   QPixmap f_pixmap(f_evidence_path);
 
@@ -38,15 +39,15 @@ void AOEvidenceDisplay::show_evidence(QString p_evidence_image, bool is_left_sid
     gif_name = "evidence_appear_right.gif";
   }
 
-  pos_size_type icon_dimensions = ao_app->get_element_dimensions(icon_identifier, "courtroom_design.ini");
+  pos_size_type icon_dimensions = TextFileHandler::getInstance().get_element_dimensions(icon_identifier, "courtroom_design.ini");
 
   evidence_icon->move(icon_dimensions.x, icon_dimensions.y);
   evidence_icon->resize(icon_dimensions.width, icon_dimensions.height);
 
   evidence_icon->setPixmap(f_pixmap.scaled(evidence_icon->width(), evidence_icon->height(), Qt::IgnoreAspectRatio));
 
-  QString f_default_gif_path = ao_app->get_default_theme_path(gif_name);
-  QString f_gif_path = ao_app->get_theme_path(gif_name);
+  QString f_default_gif_path = TextFileHandler::getInstance().get_default_theme_path(gif_name);
+  QString f_gif_path = TextFileHandler::getInstance().get_theme_path(gif_name);
 
   if (file_exists(f_gif_path))
     final_gif_path = f_gif_path;
@@ -61,7 +62,7 @@ void AOEvidenceDisplay::show_evidence(QString p_evidence_image, bool is_left_sid
   this->setMovie(evidence_movie);
 
   evidence_movie->start();
-  sfx_player->play(ao_app->get_sfx("evidence_present"));
+  sfx_player->play(TextFileHandler::getInstance().get_sfx("evidence_present"));
 }
 
 void AOEvidenceDisplay::frame_change(int p_frame)

--- a/aoevidencedisplay.h
+++ b/aoevidencedisplay.h
@@ -1,7 +1,6 @@
 #ifndef AOEVIDENCEDISPLAY_H
 #define AOEVIDENCEDISPLAY_H
 
-#include "aoapplication.h"
 #include "aosfxplayer.h"
 
 #include <QLabel>
@@ -13,14 +12,13 @@ class AOEvidenceDisplay : public QLabel
   Q_OBJECT
 
 public:
-  AOEvidenceDisplay(QWidget *p_parent, AOApplication *p_ao_app);
+  AOEvidenceDisplay(QWidget *p_parent);
 
   void show_evidence(QString p_evidence_image, bool is_left_side, int p_volume);
   QLabel* get_evidence_icon();
   void reset();
 
 private:
-  AOApplication *ao_app;
   QMovie *evidence_movie;
   QLabel *evidence_icon;
   AOSfxPlayer *sfx_player;

--- a/aoimage.cpp
+++ b/aoimage.cpp
@@ -2,10 +2,9 @@
 
 #include "aoimage.h"
 
-AOImage::AOImage(QWidget *parent, AOApplication *p_ao_app) : QLabel(parent)
+AOImage::AOImage(QWidget *parent) : QLabel(parent)
 {
   m_parent = parent;
-  ao_app = p_ao_app;
 }
 
 AOImage::~AOImage()

--- a/aoimage.cpp
+++ b/aoimage.cpp
@@ -14,8 +14,8 @@ AOImage::~AOImage()
 
 void AOImage::set_image(QString p_image)
 {
-  QString theme_image_path = TextFileHandler::getInstance().get_theme_path(p_image);
-  QString default_image_path = TextFileHandler::getInstance().get_default_theme_path(p_image);
+  QString theme_image_path = TextFileHandler::get_instance()->get_theme_path(p_image);
+  QString default_image_path = TextFileHandler::get_instance()->get_default_theme_path(p_image);
 
   QString final_image_path;
 
@@ -31,7 +31,7 @@ void AOImage::set_image(QString p_image)
 
 void AOImage::set_image_from_path(QString p_path)
 {
-  QString default_path = TextFileHandler::getInstance().get_default_theme_path("chatmed.png");
+  QString default_path = TextFileHandler::get_instance()->get_default_theme_path("chatmed.png");
 
   QString final_path;
 

--- a/aoimage.cpp
+++ b/aoimage.cpp
@@ -14,8 +14,8 @@ AOImage::~AOImage()
 
 void AOImage::set_image(QString p_image)
 {
-  QString theme_image_path = ao_app->get_theme_path(p_image);
-  QString default_image_path = ao_app->get_default_theme_path(p_image);
+  QString theme_image_path = TextFileHandler::getInstance().get_theme_path(p_image);
+  QString default_image_path = TextFileHandler::getInstance().get_default_theme_path(p_image);
 
   QString final_image_path;
 
@@ -31,7 +31,7 @@ void AOImage::set_image(QString p_image)
 
 void AOImage::set_image_from_path(QString p_path)
 {
-  QString default_path = ao_app->get_default_theme_path("chatmed.png");
+  QString default_path = TextFileHandler::getInstance().get_default_theme_path("chatmed.png");
 
   QString final_path;
 

--- a/aoimage.h
+++ b/aoimage.h
@@ -3,6 +3,8 @@
 #ifndef AOIMAGE_H
 #define AOIMAGE_H
 
+#include "text_file_functions.h"
+
 #include <QLabel>
 #include <QDebug>
 

--- a/aoimage.h
+++ b/aoimage.h
@@ -3,19 +3,16 @@
 #ifndef AOIMAGE_H
 #define AOIMAGE_H
 
-#include "aoapplication.h"
-
 #include <QLabel>
 #include <QDebug>
 
 class AOImage : public QLabel
 {
 public:
-  AOImage(QWidget *parent, AOApplication *p_ao_app);
+  AOImage(QWidget *parent);
   ~AOImage();
 
   QWidget *m_parent;
-  AOApplication *ao_app;
 
   void set_image(QString p_image);
   void set_image_from_path(QString p_path);

--- a/aomovie.cpp
+++ b/aomovie.cpp
@@ -26,16 +26,16 @@ void AOMovie::play(QString p_gif, QString p_char, QString p_custom_theme)
 
   QString custom_path;
   if (p_gif == "custom")
-    custom_path = ao_app->get_image_suffix(ao_app->get_character_path(p_char, p_gif));
+    custom_path = TextFileHandler::getInstance().get_image_suffix(TextFileHandler::getInstance().get_character_path(p_char, p_gif));
   else
-    custom_path = ao_app->get_image_suffix(ao_app->get_character_path(p_char, p_gif + "_bubble"));
+    custom_path = TextFileHandler::getInstance().get_image_suffix(TextFileHandler::getInstance().get_character_path(p_char, p_gif + "_bubble"));
 
-  QString misc_path = ao_app->get_base_path() + "misc/" + p_custom_theme + "/" + p_gif + "_bubble.gif";
-  QString custom_theme_path = ao_app->get_custom_theme_path(p_custom_theme, p_gif + ".gif");
-  QString theme_path = ao_app->get_theme_path(p_gif + ".gif");
-  QString default_theme_path = ao_app->get_default_theme_path(p_gif + ".gif");
-  QString placeholder_path = ao_app->get_theme_path("placeholder.gif");
-  QString default_placeholder_path = ao_app->get_default_theme_path("placeholder.gif");
+  QString misc_path = TextFileHandler::getInstance().get_base_path() + "misc/" + p_custom_theme + "/" + p_gif + "_bubble.gif";
+  QString custom_theme_path = TextFileHandler::getInstance().get_custom_theme_path(p_custom_theme, p_gif + ".gif");
+  QString theme_path = TextFileHandler::getInstance().get_theme_path(p_gif + ".gif");
+  QString default_theme_path = TextFileHandler::getInstance().get_default_theme_path(p_gif + ".gif");
+  QString placeholder_path = TextFileHandler::getInstance().get_theme_path("placeholder.gif");
+  QString default_placeholder_path = TextFileHandler::getInstance().get_default_theme_path("placeholder.gif");
 
   if (file_exists(misc_path))
     gif_path = misc_path;

--- a/aomovie.cpp
+++ b/aomovie.cpp
@@ -24,18 +24,20 @@ void AOMovie::play(QString p_gif, QString p_char, QString p_custom_theme)
 
   QString gif_path;
 
+  TextFileHandler* filehandler = TextFileHandler::getInstance();
+
   QString custom_path;
   if (p_gif == "custom")
-    custom_path = TextFileHandler::getInstance().get_image_suffix(TextFileHandler::getInstance().get_character_path(p_char, p_gif));
+    custom_path = filehandler->get_image_suffix(filehandler->get_character_path(p_char, p_gif));
   else
-    custom_path = TextFileHandler::getInstance().get_image_suffix(TextFileHandler::getInstance().get_character_path(p_char, p_gif + "_bubble"));
+    custom_path = filehandler->get_image_suffix(filehandler->get_character_path(p_char, p_gif + "_bubble"));
 
-  QString misc_path = TextFileHandler::getInstance().get_base_path() + "misc/" + p_custom_theme + "/" + p_gif + "_bubble.gif";
-  QString custom_theme_path = TextFileHandler::getInstance().get_custom_theme_path(p_custom_theme, p_gif + ".gif");
-  QString theme_path = TextFileHandler::getInstance().get_theme_path(p_gif + ".gif");
-  QString default_theme_path = TextFileHandler::getInstance().get_default_theme_path(p_gif + ".gif");
-  QString placeholder_path = TextFileHandler::getInstance().get_theme_path("placeholder.gif");
-  QString default_placeholder_path = TextFileHandler::getInstance().get_default_theme_path("placeholder.gif");
+  QString misc_path = filehandler->get_base_path() + "misc/" + p_custom_theme + "/" + p_gif + "_bubble.gif";
+  QString custom_theme_path = filehandler->get_custom_theme_path(p_custom_theme, p_gif + ".gif");
+  QString theme_path = filehandler->get_theme_path(p_gif + ".gif");
+  QString default_theme_path = filehandler->get_default_theme_path(p_gif + ".gif");
+  QString placeholder_path = filehandler->get_theme_path("placeholder.gif");
+  QString default_placeholder_path = filehandler->get_default_theme_path("placeholder.gif");
 
   if (file_exists(misc_path))
     gif_path = misc_path;

--- a/aomovie.cpp
+++ b/aomovie.cpp
@@ -24,7 +24,7 @@ void AOMovie::play(QString p_gif, QString p_char, QString p_custom_theme)
 
   QString gif_path;
 
-  TextFileHandler* filehandler = TextFileHandler::getInstance();
+  TextFileHandler* filehandler = TextFileHandler::get_instance();
 
   QString custom_path;
   if (p_gif == "custom")
@@ -78,7 +78,7 @@ void AOMovie::frame_change(int n_frame)
     this->stop();
 
     //signal connected to courtroom object, let it figure out what to do
-    done();
+    emit done();
   }
 }
 

--- a/aomovie.cpp
+++ b/aomovie.cpp
@@ -4,10 +4,8 @@
 #include "courtroom.h"
 #include "misc_functions.h"
 
-AOMovie::AOMovie(QWidget *p_parent, AOApplication *p_ao_app) : QLabel(p_parent)
+AOMovie::AOMovie(QWidget *p_parent) : QLabel(p_parent)
 {
-  ao_app = p_ao_app;
-
   m_movie = new QMovie();
 
   this->setMovie(m_movie);

--- a/aomovie.h
+++ b/aomovie.h
@@ -12,7 +12,7 @@ class AOMovie : public QLabel
   Q_OBJECT
 
 public:
-  AOMovie(QWidget *p_parent, AOApplication *p_ao_app);
+  AOMovie(QWidget *p_parent);
 
   void set_play_once(bool p_play_once);
   void play(QString p_gif, QString p_char = "", QString p_custom_theme = "");
@@ -21,7 +21,6 @@ public:
 
 private:
   QMovie *m_movie;
-  AOApplication *ao_app;
   bool play_once = true;
 
 signals:

--- a/aomusicplayer.cpp
+++ b/aomusicplayer.cpp
@@ -1,4 +1,5 @@
 #include "aomusicplayer.h"
+#include "text_file_functions.h"
 
 AOMusicPlayer::AOMusicPlayer(QWidget *parent)
 {
@@ -14,13 +15,13 @@ void AOMusicPlayer::play(QString p_song)
 {
   BASS_ChannelStop(m_stream);
 
-  QString f_path = ao_app->get_music_path(p_song);
+  QString f_path = TextFileHandler::getInstance().get_music_path(p_song);
 
   m_stream = BASS_StreamCreateFile(FALSE, f_path.utf16(), 0, 0, BASS_STREAM_AUTOFREE | BASS_UNICODE | BASS_ASYNCFILE);
 
   this->set_volume(m_volume);
 
-  if (ao_app->get_audio_output_device() != "Default")
+  if (TextFileHandler::getInstance().get_audio_output_device() != "Default")
     BASS_ChannelSetDevice(m_stream, BASS_GetDevice());
   BASS_ChannelPlay(m_stream, false);
 }

--- a/aomusicplayer.cpp
+++ b/aomusicplayer.cpp
@@ -15,13 +15,13 @@ void AOMusicPlayer::play(QString p_song)
 {
   BASS_ChannelStop(m_stream);
 
-  QString f_path = TextFileHandler::getInstance().get_music_path(p_song);
+  QString f_path = TextFileHandler::get_instance()->get_music_path(p_song);
 
   m_stream = BASS_StreamCreateFile(FALSE, f_path.utf16(), 0, 0, BASS_STREAM_AUTOFREE | BASS_UNICODE | BASS_ASYNCFILE);
 
   this->set_volume(m_volume);
 
-  if (TextFileHandler::getInstance().get_audio_output_device() != "Default")
+  if (TextFileHandler::get_instance()->get_audio_output_device() != "Default")
     BASS_ChannelSetDevice(m_stream, BASS_GetDevice());
   BASS_ChannelPlay(m_stream, false);
 }

--- a/aomusicplayer.cpp
+++ b/aomusicplayer.cpp
@@ -1,9 +1,8 @@
 #include "aomusicplayer.h"
 
-AOMusicPlayer::AOMusicPlayer(QWidget *parent, AOApplication *p_ao_app)
+AOMusicPlayer::AOMusicPlayer(QWidget *parent)
 {
   m_parent = parent;
-  ao_app = p_ao_app;
 }
 
 AOMusicPlayer::~AOMusicPlayer()

--- a/aomusicplayer.h
+++ b/aomusicplayer.h
@@ -2,7 +2,6 @@
 #define AOMUSICPLAYER_H
 
 #include "bass.h"
-#include "aoapplication.h"
 
 #include <QWidget>
 #include <string.h>
@@ -11,7 +10,7 @@
 class AOMusicPlayer
 {
 public:
-  AOMusicPlayer(QWidget *parent, AOApplication *p_ao_app);
+  AOMusicPlayer(QWidget *parent);
   ~AOMusicPlayer();
 
   void play(QString p_song);
@@ -19,7 +18,6 @@ public:
 
 private:
   QWidget *m_parent;
-  AOApplication *ao_app;
 
   int m_volume = 0;
   HSTREAM m_stream;

--- a/aooptionsdialog.cpp
+++ b/aooptionsdialog.cpp
@@ -4,6 +4,8 @@
 
 AOOptionsDialog::AOOptionsDialog(QWidget *parent, bool casing_alerts_on_server) : QDialog(parent)
 {
+    TextFileHandler *filehandler = TextFileHandler::getInstance();
+
     // Setting up the basics.
     // setAttribute(Qt::WA_DeleteOnClose);
     setWindowTitle(tr("Settings"));
@@ -56,13 +58,13 @@ AOOptionsDialog::AOOptionsDialog(QWidget *parent, bool casing_alerts_on_server) 
     ui_theme_combobox = new QComboBox(ui_form_layout_widget);
 
     // Fill the combobox with the names of the themes.
-    QDirIterator it(TextFileHandler::getInstance().get_base_path() + "themes", QDir::Dirs, QDirIterator::NoIteratorFlags);
+    QDirIterator it(filehandler->get_base_path() + "themes", QDir::Dirs, QDirIterator::NoIteratorFlags);
     while (it.hasNext())
     {
         QString actualname = QDir(it.next()).dirName();
         if (actualname != "." && actualname != "..")
             ui_theme_combobox->addItem(actualname);
-        if (actualname == TextFileHandler::getInstance().get_current_theme())
+        if (actualname == filehandler->get_current_theme())
             ui_theme_combobox->setCurrentIndex(ui_theme_combobox->count()-1);
     }
 
@@ -84,7 +86,7 @@ AOOptionsDialog::AOOptionsDialog(QWidget *parent, bool casing_alerts_on_server) 
     ui_gameplay_form->setWidget(2, QFormLayout::LabelRole, ui_downwards_lbl);
 
     ui_downwards_cb = new QCheckBox(ui_form_layout_widget);
-    ui_downwards_cb->setChecked(TextFileHandler::getInstance().get_log_goes_downwards());
+    ui_downwards_cb->setChecked(filehandler->get_log_goes_downwards());
 
     ui_gameplay_form->setWidget(2, QFormLayout::FieldRole, ui_downwards_cb);
 
@@ -97,7 +99,7 @@ AOOptionsDialog::AOOptionsDialog(QWidget *parent, bool casing_alerts_on_server) 
 
     ui_length_spinbox = new QSpinBox(ui_form_layout_widget);
     ui_length_spinbox->setMaximum(10000);
-    ui_length_spinbox->setValue(TextFileHandler::getInstance().get_max_log_size());
+    ui_length_spinbox->setValue(filehandler->get_max_log_size());
 
     ui_gameplay_form->setWidget(3, QFormLayout::FieldRole, ui_length_spinbox);
 
@@ -116,7 +118,7 @@ AOOptionsDialog::AOOptionsDialog(QWidget *parent, bool casing_alerts_on_server) 
 
     ui_username_textbox = new QLineEdit(ui_form_layout_widget);
     ui_username_textbox->setMaxLength(30);
-    ui_username_textbox->setText(TextFileHandler::getInstance().get_default_username());
+    ui_username_textbox->setText(filehandler->get_default_username());
 
     ui_gameplay_form->setWidget(5, QFormLayout::FieldRole, ui_username_textbox);
 
@@ -129,7 +131,7 @@ AOOptionsDialog::AOOptionsDialog(QWidget *parent, bool casing_alerts_on_server) 
     ui_gameplay_form->setWidget(6, QFormLayout::LabelRole, ui_showname_lbl);
 
     ui_showname_cb = new QCheckBox(ui_form_layout_widget);
-    ui_showname_cb->setChecked(TextFileHandler::getInstance().get_showname_enabled_by_default());
+    ui_showname_cb->setChecked(filehandler->get_showname_enabled_by_default());
 
     ui_gameplay_form->setWidget(6, QFormLayout::FieldRole, ui_showname_cb);
 
@@ -147,7 +149,7 @@ AOOptionsDialog::AOOptionsDialog(QWidget *parent, bool casing_alerts_on_server) 
     ui_gameplay_form->setWidget(8, QFormLayout::LabelRole, ui_ms_lbl);
 
     ui_ms_textbox = new QLineEdit(ui_form_layout_widget);
-    ui_ms_textbox->setText(TextFileHandler::getInstance().get_master_server());
+    ui_ms_textbox->setText(filehandler->get_master_server());
 
     ui_gameplay_form->setWidget(8, QFormLayout::FieldRole, ui_ms_textbox);
 
@@ -160,7 +162,7 @@ AOOptionsDialog::AOOptionsDialog(QWidget *parent, bool casing_alerts_on_server) 
     ui_gameplay_form->setWidget(9, QFormLayout::LabelRole, ui_discord_lbl);
 
     ui_discord_cb = new QCheckBox(ui_form_layout_widget);
-    ui_discord_cb->setChecked(TextFileHandler::getInstance().is_discord_enabled());
+    ui_discord_cb->setChecked(filehandler->is_discord_enabled());
 
     ui_gameplay_form->setWidget(9, QFormLayout::FieldRole, ui_discord_cb);
 
@@ -183,7 +185,7 @@ AOOptionsDialog::AOOptionsDialog(QWidget *parent, bool casing_alerts_on_server) 
 
     // Let's fill the callwords text edit with the already present callwords.
     ui_callwords_textbox->document()->clear();
-    foreach (QString callword, TextFileHandler::getInstance().get_call_words()) {
+    foreach (QString callword, filehandler->get_call_words()) {
         ui_callwords_textbox->appendPlainText(callword);
     }
 
@@ -227,7 +229,7 @@ AOOptionsDialog::AOOptionsDialog(QWidget *parent, bool casing_alerts_on_server) 
     for (a = 0; BASS_GetDeviceInfo(a, &info); a++)
     {
         ui_audio_device_combobox->addItem(info.name);
-        if (TextFileHandler::getInstance().get_audio_output_device() == info.name)
+        if (filehandler->get_audio_output_device() == info.name)
             ui_audio_device_combobox->setCurrentIndex(ui_audio_device_combobox->count()-1);
     }
 
@@ -246,7 +248,7 @@ AOOptionsDialog::AOOptionsDialog(QWidget *parent, bool casing_alerts_on_server) 
     ui_audio_layout->setWidget(2, QFormLayout::LabelRole, ui_music_volume_lbl);
 
     ui_music_volume_spinbox = new QSpinBox(ui_audio_widget);
-    ui_music_volume_spinbox->setValue(TextFileHandler::getInstance().get_default_music());
+    ui_music_volume_spinbox->setValue(filehandler->get_default_music());
     ui_music_volume_spinbox->setMaximum(100);
     ui_music_volume_spinbox->setSuffix("%");
 
@@ -260,7 +262,7 @@ AOOptionsDialog::AOOptionsDialog(QWidget *parent, bool casing_alerts_on_server) 
     ui_audio_layout->setWidget(3, QFormLayout::LabelRole, ui_sfx_volume_lbl);
 
     ui_sfx_volume_spinbox = new QSpinBox(ui_audio_widget);
-    ui_sfx_volume_spinbox->setValue(TextFileHandler::getInstance().get_default_sfx());
+    ui_sfx_volume_spinbox->setValue(filehandler->get_default_sfx());
     ui_sfx_volume_spinbox->setMaximum(100);
     ui_sfx_volume_spinbox->setSuffix("%");
 
@@ -273,7 +275,7 @@ AOOptionsDialog::AOOptionsDialog(QWidget *parent, bool casing_alerts_on_server) 
     ui_audio_layout->setWidget(4, QFormLayout::LabelRole, ui_blips_volume_lbl);
 
     ui_blips_volume_spinbox = new QSpinBox(ui_audio_widget);
-    ui_blips_volume_spinbox->setValue(TextFileHandler::getInstance().get_default_blip());
+    ui_blips_volume_spinbox->setValue(filehandler->get_default_blip());
     ui_blips_volume_spinbox->setMaximum(100);
     ui_blips_volume_spinbox->setSuffix("%");
 
@@ -292,7 +294,7 @@ AOOptionsDialog::AOOptionsDialog(QWidget *parent, bool casing_alerts_on_server) 
     ui_audio_layout->setWidget(6, QFormLayout::LabelRole, ui_bliprate_lbl);
 
     ui_bliprate_spinbox = new QSpinBox(ui_audio_widget);
-    ui_bliprate_spinbox->setValue(TextFileHandler::getInstance().read_blip_rate());
+    ui_bliprate_spinbox->setValue(filehandler->read_blip_rate());
     ui_bliprate_spinbox->setMinimum(1);
 
     ui_audio_layout->setWidget(6, QFormLayout::FieldRole, ui_bliprate_spinbox);
@@ -305,7 +307,7 @@ AOOptionsDialog::AOOptionsDialog(QWidget *parent, bool casing_alerts_on_server) 
     ui_audio_layout->setWidget(7, QFormLayout::LabelRole, ui_blank_blips_lbl);
 
     ui_blank_blips_cb = new QCheckBox(ui_audio_widget);
-    ui_blank_blips_cb->setChecked(TextFileHandler::getInstance().get_blank_blip());
+    ui_blank_blips_cb->setChecked(filehandler->get_blank_blip());
 
     ui_audio_layout->setWidget(7, QFormLayout::FieldRole, ui_blank_blips_cb);
 
@@ -342,7 +344,7 @@ AOOptionsDialog::AOOptionsDialog(QWidget *parent, bool casing_alerts_on_server) 
     ui_casing_layout->setWidget(1, QFormLayout::LabelRole, ui_casing_enabled_lbl);
 
     ui_casing_enabled_cb = new QCheckBox(ui_casing_widget);
-    ui_casing_enabled_cb->setChecked(TextFileHandler::getInstance().get_casing_enabled());
+    ui_casing_enabled_cb->setChecked(filehandler->get_casing_enabled());
 
     ui_casing_layout->setWidget(1, QFormLayout::FieldRole, ui_casing_enabled_cb);
 
@@ -356,7 +358,7 @@ AOOptionsDialog::AOOptionsDialog(QWidget *parent, bool casing_alerts_on_server) 
     ui_casing_layout->setWidget(2, QFormLayout::LabelRole, ui_casing_def_lbl);
 
     ui_casing_def_cb = new QCheckBox(ui_casing_widget);
-    ui_casing_def_cb->setChecked(TextFileHandler::getInstance().get_casing_defence_enabled());
+    ui_casing_def_cb->setChecked(filehandler->get_casing_defence_enabled());
 
     ui_casing_layout->setWidget(2, QFormLayout::FieldRole, ui_casing_def_cb);
 
@@ -370,7 +372,7 @@ AOOptionsDialog::AOOptionsDialog(QWidget *parent, bool casing_alerts_on_server) 
     ui_casing_layout->setWidget(3, QFormLayout::LabelRole, ui_casing_pro_lbl);
 
     ui_casing_pro_cb = new QCheckBox(ui_casing_widget);
-    ui_casing_pro_cb->setChecked(TextFileHandler::getInstance().get_casing_prosecution_enabled());
+    ui_casing_pro_cb->setChecked(filehandler->get_casing_prosecution_enabled());
 
     ui_casing_layout->setWidget(3, QFormLayout::FieldRole, ui_casing_pro_cb);
 
@@ -384,7 +386,7 @@ AOOptionsDialog::AOOptionsDialog(QWidget *parent, bool casing_alerts_on_server) 
     ui_casing_layout->setWidget(4, QFormLayout::LabelRole, ui_casing_jud_lbl);
 
     ui_casing_jud_cb = new QCheckBox(ui_casing_widget);
-    ui_casing_jud_cb->setChecked(TextFileHandler::getInstance().get_casing_judge_enabled());
+    ui_casing_jud_cb->setChecked(filehandler->get_casing_judge_enabled());
 
     ui_casing_layout->setWidget(4, QFormLayout::FieldRole, ui_casing_jud_cb);
 
@@ -398,7 +400,7 @@ AOOptionsDialog::AOOptionsDialog(QWidget *parent, bool casing_alerts_on_server) 
     ui_casing_layout->setWidget(5, QFormLayout::LabelRole, ui_casing_jur_lbl);
 
     ui_casing_jur_cb = new QCheckBox(ui_casing_widget);
-    ui_casing_jur_cb->setChecked(TextFileHandler::getInstance().get_casing_juror_enabled());
+    ui_casing_jur_cb->setChecked(filehandler->get_casing_juror_enabled());
 
     ui_casing_layout->setWidget(5, QFormLayout::FieldRole, ui_casing_jur_cb);
 
@@ -412,7 +414,7 @@ AOOptionsDialog::AOOptionsDialog(QWidget *parent, bool casing_alerts_on_server) 
     ui_casing_layout->setWidget(6, QFormLayout::LabelRole, ui_casing_steno_lbl);
 
     ui_casing_steno_cb = new QCheckBox(ui_casing_widget);
-    ui_casing_steno_cb->setChecked(TextFileHandler::getInstance().get_casing_steno_enabled());
+    ui_casing_steno_cb->setChecked(filehandler->get_casing_steno_enabled());
 
     ui_casing_layout->setWidget(6, QFormLayout::FieldRole, ui_casing_steno_cb);
 
@@ -426,7 +428,7 @@ AOOptionsDialog::AOOptionsDialog(QWidget *parent, bool casing_alerts_on_server) 
     ui_casing_layout->setWidget(7, QFormLayout::LabelRole, ui_casing_cm_lbl);
 
     ui_casing_cm_cb = new QCheckBox(ui_casing_widget);
-    ui_casing_cm_cb->setChecked(TextFileHandler::getInstance().get_casing_cm_enabled());
+    ui_casing_cm_cb->setChecked(filehandler->get_casing_cm_enabled());
 
     ui_casing_layout->setWidget(7, QFormLayout::FieldRole, ui_casing_cm_cb);
 
@@ -440,7 +442,7 @@ AOOptionsDialog::AOOptionsDialog(QWidget *parent, bool casing_alerts_on_server) 
     ui_casing_layout->setWidget(8, QFormLayout::LabelRole, ui_casing_cm_cases_lbl);
 
     ui_casing_cm_cases_textbox = new QLineEdit(ui_casing_widget);
-    ui_casing_cm_cases_textbox->setText(TextFileHandler::getInstance().get_casing_can_host_cases());
+    ui_casing_cm_cases_textbox->setText(filehandler->get_casing_can_host_cases());
 
     ui_casing_layout->setWidget(8, QFormLayout::FieldRole, ui_casing_cm_cases_textbox);
 
@@ -451,7 +453,7 @@ AOOptionsDialog::AOOptionsDialog(QWidget *parent, bool casing_alerts_on_server) 
 void AOOptionsDialog::save_pressed()
 {
     // Save everything into the config.ini.
-    QSettings* configini = TextFileHandler::getInstance().configini;
+    QSettings* configini = TextFileHandler::getInstance()->configini;
 
     configini->setValue("theme", ui_theme_combobox->currentText());
     configini->setValue("log_goes_downwards", ui_downwards_cb->isChecked());
@@ -461,7 +463,7 @@ void AOOptionsDialog::save_pressed()
     configini->setValue("master", ui_ms_textbox->text());
     configini->setValue("discord", ui_discord_cb->isChecked());
 
-    QFile* callwordsini = new QFile(TextFileHandler::getInstance().get_base_path() + "callwords.ini");
+    QFile* callwordsini = new QFile(TextFileHandler::getInstance()->get_base_path() + "callwords.ini");
 
     if (!callwordsini->open(QIODevice::WriteOnly | QIODevice::Truncate | QIODevice::Text))
     {

--- a/aooptionsdialog.cpp
+++ b/aooptionsdialog.cpp
@@ -1,11 +1,8 @@
 #include "aooptionsdialog.h"
-#include "aoapplication.h"
 #include "bass.h"
 
-AOOptionsDialog::AOOptionsDialog(QWidget *parent, AOApplication *p_ao_app) : QDialog(parent)
+AOOptionsDialog::AOOptionsDialog(QWidget *parent) : QDialog(parent)
 {
-    ao_app = p_ao_app;
-
     // Setting up the basics.
     // setAttribute(Qt::WA_DeleteOnClose);
     setWindowTitle(tr("Settings"));

--- a/aooptionsdialog.cpp
+++ b/aooptionsdialog.cpp
@@ -4,7 +4,7 @@
 
 AOOptionsDialog::AOOptionsDialog(QWidget *parent, bool casing_alerts_on_server) : QDialog(parent)
 {
-    TextFileHandler *filehandler = TextFileHandler::getInstance();
+    TextFileHandler *filehandler = TextFileHandler::get_instance();
 
     // Setting up the basics.
     // setAttribute(Qt::WA_DeleteOnClose);
@@ -453,7 +453,7 @@ AOOptionsDialog::AOOptionsDialog(QWidget *parent, bool casing_alerts_on_server) 
 void AOOptionsDialog::save_pressed()
 {
     // Save everything into the config.ini.
-    QSettings* configini = TextFileHandler::getInstance()->configini;
+    QSettings* configini = TextFileHandler::get_instance()->configini;
 
     configini->setValue("theme", ui_theme_combobox->currentText());
     configini->setValue("log_goes_downwards", ui_downwards_cb->isChecked());
@@ -463,7 +463,7 @@ void AOOptionsDialog::save_pressed()
     configini->setValue("master", ui_ms_textbox->text());
     configini->setValue("discord", ui_discord_cb->isChecked());
 
-    QFile* callwordsini = new QFile(TextFileHandler::getInstance()->get_base_path() + "callwords.ini");
+    QFile* callwordsini = new QFile(TextFileHandler::get_instance()->get_base_path() + "callwords.ini");
 
     if (!callwordsini->open(QIODevice::WriteOnly | QIODevice::Truncate | QIODevice::Text))
     {

--- a/aooptionsdialog.cpp
+++ b/aooptionsdialog.cpp
@@ -1,8 +1,11 @@
 #include "aooptionsdialog.h"
 #include "bass.h"
+#include "text_file_functions.h"
 
-AOOptionsDialog::AOOptionsDialog(QWidget *parent) : QDialog(parent)
+AOOptionsDialog::AOOptionsDialog(QWidget *parent, AOApplication *p_ao_app) : QDialog(parent)
 {
+    ao_app = p_ao_app;
+
     // Setting up the basics.
     // setAttribute(Qt::WA_DeleteOnClose);
     setWindowTitle(tr("Settings"));
@@ -55,13 +58,13 @@ AOOptionsDialog::AOOptionsDialog(QWidget *parent) : QDialog(parent)
     ui_theme_combobox = new QComboBox(ui_form_layout_widget);
 
     // Fill the combobox with the names of the themes.
-    QDirIterator it(p_ao_app->get_base_path() + "themes", QDir::Dirs, QDirIterator::NoIteratorFlags);
+    QDirIterator it(TextFileHandler::getInstance().get_base_path() + "themes", QDir::Dirs, QDirIterator::NoIteratorFlags);
     while (it.hasNext())
     {
         QString actualname = QDir(it.next()).dirName();
         if (actualname != "." && actualname != "..")
             ui_theme_combobox->addItem(actualname);
-        if (actualname == p_ao_app->read_theme())
+        if (actualname == TextFileHandler::getInstance().get_current_theme())
             ui_theme_combobox->setCurrentIndex(ui_theme_combobox->count()-1);
     }
 
@@ -83,7 +86,7 @@ AOOptionsDialog::AOOptionsDialog(QWidget *parent) : QDialog(parent)
     ui_gameplay_form->setWidget(2, QFormLayout::LabelRole, ui_downwards_lbl);
 
     ui_downwards_cb = new QCheckBox(ui_form_layout_widget);
-    ui_downwards_cb->setChecked(p_ao_app->get_log_goes_downwards());
+    ui_downwards_cb->setChecked(TextFileHandler::getInstance().get_log_goes_downwards());
 
     ui_gameplay_form->setWidget(2, QFormLayout::FieldRole, ui_downwards_cb);
 
@@ -96,7 +99,7 @@ AOOptionsDialog::AOOptionsDialog(QWidget *parent) : QDialog(parent)
 
     ui_length_spinbox = new QSpinBox(ui_form_layout_widget);
     ui_length_spinbox->setMaximum(10000);
-    ui_length_spinbox->setValue(p_ao_app->get_max_log_size());
+    ui_length_spinbox->setValue(TextFileHandler::getInstance().get_max_log_size());
 
     ui_gameplay_form->setWidget(3, QFormLayout::FieldRole, ui_length_spinbox);
 
@@ -115,7 +118,7 @@ AOOptionsDialog::AOOptionsDialog(QWidget *parent) : QDialog(parent)
 
     ui_username_textbox = new QLineEdit(ui_form_layout_widget);
     ui_username_textbox->setMaxLength(30);
-    ui_username_textbox->setText(p_ao_app->get_default_username());
+    ui_username_textbox->setText(TextFileHandler::getInstance().get_default_username());
 
     ui_gameplay_form->setWidget(5, QFormLayout::FieldRole, ui_username_textbox);
 
@@ -128,7 +131,7 @@ AOOptionsDialog::AOOptionsDialog(QWidget *parent) : QDialog(parent)
     ui_gameplay_form->setWidget(6, QFormLayout::LabelRole, ui_showname_lbl);
 
     ui_showname_cb = new QCheckBox(ui_form_layout_widget);
-    ui_showname_cb->setChecked(p_ao_app->get_showname_enabled_by_default());
+    ui_showname_cb->setChecked(TextFileHandler::getInstance().get_showname_enabled_by_default());
 
     ui_gameplay_form->setWidget(6, QFormLayout::FieldRole, ui_showname_cb);
 
@@ -145,9 +148,8 @@ AOOptionsDialog::AOOptionsDialog(QWidget *parent) : QDialog(parent)
 
     ui_gameplay_form->setWidget(8, QFormLayout::LabelRole, ui_ms_lbl);
 
-    QSettings* configini = ao_app->configini;
     ui_ms_textbox = new QLineEdit(ui_form_layout_widget);
-    ui_ms_textbox->setText(configini->value("master", "").value<QString>());
+    ui_ms_textbox->setText(TextFileHandler::getInstance().get_master_server());
 
     ui_gameplay_form->setWidget(8, QFormLayout::FieldRole, ui_ms_textbox);
 
@@ -160,7 +162,7 @@ AOOptionsDialog::AOOptionsDialog(QWidget *parent) : QDialog(parent)
     ui_gameplay_form->setWidget(9, QFormLayout::LabelRole, ui_discord_lbl);
 
     ui_discord_cb = new QCheckBox(ui_form_layout_widget);
-    ui_discord_cb->setChecked(ao_app->is_discord_enabled());
+    ui_discord_cb->setChecked(TextFileHandler::getInstance().is_discord_enabled());
 
     ui_gameplay_form->setWidget(9, QFormLayout::FieldRole, ui_discord_cb);
 
@@ -183,7 +185,7 @@ AOOptionsDialog::AOOptionsDialog(QWidget *parent) : QDialog(parent)
 
     // Let's fill the callwords text edit with the already present callwords.
     ui_callwords_textbox->document()->clear();
-    foreach (QString callword, p_ao_app->get_call_words()) {
+    foreach (QString callword, TextFileHandler::getInstance().get_call_words()) {
         ui_callwords_textbox->appendPlainText(callword);
     }
 
@@ -227,7 +229,7 @@ AOOptionsDialog::AOOptionsDialog(QWidget *parent) : QDialog(parent)
     for (a = 0; BASS_GetDeviceInfo(a, &info); a++)
     {
         ui_audio_device_combobox->addItem(info.name);
-        if (p_ao_app->get_audio_output_device() == info.name)
+        if (TextFileHandler::getInstance().get_audio_output_device() == info.name)
             ui_audio_device_combobox->setCurrentIndex(ui_audio_device_combobox->count()-1);
     }
 
@@ -246,7 +248,7 @@ AOOptionsDialog::AOOptionsDialog(QWidget *parent) : QDialog(parent)
     ui_audio_layout->setWidget(2, QFormLayout::LabelRole, ui_music_volume_lbl);
 
     ui_music_volume_spinbox = new QSpinBox(ui_audio_widget);
-    ui_music_volume_spinbox->setValue(p_ao_app->get_default_music());
+    ui_music_volume_spinbox->setValue(TextFileHandler::getInstance().get_default_music());
     ui_music_volume_spinbox->setMaximum(100);
     ui_music_volume_spinbox->setSuffix("%");
 
@@ -260,7 +262,7 @@ AOOptionsDialog::AOOptionsDialog(QWidget *parent) : QDialog(parent)
     ui_audio_layout->setWidget(3, QFormLayout::LabelRole, ui_sfx_volume_lbl);
 
     ui_sfx_volume_spinbox = new QSpinBox(ui_audio_widget);
-    ui_sfx_volume_spinbox->setValue(p_ao_app->get_default_sfx());
+    ui_sfx_volume_spinbox->setValue(TextFileHandler::getInstance().get_default_sfx());
     ui_sfx_volume_spinbox->setMaximum(100);
     ui_sfx_volume_spinbox->setSuffix("%");
 
@@ -273,7 +275,7 @@ AOOptionsDialog::AOOptionsDialog(QWidget *parent) : QDialog(parent)
     ui_audio_layout->setWidget(4, QFormLayout::LabelRole, ui_blips_volume_lbl);
 
     ui_blips_volume_spinbox = new QSpinBox(ui_audio_widget);
-    ui_blips_volume_spinbox->setValue(p_ao_app->get_default_blip());
+    ui_blips_volume_spinbox->setValue(TextFileHandler::getInstance().get_default_blip());
     ui_blips_volume_spinbox->setMaximum(100);
     ui_blips_volume_spinbox->setSuffix("%");
 
@@ -292,7 +294,7 @@ AOOptionsDialog::AOOptionsDialog(QWidget *parent) : QDialog(parent)
     ui_audio_layout->setWidget(6, QFormLayout::LabelRole, ui_bliprate_lbl);
 
     ui_bliprate_spinbox = new QSpinBox(ui_audio_widget);
-    ui_bliprate_spinbox->setValue(p_ao_app->read_blip_rate());
+    ui_bliprate_spinbox->setValue(TextFileHandler::getInstance().read_blip_rate());
     ui_bliprate_spinbox->setMinimum(1);
 
     ui_audio_layout->setWidget(6, QFormLayout::FieldRole, ui_bliprate_spinbox);
@@ -305,7 +307,7 @@ AOOptionsDialog::AOOptionsDialog(QWidget *parent) : QDialog(parent)
     ui_audio_layout->setWidget(7, QFormLayout::LabelRole, ui_blank_blips_lbl);
 
     ui_blank_blips_cb = new QCheckBox(ui_audio_widget);
-    ui_blank_blips_cb->setChecked(p_ao_app->get_blank_blip());
+    ui_blank_blips_cb->setChecked(TextFileHandler::getInstance().get_blank_blip());
 
     ui_audio_layout->setWidget(7, QFormLayout::FieldRole, ui_blank_blips_cb);
 
@@ -342,7 +344,7 @@ AOOptionsDialog::AOOptionsDialog(QWidget *parent) : QDialog(parent)
     ui_casing_layout->setWidget(1, QFormLayout::LabelRole, ui_casing_enabled_lbl);
 
     ui_casing_enabled_cb = new QCheckBox(ui_casing_widget);
-    ui_casing_enabled_cb->setChecked(ao_app->get_casing_enabled());
+    ui_casing_enabled_cb->setChecked(TextFileHandler::getInstance().get_casing_enabled());
 
     ui_casing_layout->setWidget(1, QFormLayout::FieldRole, ui_casing_enabled_cb);
 
@@ -356,7 +358,7 @@ AOOptionsDialog::AOOptionsDialog(QWidget *parent) : QDialog(parent)
     ui_casing_layout->setWidget(2, QFormLayout::LabelRole, ui_casing_def_lbl);
 
     ui_casing_def_cb = new QCheckBox(ui_casing_widget);
-    ui_casing_def_cb->setChecked(ao_app->get_casing_defence_enabled());
+    ui_casing_def_cb->setChecked(TextFileHandler::getInstance().get_casing_defence_enabled());
 
     ui_casing_layout->setWidget(2, QFormLayout::FieldRole, ui_casing_def_cb);
 
@@ -370,7 +372,7 @@ AOOptionsDialog::AOOptionsDialog(QWidget *parent) : QDialog(parent)
     ui_casing_layout->setWidget(3, QFormLayout::LabelRole, ui_casing_pro_lbl);
 
     ui_casing_pro_cb = new QCheckBox(ui_casing_widget);
-    ui_casing_pro_cb->setChecked(ao_app->get_casing_prosecution_enabled());
+    ui_casing_pro_cb->setChecked(TextFileHandler::getInstance().get_casing_prosecution_enabled());
 
     ui_casing_layout->setWidget(3, QFormLayout::FieldRole, ui_casing_pro_cb);
 
@@ -384,7 +386,7 @@ AOOptionsDialog::AOOptionsDialog(QWidget *parent) : QDialog(parent)
     ui_casing_layout->setWidget(4, QFormLayout::LabelRole, ui_casing_jud_lbl);
 
     ui_casing_jud_cb = new QCheckBox(ui_casing_widget);
-    ui_casing_jud_cb->setChecked(ao_app->get_casing_judge_enabled());
+    ui_casing_jud_cb->setChecked(TextFileHandler::getInstance().get_casing_judge_enabled());
 
     ui_casing_layout->setWidget(4, QFormLayout::FieldRole, ui_casing_jud_cb);
 
@@ -398,7 +400,7 @@ AOOptionsDialog::AOOptionsDialog(QWidget *parent) : QDialog(parent)
     ui_casing_layout->setWidget(5, QFormLayout::LabelRole, ui_casing_jur_lbl);
 
     ui_casing_jur_cb = new QCheckBox(ui_casing_widget);
-    ui_casing_jur_cb->setChecked(ao_app->get_casing_juror_enabled());
+    ui_casing_jur_cb->setChecked(TextFileHandler::getInstance().get_casing_juror_enabled());
 
     ui_casing_layout->setWidget(5, QFormLayout::FieldRole, ui_casing_jur_cb);
 
@@ -412,7 +414,7 @@ AOOptionsDialog::AOOptionsDialog(QWidget *parent) : QDialog(parent)
     ui_casing_layout->setWidget(6, QFormLayout::LabelRole, ui_casing_steno_lbl);
 
     ui_casing_steno_cb = new QCheckBox(ui_casing_widget);
-    ui_casing_steno_cb->setChecked(ao_app->get_casing_steno_enabled());
+    ui_casing_steno_cb->setChecked(TextFileHandler::getInstance().get_casing_steno_enabled());
 
     ui_casing_layout->setWidget(6, QFormLayout::FieldRole, ui_casing_steno_cb);
 
@@ -426,7 +428,7 @@ AOOptionsDialog::AOOptionsDialog(QWidget *parent) : QDialog(parent)
     ui_casing_layout->setWidget(7, QFormLayout::LabelRole, ui_casing_cm_lbl);
 
     ui_casing_cm_cb = new QCheckBox(ui_casing_widget);
-    ui_casing_cm_cb->setChecked(ao_app->get_casing_cm_enabled());
+    ui_casing_cm_cb->setChecked(TextFileHandler::getInstance().get_casing_cm_enabled());
 
     ui_casing_layout->setWidget(7, QFormLayout::FieldRole, ui_casing_cm_cb);
 
@@ -440,7 +442,7 @@ AOOptionsDialog::AOOptionsDialog(QWidget *parent) : QDialog(parent)
     ui_casing_layout->setWidget(8, QFormLayout::LabelRole, ui_casing_cm_cases_lbl);
 
     ui_casing_cm_cases_textbox = new QLineEdit(ui_casing_widget);
-    ui_casing_cm_cases_textbox->setText(ao_app->get_casing_can_host_cases());
+    ui_casing_cm_cases_textbox->setText(TextFileHandler::getInstance().get_casing_can_host_cases());
 
     ui_casing_layout->setWidget(8, QFormLayout::FieldRole, ui_casing_cm_cases_textbox);
 
@@ -451,7 +453,7 @@ AOOptionsDialog::AOOptionsDialog(QWidget *parent) : QDialog(parent)
 void AOOptionsDialog::save_pressed()
 {
     // Save everything into the config.ini.
-    QSettings* configini = ao_app->configini;
+    QSettings* configini = TextFileHandler::getInstance().configini;
 
     configini->setValue("theme", ui_theme_combobox->currentText());
     configini->setValue("log_goes_downwards", ui_downwards_cb->isChecked());
@@ -461,7 +463,7 @@ void AOOptionsDialog::save_pressed()
     configini->setValue("master", ui_ms_textbox->text());
     configini->setValue("discord", ui_discord_cb->isChecked());
 
-    QFile* callwordsini = new QFile(ao_app->get_base_path() + "callwords.ini");
+    QFile* callwordsini = new QFile(TextFileHandler::getInstance().get_base_path() + "callwords.ini");
 
     if (!callwordsini->open(QIODevice::WriteOnly | QIODevice::Truncate | QIODevice::Text))
     {

--- a/aooptionsdialog.cpp
+++ b/aooptionsdialog.cpp
@@ -2,10 +2,8 @@
 #include "bass.h"
 #include "text_file_functions.h"
 
-AOOptionsDialog::AOOptionsDialog(QWidget *parent, AOApplication *p_ao_app) : QDialog(parent)
+AOOptionsDialog::AOOptionsDialog(QWidget *parent, bool casing_alerts_on_server) : QDialog(parent)
 {
-    ao_app = p_ao_app;
-
     // Setting up the basics.
     // setAttribute(Qt::WA_DeleteOnClose);
     setWindowTitle(tr("Settings"));
@@ -326,7 +324,7 @@ AOOptionsDialog::AOOptionsDialog(QWidget *parent, AOApplication *p_ao_app) : QDi
     // -- SERVER SUPPORTS CASING
 
     ui_casing_supported_lbl = new QLabel(ui_casing_widget);
-    if (ao_app->casing_alerts_enabled)
+    if (casing_alerts_on_server)
       ui_casing_supported_lbl->setText(tr("This server supports case alerts."));
     else
       ui_casing_supported_lbl->setText(tr("This server does not support case alerts."));

--- a/aooptionsdialog.h
+++ b/aooptionsdialog.h
@@ -2,6 +2,7 @@
 #define AOOPTIONSDIALOG_H
 
 #include "bass.h"
+#include "aoapplication.h"
 
 #include <QtCore/QVariant>
 #include <QtWidgets/QApplication>
@@ -26,9 +27,11 @@ class AOOptionsDialog: public QDialog
 {
     Q_OBJECT
 public:
-    explicit AOOptionsDialog(QWidget *parent = nullptr);
+    explicit AOOptionsDialog(QWidget *parent = nullptr, AOApplication *p_ao_app = nullptr);
 
 private:
+    AOApplication *ao_app;
+
     QVBoxLayout *ui_vertical_layout;
     QTabWidget *ui_settings_tabs;
 

--- a/aooptionsdialog.h
+++ b/aooptionsdialog.h
@@ -103,8 +103,6 @@ private:
 
     bool needs_default_audiodev();
 
-signals:
-
 public slots:
     void save_pressed();
     void discard_pressed();

--- a/aooptionsdialog.h
+++ b/aooptionsdialog.h
@@ -1,7 +1,6 @@
 #ifndef AOOPTIONSDIALOG_H
 #define AOOPTIONSDIALOG_H
 
-#include "aoapplication.h"
 #include "bass.h"
 
 #include <QtCore/QVariant>
@@ -27,11 +26,9 @@ class AOOptionsDialog: public QDialog
 {
     Q_OBJECT
 public:
-    explicit AOOptionsDialog(QWidget *parent = nullptr, AOApplication *p_ao_app = nullptr);
+    explicit AOOptionsDialog(QWidget *parent = nullptr);
 
 private:
-    AOApplication *ao_app;
-
     QVBoxLayout *ui_vertical_layout;
     QTabWidget *ui_settings_tabs;
 

--- a/aooptionsdialog.h
+++ b/aooptionsdialog.h
@@ -27,11 +27,9 @@ class AOOptionsDialog: public QDialog
 {
     Q_OBJECT
 public:
-    explicit AOOptionsDialog(QWidget *parent = nullptr, AOApplication *p_ao_app = nullptr);
+    explicit AOOptionsDialog(QWidget *parent = nullptr, bool casing_alerts_on_server = false);
 
 private:
-    AOApplication *ao_app;
-
     QVBoxLayout *ui_vertical_layout;
     QTabWidget *ui_settings_tabs;
 

--- a/aoscene.cpp
+++ b/aoscene.cpp
@@ -10,9 +10,9 @@ AOScene::AOScene(QWidget *parent) : QLabel(parent)
 
 void AOScene::set_image(QString p_image)
 {
-  QString background_path = TextFileHandler::getInstance().get_background_path(p_image + ".png");
-  QString animated_background_path = TextFileHandler::getInstance().get_background_path(p_image + ".gif");
-  QString default_path = TextFileHandler::getInstance().get_default_background_path(p_image + ".png");
+  QString background_path = TextFileHandler::getInstance()->get_background_path(p_image + ".png");
+  QString animated_background_path = TextFileHandler::getInstance()->get_background_path(p_image + ".gif");
+  QString default_path = TextFileHandler::getInstance()->get_default_background_path(p_image + ".png");
 
   QPixmap background(background_path);
   QPixmap default_bg(default_path);
@@ -47,8 +47,8 @@ void AOScene::set_legacy_desk(QString p_image)
   //vanilla desks vary in both width and height. in order to make that work with viewport rescaling,
   //some INTENSE math is needed.
 
-  QString desk_path = TextFileHandler::getInstance().get_background_path(p_image);
-  QString default_path = TextFileHandler::getInstance().get_default_background_path(p_image);
+  QString desk_path = TextFileHandler::getInstance()->get_background_path(p_image);
+  QString default_path = TextFileHandler::getInstance()->get_default_background_path(p_image);
 
   QPixmap f_desk;
 

--- a/aoscene.cpp
+++ b/aoscene.cpp
@@ -2,10 +2,9 @@
 #include "courtroom.h"
 #include "file_functions.h"
 
-AOScene::AOScene(QWidget *parent, AOApplication *p_ao_app) : QLabel(parent)
+AOScene::AOScene(QWidget *parent) : QLabel(parent)
 {
   m_parent = parent;
-  ao_app = p_ao_app;
   m_movie = new QMovie(this);
 }
 

--- a/aoscene.cpp
+++ b/aoscene.cpp
@@ -10,9 +10,9 @@ AOScene::AOScene(QWidget *parent) : QLabel(parent)
 
 void AOScene::set_image(QString p_image)
 {
-  QString background_path = TextFileHandler::getInstance()->get_background_path(p_image + ".png");
-  QString animated_background_path = TextFileHandler::getInstance()->get_background_path(p_image + ".gif");
-  QString default_path = TextFileHandler::getInstance()->get_default_background_path(p_image + ".png");
+  QString background_path = TextFileHandler::get_instance()->get_background_path(p_image + ".png");
+  QString animated_background_path = TextFileHandler::get_instance()->get_background_path(p_image + ".gif");
+  QString default_path = TextFileHandler::get_instance()->get_default_background_path(p_image + ".png");
 
   QPixmap background(background_path);
   QPixmap default_bg(default_path);
@@ -47,8 +47,8 @@ void AOScene::set_legacy_desk(QString p_image)
   //vanilla desks vary in both width and height. in order to make that work with viewport rescaling,
   //some INTENSE math is needed.
 
-  QString desk_path = TextFileHandler::getInstance()->get_background_path(p_image);
-  QString default_path = TextFileHandler::getInstance()->get_default_background_path(p_image);
+  QString desk_path = TextFileHandler::get_instance()->get_background_path(p_image);
+  QString default_path = TextFileHandler::get_instance()->get_default_background_path(p_image);
 
   QPixmap f_desk;
 

--- a/aoscene.cpp
+++ b/aoscene.cpp
@@ -10,9 +10,9 @@ AOScene::AOScene(QWidget *parent) : QLabel(parent)
 
 void AOScene::set_image(QString p_image)
 {
-  QString background_path = ao_app->get_background_path(p_image + ".png");
-  QString animated_background_path = ao_app->get_background_path(p_image + ".gif");
-  QString default_path = ao_app->get_default_background_path(p_image + ".png");
+  QString background_path = TextFileHandler::getInstance().get_background_path(p_image + ".png");
+  QString animated_background_path = TextFileHandler::getInstance().get_background_path(p_image + ".gif");
+  QString default_path = TextFileHandler::getInstance().get_default_background_path(p_image + ".png");
 
   QPixmap background(background_path);
   QPixmap default_bg(default_path);
@@ -47,8 +47,8 @@ void AOScene::set_legacy_desk(QString p_image)
   //vanilla desks vary in both width and height. in order to make that work with viewport rescaling,
   //some INTENSE math is needed.
 
-  QString desk_path = ao_app->get_background_path(p_image);
-  QString default_path = ao_app->get_default_background_path(p_image);
+  QString desk_path = TextFileHandler::getInstance().get_background_path(p_image);
+  QString default_path = TextFileHandler::getInstance().get_default_background_path(p_image);
 
   QPixmap f_desk;
 

--- a/aoscene.h
+++ b/aoscene.h
@@ -12,7 +12,7 @@ class AOScene : public QLabel
 {
   Q_OBJECT
 public:
-  explicit AOScene(QWidget *parent, AOApplication *p_ao_app);
+  explicit AOScene(QWidget *parent);
 
   void set_image(QString p_image);
   void set_legacy_desk(QString p_image);
@@ -20,7 +20,6 @@ public:
 private:
   QWidget *m_parent;
   QMovie *m_movie;
-  AOApplication *ao_app;
 
 };
 

--- a/aosfxplayer.cpp
+++ b/aosfxplayer.cpp
@@ -11,12 +11,12 @@ void AOSfxPlayer::play(QString p_sfx, QString p_char, QString shout)
 {
   QString misc_path = "";
   QString char_path = "";
-  QString sound_path = TextFileHandler::getInstance().get_sounds_path(p_sfx);
+  QString sound_path = TextFileHandler::get_instance()->get_sounds_path(p_sfx);
 
   if (shout != "")
-    misc_path = TextFileHandler::getInstance().get_base_path() + "misc/" + shout + "/" + p_sfx;
+    misc_path = TextFileHandler::get_instance()->get_base_path() + "misc/" + shout + "/" + p_sfx;
   if (p_char != "")
-    char_path = TextFileHandler::getInstance().get_character_path(p_char, p_sfx);
+    char_path = TextFileHandler::get_instance()->get_character_path(p_char, p_sfx);
 
   QString f_path;
 
@@ -31,7 +31,7 @@ void AOSfxPlayer::play(QString p_sfx, QString p_char, QString shout)
 
   m_stream = BASS_StreamCreateFile(FALSE, f_path.utf16(), 0, 0, BASS_STREAM_AUTOFREE | BASS_UNICODE | BASS_ASYNCFILE);
 
-  if (TextFileHandler::getInstance().get_audio_output_device() != "Default")
+  if (TextFileHandler::get_instance()->get_audio_output_device() != "Default")
     BASS_ChannelSetDevice(m_stream, BASS_GetDevice());
   BASS_ChannelPlay(m_stream, false);
 }

--- a/aosfxplayer.cpp
+++ b/aosfxplayer.cpp
@@ -1,10 +1,9 @@
 #include "aosfxplayer.h"
 #include "file_functions.h"
 
-AOSfxPlayer::AOSfxPlayer(QWidget *parent, AOApplication *p_ao_app)
+AOSfxPlayer::AOSfxPlayer(QWidget *parent)
 {
   m_parent = parent;
-  ao_app = p_ao_app;
 }
 
 void AOSfxPlayer::play(QString p_sfx, QString p_char, QString shout)

--- a/aosfxplayer.cpp
+++ b/aosfxplayer.cpp
@@ -1,5 +1,6 @@
 #include "aosfxplayer.h"
 #include "file_functions.h"
+#include "text_file_functions.h"
 
 AOSfxPlayer::AOSfxPlayer(QWidget *parent)
 {
@@ -10,12 +11,12 @@ void AOSfxPlayer::play(QString p_sfx, QString p_char, QString shout)
 {
   QString misc_path = "";
   QString char_path = "";
-  QString sound_path = ao_app->get_sounds_path(p_sfx);
+  QString sound_path = TextFileHandler::getInstance().get_sounds_path(p_sfx);
 
   if (shout != "")
-    misc_path = ao_app->get_base_path() + "misc/" + shout + "/" + p_sfx;
+    misc_path = TextFileHandler::getInstance().get_base_path() + "misc/" + shout + "/" + p_sfx;
   if (p_char != "")
-    char_path = ao_app->get_character_path(p_char, p_sfx);
+    char_path = TextFileHandler::getInstance().get_character_path(p_char, p_sfx);
 
   QString f_path;
 
@@ -28,7 +29,9 @@ void AOSfxPlayer::play(QString p_sfx, QString p_char, QString shout)
 
   set_volume(m_volume);
 
-  if (ao_app->get_audio_output_device() != "Default")
+  m_stream = BASS_StreamCreateFile(FALSE, f_path.utf16(), 0, 0, BASS_STREAM_AUTOFREE | BASS_UNICODE | BASS_ASYNCFILE);
+
+  if (TextFileHandler::getInstance().get_audio_output_device() != "Default")
     BASS_ChannelSetDevice(m_stream, BASS_GetDevice());
   BASS_ChannelPlay(m_stream, false);
 }

--- a/aosfxplayer.h
+++ b/aosfxplayer.h
@@ -2,7 +2,6 @@
 #define AOSFXPLAYER_H
 
 #include "bass.h"
-#include "aoapplication.h"
 
 #include <QWidget>
 #include <string.h>
@@ -11,7 +10,7 @@
 class AOSfxPlayer
 {
 public:
-  AOSfxPlayer(QWidget *parent, AOApplication *p_ao_app);
+  AOSfxPlayer(QWidget *parent);
 
   void play(QString p_sfx, QString p_char = "", QString shout = "");
   void stop();
@@ -19,7 +18,6 @@ public:
 
 private:
   QWidget *m_parent;
-  AOApplication *ao_app;
 
   int m_volume = 0;
   HSTREAM m_stream;

--- a/charselect.cpp
+++ b/charselect.cpp
@@ -136,7 +136,7 @@ void Courtroom::char_clicked(int n_char)
   }
   else
   {
-    send_server_packet(new AOPacket("CC#" + QString::number(ao_app->s_pv) + "#" + QString::number(n_char) + "#" + get_hdid() + "#%"));
+    emit send_server_packet(new AOPacket("CC#" + QString::number(ao_app->s_pv) + "#" + QString::number(n_char) + "#" + get_hdid() + "#%"));
   }
 
   ui_ic_chat_name->setPlaceholderText(char_list.at(n_char).name);

--- a/charselect.cpp
+++ b/charselect.cpp
@@ -61,7 +61,7 @@ void Courtroom::set_char_select()
 {
   QString filename = "courtroom_design.ini";
 
-  pos_size_type f_charselect = TextFileHandler::getInstance().get_element_dimensions("char_select", filename);
+  pos_size_type f_charselect = TextFileHandler::get_instance()->get_element_dimensions("char_select", filename);
 
   if (f_charselect.width < 0 || f_charselect.height < 0)
   {
@@ -120,7 +120,7 @@ void Courtroom::set_char_select_page()
 
 void Courtroom::char_clicked(int n_char)
 {
-  QString char_ini_path = TextFileHandler::getInstance().get_character_path(char_list.at(n_char).name, "char.ini");
+  QString char_ini_path = TextFileHandler::get_instance()->get_character_path(char_list.at(n_char).name, "char.ini");
 
   qDebug() << "char_ini_path" << char_ini_path;
 
@@ -147,7 +147,7 @@ void Courtroom::put_button_in_place(int starting, int chars_on_this_page)
     if (ui_char_button_list_filtered.size() == 0)
         return;
 
-    QPoint f_spacing = TextFileHandler::getInstance().get_button_spacing("char_button_spacing", "courtroom_design.ini");
+    QPoint f_spacing = TextFileHandler::get_instance()->get_button_spacing("char_button_spacing", "courtroom_design.ini");
 
     int x_spacing = f_spacing.x();
     int x_mod_count = 0;

--- a/charselect.cpp
+++ b/charselect.cpp
@@ -7,23 +7,23 @@
 
 void Courtroom::construct_char_select()
 {
-  ui_char_select_background = new AOImage(this, ao_app);
+  ui_char_select_background = new AOImage(this);
 
   ui_char_buttons = new QWidget(ui_char_select_background);
 
-  ui_selector = new AOImage(ui_char_select_background, ao_app);
+  ui_selector = new AOImage(ui_char_select_background);
   ui_selector->setAttribute(Qt::WA_TransparentForMouseEvents);
   ui_selector->resize(62, 62);
 
-  ui_back_to_lobby = new AOButton(ui_char_select_background, ao_app);
+  ui_back_to_lobby = new AOButton(ui_char_select_background);
 
   ui_char_password = new QLineEdit(ui_char_select_background);
   ui_char_password->setPlaceholderText(tr("Password"));
 
-  ui_char_select_left = new AOButton(ui_char_select_background, ao_app);
-  ui_char_select_right = new AOButton(ui_char_select_background, ao_app);
+  ui_char_select_left = new AOButton(ui_char_select_background);
+  ui_char_select_right = new AOButton(ui_char_select_background);
 
-  ui_spectator = new AOButton(ui_char_select_background, ao_app);
+  ui_spectator = new AOButton(ui_char_select_background);
   ui_spectator->setText(tr("Spectator"));
 
   ui_char_search = new QLineEdit(ui_char_select_background);
@@ -61,7 +61,7 @@ void Courtroom::set_char_select()
 {
   QString filename = "courtroom_design.ini";
 
-  pos_size_type f_charselect = ao_app->get_element_dimensions("char_select", filename);
+  pos_size_type f_charselect = TextFileHandler::getInstance().get_element_dimensions("char_select", filename);
 
   if (f_charselect.width < 0 || f_charselect.height < 0)
   {
@@ -120,7 +120,7 @@ void Courtroom::set_char_select_page()
 
 void Courtroom::char_clicked(int n_char)
 {
-  QString char_ini_path = ao_app->get_character_path(char_list.at(n_char).name, "char.ini");
+  QString char_ini_path = TextFileHandler::getInstance().get_character_path(char_list.at(n_char).name, "char.ini");
 
   qDebug() << "char_ini_path" << char_ini_path;
 
@@ -147,7 +147,7 @@ void Courtroom::put_button_in_place(int starting, int chars_on_this_page)
     if (ui_char_button_list_filtered.size() == 0)
         return;
 
-    QPoint f_spacing = ao_app->get_button_spacing("char_button_spacing", "courtroom_design.ini");
+    QPoint f_spacing = TextFileHandler::getInstance().get_button_spacing("char_button_spacing", "courtroom_design.ini");
 
     int x_spacing = f_spacing.x();
     int x_mod_count = 0;
@@ -198,7 +198,7 @@ void Courtroom::character_loading_finished()
     // Later on, we'll be revealing buttons as we need them.
     for (int n = 0; n < char_list.size(); n++)
     {
-      AOCharButton* character = new AOCharButton(ui_char_buttons, ao_app, 0, 0, char_list.at(n).taken);
+      AOCharButton* character = new AOCharButton(ui_char_buttons, 0, 0, char_list.at(n).taken);
       character->reset();
       character->hide();
       character->set_image(char_list.at(n).name);

--- a/charselect.cpp
+++ b/charselect.cpp
@@ -136,7 +136,7 @@ void Courtroom::char_clicked(int n_char)
   }
   else
   {
-    ao_app->send_server_packet(new AOPacket("CC#" + QString::number(ao_app->s_pv) + "#" + QString::number(n_char) + "#" + get_hdid() + "#%"));
+    send_server_packet(new AOPacket("CC#" + QString::number(ao_app->s_pv) + "#" + QString::number(n_char) + "#" + get_hdid() + "#%"));
   }
 
   ui_ic_chat_name->setPlaceholderText(char_list.at(n_char).name);

--- a/courtroom.cpp
+++ b/courtroom.cpp
@@ -3,7 +3,7 @@
 Courtroom::Courtroom(AOApplication *p_ao_app) : QMainWindow()
 {
   ao_app = p_ao_app;
-  filehandler = TextFileHandler::getInstance();
+  filehandler = TextFileHandler::get_instance();
 
   // Change the default audio output device to be the one the user has given
   // in his config.ini file for now.
@@ -1229,7 +1229,7 @@ void Courtroom::on_chat_return_pressed()
     }
   }
 
-  send_server_packet(new AOPacket("MS", packet_contents));
+  emit send_server_packet(new AOPacket("MS", packet_contents));
 }
 
 void Courtroom::handle_chatmessage(QStringList *p_contents)
@@ -2902,14 +2902,14 @@ void Courtroom::on_ooc_return_pressed()
     if (!caseauth.isEmpty())
       append_server_chatmessage("CLIENT", "Case made by " + caseauth + ".", "1");
     if (!casedoc.isEmpty())
-      send_server_packet(new AOPacket("CT#" + ui_ooc_chat_name->text() + "#/doc " + casedoc + "#%"));
+      emit send_server_packet(new AOPacket("CT#" + ui_ooc_chat_name->text() + "#/doc " + casedoc + "#%"));
     if (!casestatus.isEmpty())
-      send_server_packet(new AOPacket("CT#" + ui_ooc_chat_name->text() + "#/status " + casestatus + "#%"));
+      emit send_server_packet(new AOPacket("CT#" + ui_ooc_chat_name->text() + "#/status " + casestatus + "#%"));
     if (!cmdoc.isEmpty())
       append_server_chatmessage("CLIENT", "Navigate to " + cmdoc + " for the CM doc.", "1");
 
     for (int i = local_evidence_list.size() - 1; i >= 0; i--) {
-        send_server_packet(new AOPacket("DE#" + QString::number(i) + "#%"));
+        emit send_server_packet(new AOPacket("DE#" + QString::number(i) + "#%"));
     }
 
     foreach (QString evi, casefile.childGroups()) {
@@ -2922,7 +2922,7 @@ void Courtroom::on_ooc_return_pressed()
         f_contents.append(casefile.value(evi + "/description", "UNKNOWN").value<QString>());
         f_contents.append(casefile.value(evi + "/image", "UNKNOWN.png").value<QString>());
 
-        send_server_packet(new AOPacket("PE", f_contents));
+        emit send_server_packet(new AOPacket("PE", f_contents));
       }
 
     append_server_chatmessage("CLIENT", "Your case \"" + command[1] + "\" was loaded!", "1");
@@ -2937,9 +2937,9 @@ void Courtroom::on_ooc_return_pressed()
   AOPacket *f_packet = new AOPacket("CT", packet_contents);
 
   if (server_ooc)
-    send_server_packet(f_packet);
+    emit send_server_packet(f_packet);
   else
-    send_ms_packet(f_packet);
+    emit send_ms_packet(f_packet);
 
   ui_ooc_chat_message->clear();
 
@@ -3010,7 +3010,7 @@ void Courtroom::on_pos_dropdown_changed(int p_index)
   if (f_pos == "" || ui_ooc_chat_name->text() == "")
     return;
 
-  send_server_packet(new AOPacket("CT#" + ui_ooc_chat_name->text() + "#/pos " + f_pos + "#%"));
+  emit send_server_packet(new AOPacket("CT#" + ui_ooc_chat_name->text() + "#/pos " + f_pos + "#%"));
 }
 
 void Courtroom::on_mute_list_clicked(QModelIndex p_index)
@@ -3104,18 +3104,18 @@ void Courtroom::on_music_list_double_clicked(QModelIndex p_model)
 
   if (!ui_ic_chat_name->text().isEmpty() && ao_app->cccc_ic_support_enabled)
   {
-    send_server_packet(new AOPacket("MC#" + p_song + "#" + QString::number(m_cid) + "#" + ui_ic_chat_name->text() + "#%"), false);
+    emit send_server_packet(new AOPacket("MC#" + p_song + "#" + QString::number(m_cid) + "#" + ui_ic_chat_name->text() + "#%"), false);
   }
   else
   {
-    send_server_packet(new AOPacket("MC#" + p_song + "#" + QString::number(m_cid) + "#%"), false);
+    emit send_server_packet(new AOPacket("MC#" + p_song + "#" + QString::number(m_cid) + "#%"), false);
   }
 }
 
 void Courtroom::on_area_list_double_clicked(QModelIndex p_model)
 {
     QString p_area = area_list.at(area_row_to_number.at(p_model.row()));
-    send_server_packet(new AOPacket("MC#" + p_area + "#" + QString::number(m_cid) + "#%"), false);
+    emit send_server_packet(new AOPacket("MC#" + p_area + "#" + QString::number(m_cid) + "#%"), false);
 }
 
 void Courtroom::on_hold_it_clicked()
@@ -3254,7 +3254,7 @@ void Courtroom::on_defense_minus_clicked()
   int f_state = defense_bar_state - 1;
 
   if (f_state >= 0)
-    send_server_packet(new AOPacket("HP#1#" + QString::number(f_state) + "#%"));
+    emit send_server_packet(new AOPacket("HP#1#" + QString::number(f_state) + "#%"));
 }
 
 void Courtroom::on_defense_plus_clicked()
@@ -3262,7 +3262,7 @@ void Courtroom::on_defense_plus_clicked()
   int f_state = defense_bar_state + 1;
 
   if (f_state <= 10)
-    send_server_packet(new AOPacket("HP#1#" + QString::number(f_state) + "#%"));
+    emit send_server_packet(new AOPacket("HP#1#" + QString::number(f_state) + "#%"));
 }
 
 void Courtroom::on_prosecution_minus_clicked()
@@ -3270,7 +3270,7 @@ void Courtroom::on_prosecution_minus_clicked()
   int f_state = prosecution_bar_state - 1;
 
   if (f_state >= 0)
-    send_server_packet(new AOPacket("HP#2#" + QString::number(f_state) + "#%"));
+    emit send_server_packet(new AOPacket("HP#2#" + QString::number(f_state) + "#%"));
 }
 
 void Courtroom::on_prosecution_plus_clicked()
@@ -3278,7 +3278,7 @@ void Courtroom::on_prosecution_plus_clicked()
   int f_state = prosecution_bar_state + 1;
 
   if (f_state <= 10)
-    send_server_packet(new AOPacket("HP#2#" + QString::number(f_state) + "#%"));
+    emit send_server_packet(new AOPacket("HP#2#" + QString::number(f_state) + "#%"));
 }
 
 void Courtroom::on_text_color_changed(int p_color)
@@ -3321,7 +3321,7 @@ void Courtroom::on_witness_testimony_clicked()
   if (is_muted)
     return;
 
-  send_server_packet(new AOPacket("RT#testimony1#%"));
+  emit send_server_packet(new AOPacket("RT#testimony1#%"));
 
   ui_ic_chat_message->setFocus();
 }
@@ -3331,7 +3331,7 @@ void Courtroom::on_cross_examination_clicked()
   if (is_muted)
     return;
 
-  send_server_packet(new AOPacket("RT#testimony2#%"));
+  emit send_server_packet(new AOPacket("RT#testimony2#%"));
 
   ui_ic_chat_message->setFocus();
 }
@@ -3341,7 +3341,7 @@ void Courtroom::on_not_guilty_clicked()
   if (is_muted)
     return;
 
-  send_server_packet(new AOPacket("RT#judgeruling#0#%"));
+  emit send_server_packet(new AOPacket("RT#judgeruling#0#%"));
 
   ui_ic_chat_message->setFocus();
 }
@@ -3351,7 +3351,7 @@ void Courtroom::on_guilty_clicked()
   if (is_muted)
     return;
 
-  send_server_packet(new AOPacket("RT#judgeruling#1#%"));
+  emit send_server_packet(new AOPacket("RT#judgeruling#1#%"));
 
   ui_ic_chat_message->setFocus();
 }
@@ -3435,9 +3435,9 @@ void Courtroom::on_call_mod_clicked()
     QStringList mod_reason;
     mod_reason.append(text);
 
-    send_server_packet(new AOPacket("ZZ", mod_reason));
+    emit send_server_packet(new AOPacket("ZZ", mod_reason));
   } else {
-    send_server_packet(new AOPacket("ZZ#%"));
+    emit send_server_packet(new AOPacket("ZZ#%"));
   }
 
   ui_ic_chat_message->setFocus();
@@ -3522,7 +3522,7 @@ void Courtroom::on_switch_area_music_clicked()
 
 void Courtroom::ping_server()
 {
-  send_server_packet(new AOPacket("CH#" + QString::number(m_cid) + "#%"));
+  emit send_server_packet(new AOPacket("CH#" + QString::number(m_cid) + "#%"));
 }
 
 void Courtroom::on_casing_clicked()
@@ -3530,7 +3530,7 @@ void Courtroom::on_casing_clicked()
   if (ao_app->casing_alerts_enabled)
   {
     if (ui_casing->isChecked())
-      send_server_packet(new AOPacket("CT#" + ui_ooc_chat_name->text() + "#/setcase"
+      emit send_server_packet(new AOPacket("CT#" + ui_ooc_chat_name->text() + "#/setcase"
                                             + " \"" + filehandler->get_casing_can_host_cases() + "\""
                                             + " " + QString::number(filehandler->get_casing_cm_enabled())
                                             + " " + QString::number(filehandler->get_casing_defence_enabled())
@@ -3540,14 +3540,14 @@ void Courtroom::on_casing_clicked()
                                             + " " + QString::number(filehandler->get_casing_steno_enabled())
                                             + "#%"));
     else
-      send_server_packet(new AOPacket("CT#" + ui_ooc_chat_name->text() + "#/setcase \"\" 0 0 0 0 0 0#%"));
+      emit send_server_packet(new AOPacket("CT#" + ui_ooc_chat_name->text() + "#/setcase \"\" 0 0 0 0 0 0#%"));
   }
 }
 
 void Courtroom::announce_case(QString* title, bool def, bool pro, bool jud, bool jur, bool steno)
 {
   if (ao_app->casing_alerts_enabled)
-    send_server_packet(new AOPacket("CT#" + ui_ooc_chat_name->text() + "#/anncase \""
+    emit send_server_packet(new AOPacket("CT#" + ui_ooc_chat_name->text() + "#/anncase \""
                                           + title + "\" "
                                           + QString::number(def) + " "
                                           + QString::number(pro) + " "

--- a/courtroom.cpp
+++ b/courtroom.cpp
@@ -3,13 +3,14 @@
 Courtroom::Courtroom(AOApplication *p_ao_app) : QMainWindow()
 {
   ao_app = p_ao_app;
+  filehandler = TextFileHandler::getInstance();
 
   // Change the default audio output device to be the one the user has given
   // in his config.ini file for now.
   int a = 0;
   BASS_DEVICEINFO info;
 
-  if (TextFileHandler::getInstance().get_audio_output_device() == "Default")
+  if (filehandler->get_audio_output_device() == "Default")
   {
       BASS_Init(-1, 48000, BASS_DEVICE_LATENCY, nullptr, nullptr);
       load_bass_opus_plugin();
@@ -18,7 +19,7 @@ Courtroom::Courtroom(AOApplication *p_ao_app) : QMainWindow()
   {
       for (a = 0; BASS_GetDeviceInfo(a, &info); a++)
       {
-          if (TextFileHandler::getInstance().get_audio_output_device() == info.name)
+          if (filehandler->get_audio_output_device() == info.name)
           {
               BASS_SetDevice(a);
               BASS_Init(a, 48000, BASS_DEVICE_LATENCY, nullptr, nullptr);
@@ -93,8 +94,8 @@ Courtroom::Courtroom(AOApplication *p_ao_app) : QMainWindow()
   ui_ic_chatlog = new QTextEdit(this);
   ui_ic_chatlog->setReadOnly(true);
 
-  log_maximum_blocks = TextFileHandler::getInstance().get_max_log_size();
-  log_goes_downwards = TextFileHandler::getInstance().get_log_goes_downwards();
+  log_maximum_blocks = filehandler->get_max_log_size();
+  log_goes_downwards = filehandler->get_log_goes_downwards();
 
   ui_ms_chatlog = new AOTextArea(this);
   ui_ms_chatlog->setReadOnly(true);
@@ -127,7 +128,7 @@ Courtroom::Courtroom(AOApplication *p_ao_app) : QMainWindow()
   ui_ooc_chat_name->setFrame(false);
   ui_ooc_chat_name->setPlaceholderText("Name");
   ui_ooc_chat_name->setMaxLength(30);
-  ui_ooc_chat_name->setText(TextFileHandler::getInstance().get_default_username());
+  ui_ooc_chat_name->setText(filehandler->get_default_username());
 
   //ui_area_password = new QLineEdit(this);
   //ui_area_password->setFrame(false);
@@ -186,12 +187,12 @@ Courtroom::Courtroom(AOApplication *p_ao_app) : QMainWindow()
   ui_guard->setText("Guard");
   ui_guard->hide();
   ui_casing = new QCheckBox(this);
-  ui_casing->setChecked(TextFileHandler::getInstance().get_casing_enabled());
+  ui_casing->setChecked(filehandler->get_casing_enabled());
   ui_casing->setText(tr("Casing"));
   ui_casing->hide();
 
   ui_showname_enable = new QCheckBox(this);
-  ui_showname_enable->setChecked(TextFileHandler::getInstance().get_showname_enabled_by_default());
+  ui_showname_enable->setChecked(filehandler->get_showname_enabled_by_default());
   ui_showname_enable->setText(tr("Shownames"));
 
   ui_pre_non_interrupt = new QCheckBox(this);
@@ -221,19 +222,19 @@ Courtroom::Courtroom(AOApplication *p_ao_app) : QMainWindow()
 
   ui_music_slider = new QSlider(Qt::Horizontal, this);
   ui_music_slider->setRange(0, 100);
-  ui_music_slider->setValue(TextFileHandler::getInstance().get_default_music());
+  ui_music_slider->setValue(filehandler->get_default_music());
 
   ui_sfx_slider = new QSlider(Qt::Horizontal, this);
   ui_sfx_slider->setRange(0, 100);
-  ui_sfx_slider->setValue(TextFileHandler::getInstance().get_default_sfx());
+  ui_sfx_slider->setValue(filehandler->get_default_sfx());
 
   ui_blip_slider = new QSlider(Qt::Horizontal, this);
   ui_blip_slider->setRange(0, 100);
-  ui_blip_slider->setValue(TextFileHandler::getInstance().get_default_blip());
+  ui_blip_slider->setValue(filehandler->get_default_blip());
 
   ui_log_limit_spinbox = new QSpinBox(this);
   ui_log_limit_spinbox->setRange(0, 10000);
-  ui_log_limit_spinbox->setValue(TextFileHandler::getInstance().get_max_log_size());
+  ui_log_limit_spinbox->setValue(filehandler->get_max_log_size());
 
   ui_mute_list = new QListWidget(this);
   ui_pair_list = new QListWidget(this);
@@ -375,12 +376,12 @@ void Courtroom::set_pair_list()
 
 void Courtroom::set_widgets()
 {
-  blip_rate = TextFileHandler::getInstance().read_blip_rate();
-  blank_blip = TextFileHandler::getInstance().get_blank_blip();
+  blip_rate = filehandler->read_blip_rate();
+  blank_blip = filehandler->get_blank_blip();
 
   QString filename = "courtroom_design.ini";
 
-  pos_size_type f_courtroom = TextFileHandler::getInstance().get_element_dimensions("courtroom", filename);
+  pos_size_type f_courtroom = filehandler->get_element_dimensions("courtroom", filename);
 
   if (f_courtroom.width < 0 || f_courtroom.height < 0)
   {
@@ -710,7 +711,7 @@ void Courtroom::set_fonts()
 
   // Set color of labels and checkboxes
   const QString design_file = "courtroom_fonts.ini";
-  QColor f_color = TextFileHandler::getInstance().get_color("label_color", design_file);
+  QColor f_color = filehandler->get_color("label_color", design_file);
   QString color_string = "color: rgba(" +
           QString::number(f_color.red()) + ", " +
           QString::number(f_color.green()) + ", " +
@@ -723,12 +724,12 @@ void Courtroom::set_fonts()
 void Courtroom::set_font(QWidget *widget, QString p_identifier)
 {
   QString design_file = "courtroom_fonts.ini";
-  int f_weight = TextFileHandler::getInstance().get_font_size(p_identifier, design_file);
+  int f_weight = filehandler->get_font_size(p_identifier, design_file);
   QString class_name = widget->metaObject()->className();
 
   widget->setFont(QFont("Sans", f_weight));
 
-  QColor f_color = TextFileHandler::getInstance().get_color(p_identifier + "_color", design_file);
+  QColor f_color = filehandler->get_color(p_identifier + "_color", design_file);
 
   QString style_sheet_string = class_name + " { background-color: rgba(0, 0, 0, 0);\n" +
                                             "color: rgba(" +
@@ -748,7 +749,7 @@ void Courtroom::set_size_and_pos(QWidget *p_widget, QString p_identifier)
 {
   QString filename = "courtroom_design.ini";
 
-  pos_size_type design_ini_result = TextFileHandler::getInstance().get_element_dimensions(p_identifier, filename);
+  pos_size_type design_ini_result = filehandler->get_element_dimensions(p_identifier, filename);
 
   if (design_ini_result.width < 0 || design_ini_result.height < 0)
   {
@@ -806,9 +807,9 @@ void Courtroom::set_background(QString p_background)
 
   current_background = p_background;
 
-  is_ao2_bg = file_exists(TextFileHandler::getInstance().get_background_path("defensedesk.png")) &&
-              file_exists(TextFileHandler::getInstance().get_background_path("prosecutiondesk.png")) &&
-              file_exists(TextFileHandler::getInstance().get_background_path("stand.png"));
+  is_ao2_bg = file_exists(filehandler->get_background_path("defensedesk.png")) &&
+              file_exists(filehandler->get_background_path("prosecutiondesk.png")) &&
+              file_exists(filehandler->get_background_path("stand.png"));
 
   if (is_ao2_bg)
   {
@@ -830,15 +831,15 @@ void Courtroom::enter_courtroom(int p_cid)
 
   if (m_cid == -1)
   {
-    if (TextFileHandler::getInstance().is_discord_enabled())
+    if (filehandler->is_discord_enabled())
       ao_app->discord->state_spectate();
     f_char = "";
   }
   else
   {
-    f_char = TextFileHandler::getInstance().get_char_name(char_list.at(m_cid).name);
+    f_char = filehandler->get_char_name(char_list.at(m_cid).name);
 
-    if (TextFileHandler::getInstance().is_discord_enabled())
+    if (filehandler->is_discord_enabled())
       ao_app->discord->state_character(f_char.toStdString());
   }
 
@@ -860,7 +861,7 @@ void Courtroom::enter_courtroom(int p_cid)
 
   set_evidence_page();
 
-  QString side = TextFileHandler::getInstance().get_char_side(f_char);
+  QString side = filehandler->get_char_side(f_char);
 
   if (side == "jud")
   {
@@ -886,9 +887,9 @@ void Courtroom::enter_courtroom(int p_cid)
   }
 
   if (ao_app->custom_objection_enabled &&
-      (file_exists(TextFileHandler::getInstance().get_character_path(current_char, "custom.gif")) ||
-      file_exists(TextFileHandler::getInstance().get_character_path(current_char, "custom.apng"))) &&
-      file_exists(TextFileHandler::getInstance().get_character_path(current_char, "custom.wav")))
+      (file_exists(filehandler->get_character_path(current_char, "custom.gif")) ||
+      file_exists(filehandler->get_character_path(current_char, "custom.apng"))) &&
+      file_exists(filehandler->get_character_path(current_char, "custom.wav")))
     ui_custom_objection->show();
   else
     ui_custom_objection->hide();
@@ -930,8 +931,8 @@ void Courtroom::list_music()
 
   QString f_file = "courtroom_design.ini";
 
-  QBrush found_brush(TextFileHandler::getInstance().get_color("found_song_color", f_file));
-  QBrush missing_brush(TextFileHandler::getInstance().get_color("missing_song_color", f_file));
+  QBrush found_brush(filehandler->get_color("found_song_color", f_file));
+  QBrush missing_brush(filehandler->get_color("missing_song_color", f_file));
 
   int n_listed_songs = 0;
 
@@ -946,7 +947,7 @@ void Courtroom::list_music()
       ui_music_list->addItem(i_song_listname);
       music_row_to_number.append(n_song);
 
-      QString song_path = TextFileHandler::getInstance().get_music_path(i_song);
+      QString song_path = filehandler->get_music_path(i_song);
 
       if (file_exists(song_path))
         ui_music_list->item(n_listed_songs)->setBackground(found_brush);
@@ -965,13 +966,13 @@ void Courtroom::list_areas()
 
   QString f_file = "courtroom_design.ini";
 
-  QBrush free_brush(TextFileHandler::getInstance().get_color("area_free_color", f_file));
-  QBrush lfp_brush(TextFileHandler::getInstance().get_color("area_lfp_color", f_file));
-  QBrush casing_brush(TextFileHandler::getInstance().get_color("area_casing_color", f_file));
-  QBrush recess_brush(TextFileHandler::getInstance().get_color("area_recess_color", f_file));
-  QBrush rp_brush(TextFileHandler::getInstance().get_color("area_rp_color", f_file));
-  QBrush gaming_brush(TextFileHandler::getInstance().get_color("area_gaming_color", f_file));
-  QBrush locked_brush(TextFileHandler::getInstance().get_color("area_locked_color", f_file));
+  QBrush free_brush(filehandler->get_color("area_free_color", f_file));
+  QBrush lfp_brush(filehandler->get_color("area_lfp_color", f_file));
+  QBrush casing_brush(filehandler->get_color("area_casing_color", f_file));
+  QBrush recess_brush(filehandler->get_color("area_recess_color", f_file));
+  QBrush rp_brush(filehandler->get_color("area_rp_color", f_file));
+  QBrush gaming_brush(filehandler->get_color("area_gaming_color", f_file));
+  QBrush locked_brush(filehandler->get_color("area_locked_color", f_file));
 
   int n_listed_areas = 0;
 
@@ -1039,7 +1040,7 @@ void Courtroom::list_areas()
 
 void Courtroom::append_ms_chatmessage(QString f_name, QString f_message)
 {
-  ui_ms_chatlog->append_chatmessage(f_name, f_message, TextFileHandler::getInstance().get_color("ooc_default_color", "courtroom_design.ini").name());
+  ui_ms_chatlog->append_chatmessage(f_name, f_message, filehandler->get_color("ooc_default_color", "courtroom_design.ini").name());
 }
 
 void Courtroom::append_server_chatmessage(QString p_name, QString p_message, QString p_colour)
@@ -1047,9 +1048,9 @@ void Courtroom::append_server_chatmessage(QString p_name, QString p_message, QSt
   QString colour = "#000000";
 
   if (p_colour == "0")
-    colour = TextFileHandler::getInstance().get_color("ooc_default_color", "courtroom_design.ini").name();
+    colour = filehandler->get_color("ooc_default_color", "courtroom_design.ini").name();
   if (p_colour == "1")
-    colour = TextFileHandler::getInstance().get_color("ooc_server_color", "courtroom_design.ini").name();
+    colour = filehandler->get_color("ooc_server_color", "courtroom_design.ini").name();
 
   ui_server_chatlog->append_chatmessage(p_name, p_message, colour);
 }
@@ -1089,32 +1090,32 @@ void Courtroom::on_chat_return_pressed()
 
   QStringList packet_contents;
 
-  QString f_side = TextFileHandler::getInstance().get_char_side(current_char);
+  QString f_side = filehandler->get_char_side(current_char);
 
   QString f_desk_mod = "chat";
 
   if (ao_app->desk_mod_enabled)
   {
-    f_desk_mod = QString::number(TextFileHandler::getInstance().get_desk_mod(current_char, current_emote));
+    f_desk_mod = QString::number(filehandler->get_desk_mod(current_char, current_emote));
     if (f_desk_mod == "-1")
       f_desk_mod = "chat";
   }
 
   packet_contents.append(f_desk_mod);
 
-  packet_contents.append(TextFileHandler::getInstance().get_pre_emote(current_char, current_emote));
+  packet_contents.append(filehandler->get_pre_emote(current_char, current_emote));
 
   packet_contents.append(current_char);
 
-  packet_contents.append(TextFileHandler::getInstance().get_emote(current_char, current_emote));
+  packet_contents.append(filehandler->get_emote(current_char, current_emote));
 
   packet_contents.append(ui_ic_chat_message->text());
 
   packet_contents.append(f_side);
 
-  packet_contents.append(TextFileHandler::getInstance().get_sfx_name(current_char, current_emote));
+  packet_contents.append(filehandler->get_sfx_name(current_char, current_emote));
 
-  int f_emote_mod = TextFileHandler::getInstance().get_emote_mod(current_char, current_emote);
+  int f_emote_mod = filehandler->get_emote_mod(current_char, current_emote);
 
   //needed or else legacy won't understand what we're saying
   if (objection_state > 0)
@@ -1145,7 +1146,7 @@ void Courtroom::on_chat_return_pressed()
   packet_contents.append(QString::number(f_emote_mod));
   packet_contents.append(QString::number(m_cid));
 
-  packet_contents.append(QString::number(TextFileHandler::getInstance().get_sfx_delay(current_char, current_emote)));
+  packet_contents.append(QString::number(filehandler->get_sfx_delay(current_char, current_emote)));
 
   QString f_obj_state;
 
@@ -1269,7 +1270,7 @@ void Courtroom::handle_chatmessage(QStringList *p_contents)
   QString f_showname;
   if (m_chatmessage[SHOWNAME].isEmpty() || !ui_showname_enable->isChecked())
   {
-      f_showname = TextFileHandler::getInstance().get_showname(char_list.at(f_char_id).name);
+      f_showname = filehandler->get_showname(char_list.at(f_char_id).name);
   }
   else
   {
@@ -1306,7 +1307,7 @@ void Courtroom::handle_chatmessage(QStringList *p_contents)
     ui_evidence_present->set_image("present_disabled.png");
   }
 
-  chatlogpiece* temp = new chatlogpiece(TextFileHandler::getInstance().get_showname(char_list.at(f_char_id).name), f_showname, ": " + m_chatmessage[MESSAGE], false);
+  chatlogpiece* temp = new chatlogpiece(filehandler->get_showname(char_list.at(f_char_id).name), f_showname, ": " + m_chatmessage[MESSAGE], false);
   ic_chatlog_history.append(*temp);
 
   while(ic_chatlog_history.size() > log_maximum_blocks)
@@ -1320,7 +1321,7 @@ void Courtroom::handle_chatmessage(QStringList *p_contents)
 
   int objection_mod = m_chatmessage[OBJECTION_MOD].toInt();
   QString f_char = m_chatmessage[CHAR_NAME];
-  QString f_custom_theme = TextFileHandler::getInstance().get_char_shouts(f_char);
+  QString f_custom_theme = filehandler->get_char_shouts(f_char);
 
   //if an objection is used
   if (objection_mod <= 4 && objection_mod >= 1)
@@ -1371,7 +1372,7 @@ void Courtroom::handle_chatmessage_2()
   {
       QString real_name = char_list.at(m_chatmessage[CHAR_ID].toInt()).name;
 
-      QString f_showname = TextFileHandler::getInstance().get_showname(real_name);
+      QString f_showname = filehandler->get_showname(real_name);
 
       ui_vp_showname->setText(f_showname);
   }
@@ -1383,13 +1384,13 @@ void Courtroom::handle_chatmessage_2()
   ui_vp_message->clear();
   ui_vp_chatbox->hide();
 
-  QString chatbox = TextFileHandler::getInstance().get_chat(m_chatmessage[CHAR_NAME]);
+  QString chatbox = filehandler->get_chat(m_chatmessage[CHAR_NAME]);
 
   if (chatbox == "")
     ui_vp_chatbox->set_image("chatmed.png");
   else
   {
-    QString chatbox_path = TextFileHandler::getInstance().get_base_path() + "misc/" + chatbox + "/chatbox.png";
+    QString chatbox_path = filehandler->get_base_path() + "misc/" + chatbox + "/chatbox.png";
     ui_vp_chatbox->set_image_from_path(chatbox_path);
   }
 
@@ -1586,7 +1587,7 @@ void Courtroom::handle_chatmessage_3()
   {
     realization_timer->start(60);
     ui_vp_realization->show();
-    sfx_player->play(TextFileHandler::getInstance().get_custom_realization(m_chatmessage[CHAR_NAME]));
+    sfx_player->play(filehandler->get_custom_realization(m_chatmessage[CHAR_NAME]));
   }
 
   int f_evi_id = m_chatmessage[EVIDENCE_ID].toInt();
@@ -1659,13 +1660,13 @@ void Courtroom::handle_chatmessage_3()
   }
 
   QString f_message = m_chatmessage[MESSAGE];
-  QStringList call_words = TextFileHandler::getInstance().get_call_words();
+  QStringList call_words = filehandler->get_call_words();
 
   for (QString word : call_words)
   {
     if (f_message.contains(word, Qt::CaseInsensitive))
     {
-      modcall_player->play(TextFileHandler::getInstance().get_sfx("word_call"));
+      modcall_player->play(filehandler->get_sfx("word_call"));
       ao_app->alert(this);
 
       break;
@@ -1988,19 +1989,19 @@ void Courtroom::play_preanim()
   QString f_preanim = m_chatmessage[PRE_EMOTE];
 
   //all time values in char.inis are multiplied by a constant(time_mod) to get the actual time
-  int ao2_duration = TextFileHandler::getInstance().get_ao2_preanim_duration(f_char, f_preanim);
-  int text_delay = TextFileHandler::getInstance().get_text_delay(f_char, f_preanim) * time_mod;
+  int ao2_duration = filehandler->get_ao2_preanim_duration(f_char, f_preanim);
+  int text_delay = filehandler->get_text_delay(f_char, f_preanim) * time_mod;
   int sfx_delay = m_chatmessage[SFX_DELAY].toInt() * 60;
 
   int preanim_duration;
 
   if (ao2_duration < 0)
-    preanim_duration = TextFileHandler::getInstance().get_preanim_duration(f_char, f_preanim);
+    preanim_duration = filehandler->get_preanim_duration(f_char, f_preanim);
   else
     preanim_duration = ao2_duration;
 
   sfx_delay_timer->start(sfx_delay);
-  QString anim_to_find = TextFileHandler::getInstance().get_image_suffix(TextFileHandler::getInstance().get_character_path(f_char, f_preanim));
+  QString anim_to_find = filehandler->get_image_suffix(filehandler->get_character_path(f_char, f_preanim));
   if (!file_exists(anim_to_find) ||
       preanim_duration < 0)
   {
@@ -2023,19 +2024,19 @@ void Courtroom::play_noninterrupting_preanim()
   QString f_preanim = m_chatmessage[PRE_EMOTE];
 
   //all time values in char.inis are multiplied by a constant(time_mod) to get the actual time
-  int ao2_duration = TextFileHandler::getInstance().get_ao2_preanim_duration(f_char, f_preanim);
-  int text_delay = TextFileHandler::getInstance().get_text_delay(f_char, f_preanim) * time_mod;
+  int ao2_duration = filehandler->get_ao2_preanim_duration(f_char, f_preanim);
+  int text_delay = filehandler->get_text_delay(f_char, f_preanim) * time_mod;
   int sfx_delay = m_chatmessage[SFX_DELAY].toInt() * 60;
 
   int preanim_duration;
 
   if (ao2_duration < 0)
-    preanim_duration = TextFileHandler::getInstance().get_preanim_duration(f_char, f_preanim);
+    preanim_duration = filehandler->get_preanim_duration(f_char, f_preanim);
   else
     preanim_duration = ao2_duration;
 
   sfx_delay_timer->start(sfx_delay);
-  QString anim_to_find = TextFileHandler::getInstance().get_image_suffix(TextFileHandler::getInstance().get_character_path(f_char, f_preanim));
+  QString anim_to_find = filehandler->get_image_suffix(filehandler->get_character_path(f_char, f_preanim));
   if (!file_exists(anim_to_find) ||
       preanim_duration < 0)
   {
@@ -2101,7 +2102,7 @@ void Courtroom::start_chat_ticking()
   current_display_speed = 3;
   chat_tick_timer->start(message_display_speed[current_display_speed]);
 
-  QString f_gender = TextFileHandler::getInstance().get_gender(m_chatmessage[CHAR_NAME]);
+  QString f_gender = filehandler->get_gender(m_chatmessage[CHAR_NAME]);
 
   blip_player->set_blips("sfx-blip" + f_gender + ".wav");
 
@@ -2421,7 +2422,7 @@ void Courtroom::play_sfx()
   if (sfx_name == "1")
     return;
 
-  sfx_player->play(TextFileHandler::getInstance().get_sfx_suffix(sfx_name));
+  sfx_player->play(filehandler->get_sfx_suffix(sfx_name));
 }
 
 void Courtroom::set_scene()
@@ -2520,7 +2521,7 @@ void Courtroom::set_scene()
 
 void Courtroom::set_text_color()
 {
-  QColor textcolor = TextFileHandler::getInstance().get_chat_color(m_chatmessage[TEXT_COLOR], TextFileHandler::getInstance().get_chat(m_chatmessage[CHAR_NAME]));
+  QColor textcolor = filehandler->get_chat_color(m_chatmessage[TEXT_COLOR], filehandler->get_chat(m_chatmessage[CHAR_NAME]));
 
   ui_vp_message->setTextBackgroundColor(QColor(0,0,0,0));
   ui_vp_message->setTextColor(textcolor);
@@ -2539,7 +2540,7 @@ void Courtroom::set_text_color()
 
 QColor Courtroom::get_text_color(QString color)
 {
-  return TextFileHandler::getInstance().get_chat_color(color, TextFileHandler::getInstance().get_chat(m_chatmessage[CHAR_NAME]));
+  return filehandler->get_chat_color(color, filehandler->get_chat(m_chatmessage[CHAR_NAME]));
 }
 
 void Courtroom::set_ip_list(QString p_list)
@@ -2629,7 +2630,7 @@ void Courtroom::handle_wtce(QString p_wtce, int variant)
   //witness testimony
   if (p_wtce == "testimony1")
   {
-    sfx_player->play(TextFileHandler::getInstance().get_sfx("witness_testimony"));
+    sfx_player->play(filehandler->get_sfx("witness_testimony"));
     ui_vp_wtce->play("witnesstestimony");
     testimony_in_progress = true;
     show_testimony();
@@ -2637,7 +2638,7 @@ void Courtroom::handle_wtce(QString p_wtce, int variant)
   //cross examination
   else if (p_wtce == "testimony2")
   {
-    sfx_player->play(TextFileHandler::getInstance().get_sfx("cross_examination"));
+    sfx_player->play(filehandler->get_sfx("cross_examination"));
     ui_vp_wtce->play("crossexamination");
     testimony_in_progress = false;
   }
@@ -2645,12 +2646,12 @@ void Courtroom::handle_wtce(QString p_wtce, int variant)
   {
     if (variant == 0)
     {
-        sfx_player->play(TextFileHandler::getInstance().get_sfx("not_guilty"));
+        sfx_player->play(filehandler->get_sfx("not_guilty"));
         ui_vp_wtce->play("notguilty");
         testimony_in_progress = false;
     }
     else if (variant == 1) {
-        sfx_player->play(TextFileHandler::getInstance().get_sfx("guilty"));
+        sfx_player->play(filehandler->get_sfx("guilty"));
         ui_vp_wtce->play("guilty");
         testimony_in_progress = false;
     }
@@ -2679,7 +2680,7 @@ void Courtroom::mod_called(QString p_ip)
   ui_server_chatlog->append(p_ip);
   if (ui_guard->isChecked())
   {
-    modcall_player->play(TextFileHandler::getInstance().get_sfx("mod_call"));
+    modcall_player->play(filehandler->get_sfx("mod_call"));
     ao_app->alert(this);
   }
 }
@@ -2689,13 +2690,13 @@ void Courtroom::case_called(QString msg, bool def, bool pro, bool jud, bool jur,
   if (ui_casing->isChecked())
   {
     ui_server_chatlog->append(msg);
-    if ((TextFileHandler::getInstance().get_casing_defence_enabled() && def) ||
-        (TextFileHandler::getInstance().get_casing_prosecution_enabled() && pro) ||
-        (TextFileHandler::getInstance().get_casing_judge_enabled() && jud) ||
-        (TextFileHandler::getInstance().get_casing_juror_enabled() && jur) ||
-        (TextFileHandler::getInstance().get_casing_steno_enabled() && steno))
+    if ((filehandler->get_casing_defence_enabled() && def) ||
+        (filehandler->get_casing_prosecution_enabled() && pro) ||
+        (filehandler->get_casing_judge_enabled() && jud) ||
+        (filehandler->get_casing_juror_enabled() && jur) ||
+        (filehandler->get_casing_steno_enabled() && steno))
     {
-        modcall_player->play(TextFileHandler::getInstance().get_sfx("case_call"));
+        modcall_player->play(filehandler->get_sfx("case_call"));
         ao_app->alert(this);
     }
   }
@@ -3370,7 +3371,7 @@ void Courtroom::on_change_character_clicked()
 
 void Courtroom::on_reload_theme_clicked()
 { 
-  TextFileHandler::getInstance().read_theme();
+  filehandler->read_theme();
 
   //to update status on the background
   set_background(current_background);
@@ -3530,13 +3531,13 @@ void Courtroom::on_casing_clicked()
   {
     if (ui_casing->isChecked())
       send_server_packet(new AOPacket("CT#" + ui_ooc_chat_name->text() + "#/setcase"
-                                            + " \"" + TextFileHandler::getInstance().get_casing_can_host_cases() + "\""
-                                            + " " + QString::number(TextFileHandler::getInstance().get_casing_cm_enabled())
-                                            + " " + QString::number(TextFileHandler::getInstance().get_casing_defence_enabled())
-                                            + " " + QString::number(TextFileHandler::getInstance().get_casing_prosecution_enabled())
-                                            + " " + QString::number(TextFileHandler::getInstance().get_casing_judge_enabled())
-                                            + " " + QString::number(TextFileHandler::getInstance().get_casing_juror_enabled())
-                                            + " " + QString::number(TextFileHandler::getInstance().get_casing_steno_enabled())
+                                            + " \"" + filehandler->get_casing_can_host_cases() + "\""
+                                            + " " + QString::number(filehandler->get_casing_cm_enabled())
+                                            + " " + QString::number(filehandler->get_casing_defence_enabled())
+                                            + " " + QString::number(filehandler->get_casing_prosecution_enabled())
+                                            + " " + QString::number(filehandler->get_casing_judge_enabled())
+                                            + " " + QString::number(filehandler->get_casing_juror_enabled())
+                                            + " " + QString::number(filehandler->get_casing_steno_enabled())
                                             + "#%"));
     else
       send_server_packet(new AOPacket("CT#" + ui_ooc_chat_name->text() + "#/setcase \"\" 0 0 0 0 0 0#%"));

--- a/courtroom.cpp
+++ b/courtroom.cpp
@@ -1228,7 +1228,7 @@ void Courtroom::on_chat_return_pressed()
     }
   }
 
-  ao_app->send_server_packet(new AOPacket("MS", packet_contents));
+  send_server_packet(new AOPacket("MS", packet_contents));
 }
 
 void Courtroom::handle_chatmessage(QStringList *p_contents)
@@ -2901,14 +2901,14 @@ void Courtroom::on_ooc_return_pressed()
     if (!caseauth.isEmpty())
       append_server_chatmessage("CLIENT", "Case made by " + caseauth + ".", "1");
     if (!casedoc.isEmpty())
-      ao_app->send_server_packet(new AOPacket("CT#" + ui_ooc_chat_name->text() + "#/doc " + casedoc + "#%"));
+      send_server_packet(new AOPacket("CT#" + ui_ooc_chat_name->text() + "#/doc " + casedoc + "#%"));
     if (!casestatus.isEmpty())
-      ao_app->send_server_packet(new AOPacket("CT#" + ui_ooc_chat_name->text() + "#/status " + casestatus + "#%"));
+      send_server_packet(new AOPacket("CT#" + ui_ooc_chat_name->text() + "#/status " + casestatus + "#%"));
     if (!cmdoc.isEmpty())
       append_server_chatmessage("CLIENT", "Navigate to " + cmdoc + " for the CM doc.", "1");
 
     for (int i = local_evidence_list.size() - 1; i >= 0; i--) {
-        ao_app->send_server_packet(new AOPacket("DE#" + QString::number(i) + "#%"));
+        send_server_packet(new AOPacket("DE#" + QString::number(i) + "#%"));
     }
 
     foreach (QString evi, casefile.childGroups()) {
@@ -2921,7 +2921,7 @@ void Courtroom::on_ooc_return_pressed()
         f_contents.append(casefile.value(evi + "/description", "UNKNOWN").value<QString>());
         f_contents.append(casefile.value(evi + "/image", "UNKNOWN.png").value<QString>());
 
-        ao_app->send_server_packet(new AOPacket("PE", f_contents));
+        send_server_packet(new AOPacket("PE", f_contents));
       }
 
     append_server_chatmessage("CLIENT", "Your case \"" + command[1] + "\" was loaded!", "1");
@@ -2936,9 +2936,9 @@ void Courtroom::on_ooc_return_pressed()
   AOPacket *f_packet = new AOPacket("CT", packet_contents);
 
   if (server_ooc)
-    ao_app->send_server_packet(f_packet);
+    send_server_packet(f_packet);
   else
-    ao_app->send_ms_packet(f_packet);
+    send_ms_packet(f_packet);
 
   ui_ooc_chat_message->clear();
 
@@ -3009,7 +3009,7 @@ void Courtroom::on_pos_dropdown_changed(int p_index)
   if (f_pos == "" || ui_ooc_chat_name->text() == "")
     return;
 
-  ao_app->send_server_packet(new AOPacket("CT#" + ui_ooc_chat_name->text() + "#/pos " + f_pos + "#%"));
+  send_server_packet(new AOPacket("CT#" + ui_ooc_chat_name->text() + "#/pos " + f_pos + "#%"));
 }
 
 void Courtroom::on_mute_list_clicked(QModelIndex p_index)
@@ -3103,18 +3103,18 @@ void Courtroom::on_music_list_double_clicked(QModelIndex p_model)
 
   if (!ui_ic_chat_name->text().isEmpty() && ao_app->cccc_ic_support_enabled)
   {
-    ao_app->send_server_packet(new AOPacket("MC#" + p_song + "#" + QString::number(m_cid) + "#" + ui_ic_chat_name->text() + "#%"), false);
+    send_server_packet(new AOPacket("MC#" + p_song + "#" + QString::number(m_cid) + "#" + ui_ic_chat_name->text() + "#%"), false);
   }
   else
   {
-    ao_app->send_server_packet(new AOPacket("MC#" + p_song + "#" + QString::number(m_cid) + "#%"), false);
+    send_server_packet(new AOPacket("MC#" + p_song + "#" + QString::number(m_cid) + "#%"), false);
   }
 }
 
 void Courtroom::on_area_list_double_clicked(QModelIndex p_model)
 {
     QString p_area = area_list.at(area_row_to_number.at(p_model.row()));
-    ao_app->send_server_packet(new AOPacket("MC#" + p_area + "#" + QString::number(m_cid) + "#%"), false);
+    send_server_packet(new AOPacket("MC#" + p_area + "#" + QString::number(m_cid) + "#%"), false);
 }
 
 void Courtroom::on_hold_it_clicked()
@@ -3253,7 +3253,7 @@ void Courtroom::on_defense_minus_clicked()
   int f_state = defense_bar_state - 1;
 
   if (f_state >= 0)
-    ao_app->send_server_packet(new AOPacket("HP#1#" + QString::number(f_state) + "#%"));
+    send_server_packet(new AOPacket("HP#1#" + QString::number(f_state) + "#%"));
 }
 
 void Courtroom::on_defense_plus_clicked()
@@ -3261,7 +3261,7 @@ void Courtroom::on_defense_plus_clicked()
   int f_state = defense_bar_state + 1;
 
   if (f_state <= 10)
-    ao_app->send_server_packet(new AOPacket("HP#1#" + QString::number(f_state) + "#%"));
+    send_server_packet(new AOPacket("HP#1#" + QString::number(f_state) + "#%"));
 }
 
 void Courtroom::on_prosecution_minus_clicked()
@@ -3269,7 +3269,7 @@ void Courtroom::on_prosecution_minus_clicked()
   int f_state = prosecution_bar_state - 1;
 
   if (f_state >= 0)
-    ao_app->send_server_packet(new AOPacket("HP#2#" + QString::number(f_state) + "#%"));
+    send_server_packet(new AOPacket("HP#2#" + QString::number(f_state) + "#%"));
 }
 
 void Courtroom::on_prosecution_plus_clicked()
@@ -3277,7 +3277,7 @@ void Courtroom::on_prosecution_plus_clicked()
   int f_state = prosecution_bar_state + 1;
 
   if (f_state <= 10)
-    ao_app->send_server_packet(new AOPacket("HP#2#" + QString::number(f_state) + "#%"));
+    send_server_packet(new AOPacket("HP#2#" + QString::number(f_state) + "#%"));
 }
 
 void Courtroom::on_text_color_changed(int p_color)
@@ -3320,7 +3320,7 @@ void Courtroom::on_witness_testimony_clicked()
   if (is_muted)
     return;
 
-  ao_app->send_server_packet(new AOPacket("RT#testimony1#%"));
+  send_server_packet(new AOPacket("RT#testimony1#%"));
 
   ui_ic_chat_message->setFocus();
 }
@@ -3330,7 +3330,7 @@ void Courtroom::on_cross_examination_clicked()
   if (is_muted)
     return;
 
-  ao_app->send_server_packet(new AOPacket("RT#testimony2#%"));
+  send_server_packet(new AOPacket("RT#testimony2#%"));
 
   ui_ic_chat_message->setFocus();
 }
@@ -3340,7 +3340,7 @@ void Courtroom::on_not_guilty_clicked()
   if (is_muted)
     return;
 
-  ao_app->send_server_packet(new AOPacket("RT#judgeruling#0#%"));
+  send_server_packet(new AOPacket("RT#judgeruling#0#%"));
 
   ui_ic_chat_message->setFocus();
 }
@@ -3350,7 +3350,7 @@ void Courtroom::on_guilty_clicked()
   if (is_muted)
     return;
 
-  ao_app->send_server_packet(new AOPacket("RT#judgeruling#1#%"));
+  send_server_packet(new AOPacket("RT#judgeruling#1#%"));
 
   ui_ic_chat_message->setFocus();
 }
@@ -3434,9 +3434,9 @@ void Courtroom::on_call_mod_clicked()
     QStringList mod_reason;
     mod_reason.append(text);
 
-    ao_app->send_server_packet(new AOPacket("ZZ", mod_reason));
+    send_server_packet(new AOPacket("ZZ", mod_reason));
   } else {
-    ao_app->send_server_packet(new AOPacket("ZZ#%"));
+    send_server_packet(new AOPacket("ZZ#%"));
   }
 
   ui_ic_chat_message->setFocus();
@@ -3449,7 +3449,7 @@ void Courtroom::on_settings_clicked()
 
 void Courtroom::on_announce_casing_clicked()
 {
-    ao_app->call_announce_menu(this);
+    ao_app->call_announce_menu();
 }
 
 void Courtroom::on_pre_clicked()
@@ -3521,7 +3521,7 @@ void Courtroom::on_switch_area_music_clicked()
 
 void Courtroom::ping_server()
 {
-  ao_app->send_server_packet(new AOPacket("CH#" + QString::number(m_cid) + "#%"));
+  send_server_packet(new AOPacket("CH#" + QString::number(m_cid) + "#%"));
 }
 
 void Courtroom::on_casing_clicked()
@@ -3529,7 +3529,7 @@ void Courtroom::on_casing_clicked()
   if (ao_app->casing_alerts_enabled)
   {
     if (ui_casing->isChecked())
-      ao_app->send_server_packet(new AOPacket("CT#" + ui_ooc_chat_name->text() + "#/setcase"
+      send_server_packet(new AOPacket("CT#" + ui_ooc_chat_name->text() + "#/setcase"
                                             + " \"" + TextFileHandler::getInstance().get_casing_can_host_cases() + "\""
                                             + " " + QString::number(TextFileHandler::getInstance().get_casing_cm_enabled())
                                             + " " + QString::number(TextFileHandler::getInstance().get_casing_defence_enabled())
@@ -3539,14 +3539,14 @@ void Courtroom::on_casing_clicked()
                                             + " " + QString::number(TextFileHandler::getInstance().get_casing_steno_enabled())
                                             + "#%"));
     else
-      ao_app->send_server_packet(new AOPacket("CT#" + ui_ooc_chat_name->text() + "#/setcase \"\" 0 0 0 0 0 0#%"));
+      send_server_packet(new AOPacket("CT#" + ui_ooc_chat_name->text() + "#/setcase \"\" 0 0 0 0 0 0#%"));
   }
 }
 
-void Courtroom::announce_case(QString title, bool def, bool pro, bool jud, bool jur, bool steno)
+void Courtroom::announce_case(QString* title, bool def, bool pro, bool jud, bool jur, bool steno)
 {
   if (ao_app->casing_alerts_enabled)
-    ao_app->send_server_packet(new AOPacket("CT#" + ui_ooc_chat_name->text() + "#/anncase \""
+    send_server_packet(new AOPacket("CT#" + ui_ooc_chat_name->text() + "#/anncase \""
                                           + title + "\" "
                                           + QString::number(def) + " "
                                           + QString::number(pro) + " "

--- a/courtroom.cpp
+++ b/courtroom.cpp
@@ -1,13 +1,15 @@
 #include "courtroom.h"
 
-Courtroom::Courtroom() : QMainWindow()
+Courtroom::Courtroom(AOApplication *p_ao_app) : QMainWindow()
 {
+  ao_app = p_ao_app;
+
   // Change the default audio output device to be the one the user has given
   // in his config.ini file for now.
   int a = 0;
   BASS_DEVICEINFO info;
 
-  if (ao_app->get_audio_output_device() == "Default")
+  if (TextFileHandler::getInstance().get_audio_output_device() == "Default")
   {
       BASS_Init(-1, 48000, BASS_DEVICE_LATENCY, nullptr, nullptr);
       load_bass_opus_plugin();
@@ -16,7 +18,7 @@ Courtroom::Courtroom() : QMainWindow()
   {
       for (a = 0; BASS_GetDeviceInfo(a, &info); a++)
       {
-          if (ao_app->get_audio_output_device() == info.name)
+          if (TextFileHandler::getInstance().get_audio_output_device() == info.name)
           {
               BASS_SetDevice(a);
               BASS_Init(a, 48000, BASS_DEVICE_LATENCY, nullptr, nullptr);
@@ -49,33 +51,33 @@ Courtroom::Courtroom() : QMainWindow()
 
   char_button_mapper = new QSignalMapper(this);
 
-  music_player = new AOMusicPlayer(this, ao_app);
+  music_player = new AOMusicPlayer(this);
   music_player->set_volume(0);
-  sfx_player = new AOSfxPlayer(this, ao_app);
+  sfx_player = new AOSfxPlayer(this);
   sfx_player->set_volume(0);
-  objection_player = new AOSfxPlayer(this, ao_app);
+  objection_player = new AOSfxPlayer(this);
   sfx_player->set_volume(0);
-  blip_player = new AOBlipPlayer(this, ao_app);
+  blip_player = new AOBlipPlayer(this);
   blip_player->set_volume(0);
 
-  modcall_player = new AOSfxPlayer(this, ao_app);
+  modcall_player = new AOSfxPlayer(this);
   modcall_player->set_volume(50);
 
-  ui_background = new AOImage(this, ao_app);
+  ui_background = new AOImage(this);
 
   ui_viewport = new QWidget(this);
-  ui_vp_background = new AOScene(ui_viewport, ao_app);
-  ui_vp_speedlines = new AOMovie(ui_viewport, ao_app);
+  ui_vp_background = new AOScene(ui_viewport);
+  ui_vp_speedlines = new AOMovie(ui_viewport);
   ui_vp_speedlines->set_play_once(false);
-  ui_vp_player_char = new AOCharMovie(ui_viewport, ao_app);
-  ui_vp_sideplayer_char = new AOCharMovie(ui_viewport, ao_app);
+  ui_vp_player_char = new AOCharMovie(ui_viewport);
+  ui_vp_sideplayer_char = new AOCharMovie(ui_viewport);
   ui_vp_sideplayer_char->hide();
-  ui_vp_desk = new AOScene(ui_viewport, ao_app);
-  ui_vp_legacy_desk = new AOScene(ui_viewport, ao_app);
+  ui_vp_desk = new AOScene(ui_viewport);
+  ui_vp_legacy_desk = new AOScene(ui_viewport);
 
-  ui_vp_evidence_display = new AOEvidenceDisplay(this, ao_app);
+  ui_vp_evidence_display = new AOEvidenceDisplay(this);
 
-  ui_vp_chatbox = new AOImage(this, ao_app);
+  ui_vp_chatbox = new AOImage(this);
   ui_vp_showname = new QLabel(ui_vp_chatbox);
   ui_vp_message = new QTextEdit(ui_vp_chatbox);
   ui_vp_message->setFrameStyle(QFrame::NoFrame);
@@ -83,16 +85,16 @@ Courtroom::Courtroom() : QMainWindow()
   ui_vp_message->setVerticalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
   ui_vp_message->setReadOnly(true);
 
-  ui_vp_testimony = new AOImage(this, ao_app);
-  ui_vp_realization = new AOImage(this, ao_app);
-  ui_vp_wtce = new AOMovie(this, ao_app);
-  ui_vp_objection = new AOMovie(this, ao_app);
+  ui_vp_testimony = new AOImage(this);
+  ui_vp_realization = new AOImage(this);
+  ui_vp_wtce = new AOMovie(this);
+  ui_vp_objection = new AOMovie(this);
 
   ui_ic_chatlog = new QTextEdit(this);
   ui_ic_chatlog->setReadOnly(true);
 
-  log_maximum_blocks = ao_app->get_max_log_size();
-  log_goes_downwards = ao_app->get_log_goes_downwards();
+  log_maximum_blocks = TextFileHandler::getInstance().get_max_log_size();
+  log_goes_downwards = TextFileHandler::getInstance().get_log_goes_downwards();
 
   ui_ms_chatlog = new AOTextArea(this);
   ui_ms_chatlog->setReadOnly(true);
@@ -115,7 +117,7 @@ Courtroom::Courtroom() : QMainWindow()
   ui_ic_chat_message->setFrame(false);
   ui_ic_chat_message->setPlaceholderText(tr("Message"));
 
-  ui_muted = new AOImage(ui_ic_chat_message, ao_app);
+  ui_muted = new AOImage(ui_ic_chat_message);
   ui_muted->hide();
 
   ui_ooc_chat_message = new QLineEdit(this);
@@ -125,7 +127,7 @@ Courtroom::Courtroom() : QMainWindow()
   ui_ooc_chat_name->setFrame(false);
   ui_ooc_chat_name->setPlaceholderText("Name");
   ui_ooc_chat_name->setMaxLength(30);
-  ui_ooc_chat_name->setText(p_ao_app->get_default_username());
+  ui_ooc_chat_name->setText(TextFileHandler::getInstance().get_default_username());
 
   //ui_area_password = new QLineEdit(this);
   //ui_area_password->setFrame(false);
@@ -135,8 +137,8 @@ Courtroom::Courtroom() : QMainWindow()
 
   construct_emotes();
 
-  ui_emote_left = new AOButton(this, ao_app);
-  ui_emote_right = new AOButton(this, ao_app);
+  ui_emote_left = new AOButton(this);
+  ui_emote_right = new AOButton(this);
 
   ui_emote_dropdown = new QComboBox(this);
   ui_pos_dropdown = new QComboBox(this);
@@ -149,8 +151,8 @@ Courtroom::Courtroom() : QMainWindow()
   ui_pos_dropdown->addItem("jur");
   ui_pos_dropdown->addItem("sea");
 
-  ui_defense_bar = new AOImage(this, ao_app);
-  ui_prosecution_bar = new  AOImage(this, ao_app);
+  ui_defense_bar = new AOImage(this);
+  ui_prosecution_bar = new  AOImage(this);
 
   ui_music_label = new QLabel(this);
   ui_sfx_label = new QLabel(this);
@@ -158,22 +160,22 @@ Courtroom::Courtroom() : QMainWindow()
 
   ui_log_limit_label = new QLabel(this);
 
-  ui_hold_it = new AOButton(this, ao_app);
-  ui_objection = new AOButton(this, ao_app);
-  ui_take_that = new AOButton(this, ao_app);
+  ui_hold_it = new AOButton(this);
+  ui_objection = new AOButton(this);
+  ui_take_that = new AOButton(this);
 
-  ui_ooc_toggle = new AOButton(this, ao_app);
-  ui_witness_testimony = new AOButton(this, ao_app);
-  ui_cross_examination = new AOButton(this, ao_app);
-  ui_guilty = new AOButton(this, ao_app);
-  ui_not_guilty = new AOButton(this, ao_app);
+  ui_ooc_toggle = new AOButton(this);
+  ui_witness_testimony = new AOButton(this);
+  ui_cross_examination = new AOButton(this);
+  ui_guilty = new AOButton(this);
+  ui_not_guilty = new AOButton(this);
 
-  ui_change_character = new AOButton(this, ao_app);
-  ui_reload_theme = new AOButton(this, ao_app);
-  ui_call_mod = new AOButton(this, ao_app);
-  ui_settings = new AOButton(this, ao_app);
-  ui_announce_casing = new AOButton(this, ao_app);
-  ui_switch_area_music = new AOButton(this, ao_app);
+  ui_change_character = new AOButton(this);
+  ui_reload_theme = new AOButton(this);
+  ui_call_mod = new AOButton(this);
+  ui_settings = new AOButton(this);
+  ui_announce_casing = new AOButton(this);
+  ui_switch_area_music = new AOButton(this);
 
   ui_pre = new QCheckBox(this);
   ui_pre->setText("Pre");
@@ -184,27 +186,27 @@ Courtroom::Courtroom() : QMainWindow()
   ui_guard->setText("Guard");
   ui_guard->hide();
   ui_casing = new QCheckBox(this);
-  ui_casing->setChecked(ao_app->get_casing_enabled());
+  ui_casing->setChecked(TextFileHandler::getInstance().get_casing_enabled());
   ui_casing->setText(tr("Casing"));
   ui_casing->hide();
 
   ui_showname_enable = new QCheckBox(this);
-  ui_showname_enable->setChecked(ao_app->get_showname_enabled_by_default());
+  ui_showname_enable->setChecked(TextFileHandler::getInstance().get_showname_enabled_by_default());
   ui_showname_enable->setText(tr("Shownames"));
 
   ui_pre_non_interrupt = new QCheckBox(this);
   ui_pre_non_interrupt->setText(tr("No Interrupt"));
   ui_pre_non_interrupt->hide();
 
-  ui_custom_objection = new AOButton(this, ao_app);
-  ui_realization = new AOButton(this, ao_app);
-  ui_mute = new AOButton(this, ao_app);
+  ui_custom_objection = new AOButton(this);
+  ui_realization = new AOButton(this);
+  ui_mute = new AOButton(this);
 
-  ui_defense_plus = new AOButton(this, ao_app);
-  ui_defense_minus = new AOButton(this, ao_app);
+  ui_defense_plus = new AOButton(this);
+  ui_defense_minus = new AOButton(this);
 
-  ui_prosecution_plus = new AOButton(this, ao_app);
-  ui_prosecution_minus = new AOButton(this, ao_app);
+  ui_prosecution_plus = new AOButton(this);
+  ui_prosecution_minus = new AOButton(this);
 
   ui_text_color = new QComboBox(this);
   ui_text_color->addItem("White");
@@ -219,28 +221,28 @@ Courtroom::Courtroom() : QMainWindow()
 
   ui_music_slider = new QSlider(Qt::Horizontal, this);
   ui_music_slider->setRange(0, 100);
-  ui_music_slider->setValue(ao_app->get_default_music());
+  ui_music_slider->setValue(TextFileHandler::getInstance().get_default_music());
 
   ui_sfx_slider = new QSlider(Qt::Horizontal, this);
   ui_sfx_slider->setRange(0, 100);
-  ui_sfx_slider->setValue(ao_app->get_default_sfx());
+  ui_sfx_slider->setValue(TextFileHandler::getInstance().get_default_sfx());
 
   ui_blip_slider = new QSlider(Qt::Horizontal, this);
   ui_blip_slider->setRange(0, 100);
-  ui_blip_slider->setValue(ao_app->get_default_blip());
+  ui_blip_slider->setValue(TextFileHandler::getInstance().get_default_blip());
 
   ui_log_limit_spinbox = new QSpinBox(this);
   ui_log_limit_spinbox->setRange(0, 10000);
-  ui_log_limit_spinbox->setValue(ao_app->get_max_log_size());
+  ui_log_limit_spinbox->setValue(TextFileHandler::getInstance().get_max_log_size());
 
   ui_mute_list = new QListWidget(this);
   ui_pair_list = new QListWidget(this);
   ui_pair_offset_spinbox = new QSpinBox(this);
   ui_pair_offset_spinbox->setRange(-100,100);
   ui_pair_offset_spinbox->setSuffix("% offset");
-  ui_pair_button = new AOButton(this, ao_app);
+  ui_pair_button = new AOButton(this);
 
-  ui_evidence_button = new AOButton(this, ao_app);
+  ui_evidence_button = new AOButton(this);
 
   construct_evidence();
 
@@ -373,12 +375,12 @@ void Courtroom::set_pair_list()
 
 void Courtroom::set_widgets()
 {
-  blip_rate = ao_app->read_blip_rate();
-  blank_blip = ao_app->get_blank_blip();
+  blip_rate = TextFileHandler::getInstance().read_blip_rate();
+  blank_blip = TextFileHandler::getInstance().get_blank_blip();
 
   QString filename = "courtroom_design.ini";
 
-  pos_size_type f_courtroom = ao_app->get_element_dimensions("courtroom", filename);
+  pos_size_type f_courtroom = TextFileHandler::getInstance().get_element_dimensions("courtroom", filename);
 
   if (f_courtroom.width < 0 || f_courtroom.height < 0)
   {
@@ -708,7 +710,7 @@ void Courtroom::set_fonts()
 
   // Set color of labels and checkboxes
   const QString design_file = "courtroom_fonts.ini";
-  QColor f_color = ao_app->get_color("label_color", design_file);
+  QColor f_color = TextFileHandler::getInstance().get_color("label_color", design_file);
   QString color_string = "color: rgba(" +
           QString::number(f_color.red()) + ", " +
           QString::number(f_color.green()) + ", " +
@@ -721,12 +723,12 @@ void Courtroom::set_fonts()
 void Courtroom::set_font(QWidget *widget, QString p_identifier)
 {
   QString design_file = "courtroom_fonts.ini";
-  int f_weight = ao_app->get_font_size(p_identifier, design_file);
+  int f_weight = TextFileHandler::getInstance().get_font_size(p_identifier, design_file);
   QString class_name = widget->metaObject()->className();
 
   widget->setFont(QFont("Sans", f_weight));
 
-  QColor f_color = ao_app->get_color(p_identifier + "_color", design_file);
+  QColor f_color = TextFileHandler::getInstance().get_color(p_identifier + "_color", design_file);
 
   QString style_sheet_string = class_name + " { background-color: rgba(0, 0, 0, 0);\n" +
                                             "color: rgba(" +
@@ -746,7 +748,7 @@ void Courtroom::set_size_and_pos(QWidget *p_widget, QString p_identifier)
 {
   QString filename = "courtroom_design.ini";
 
-  pos_size_type design_ini_result = ao_app->get_element_dimensions(p_identifier, filename);
+  pos_size_type design_ini_result = TextFileHandler::getInstance().get_element_dimensions(p_identifier, filename);
 
   if (design_ini_result.width < 0 || design_ini_result.height < 0)
   {
@@ -804,9 +806,9 @@ void Courtroom::set_background(QString p_background)
 
   current_background = p_background;
 
-  is_ao2_bg = file_exists(ao_app->get_background_path("defensedesk.png")) &&
-              file_exists(ao_app->get_background_path("prosecutiondesk.png")) &&
-              file_exists(ao_app->get_background_path("stand.png"));
+  is_ao2_bg = file_exists(TextFileHandler::getInstance().get_background_path("defensedesk.png")) &&
+              file_exists(TextFileHandler::getInstance().get_background_path("prosecutiondesk.png")) &&
+              file_exists(TextFileHandler::getInstance().get_background_path("stand.png"));
 
   if (is_ao2_bg)
   {
@@ -828,15 +830,15 @@ void Courtroom::enter_courtroom(int p_cid)
 
   if (m_cid == -1)
   {
-    if (ao_app->is_discord_enabled())
+    if (TextFileHandler::getInstance().is_discord_enabled())
       ao_app->discord->state_spectate();
     f_char = "";
   }
   else
   {
-    f_char = ao_app->get_char_name(char_list.at(m_cid).name);
+    f_char = TextFileHandler::getInstance().get_char_name(char_list.at(m_cid).name);
 
-    if (ao_app->is_discord_enabled())
+    if (TextFileHandler::getInstance().is_discord_enabled())
       ao_app->discord->state_character(f_char.toStdString());
   }
 
@@ -858,7 +860,7 @@ void Courtroom::enter_courtroom(int p_cid)
 
   set_evidence_page();
 
-  QString side = ao_app->get_char_side(f_char);
+  QString side = TextFileHandler::getInstance().get_char_side(f_char);
 
   if (side == "jud")
   {
@@ -884,9 +886,9 @@ void Courtroom::enter_courtroom(int p_cid)
   }
 
   if (ao_app->custom_objection_enabled &&
-      (file_exists(ao_app->get_character_path(current_char, "custom.gif")) ||
-      file_exists(ao_app->get_character_path(current_char, "custom.apng"))) &&
-      file_exists(ao_app->get_character_path(current_char, "custom.wav")))
+      (file_exists(TextFileHandler::getInstance().get_character_path(current_char, "custom.gif")) ||
+      file_exists(TextFileHandler::getInstance().get_character_path(current_char, "custom.apng"))) &&
+      file_exists(TextFileHandler::getInstance().get_character_path(current_char, "custom.wav")))
     ui_custom_objection->show();
   else
     ui_custom_objection->hide();
@@ -928,8 +930,8 @@ void Courtroom::list_music()
 
   QString f_file = "courtroom_design.ini";
 
-  QBrush found_brush(ao_app->get_color("found_song_color", f_file));
-  QBrush missing_brush(ao_app->get_color("missing_song_color", f_file));
+  QBrush found_brush(TextFileHandler::getInstance().get_color("found_song_color", f_file));
+  QBrush missing_brush(TextFileHandler::getInstance().get_color("missing_song_color", f_file));
 
   int n_listed_songs = 0;
 
@@ -944,7 +946,7 @@ void Courtroom::list_music()
       ui_music_list->addItem(i_song_listname);
       music_row_to_number.append(n_song);
 
-      QString song_path = ao_app->get_music_path(i_song);
+      QString song_path = TextFileHandler::getInstance().get_music_path(i_song);
 
       if (file_exists(song_path))
         ui_music_list->item(n_listed_songs)->setBackground(found_brush);
@@ -963,13 +965,13 @@ void Courtroom::list_areas()
 
   QString f_file = "courtroom_design.ini";
 
-  QBrush free_brush(ao_app->get_color("area_free_color", f_file));
-  QBrush lfp_brush(ao_app->get_color("area_lfp_color", f_file));
-  QBrush casing_brush(ao_app->get_color("area_casing_color", f_file));
-  QBrush recess_brush(ao_app->get_color("area_recess_color", f_file));
-  QBrush rp_brush(ao_app->get_color("area_rp_color", f_file));
-  QBrush gaming_brush(ao_app->get_color("area_gaming_color", f_file));
-  QBrush locked_brush(ao_app->get_color("area_locked_color", f_file));
+  QBrush free_brush(TextFileHandler::getInstance().get_color("area_free_color", f_file));
+  QBrush lfp_brush(TextFileHandler::getInstance().get_color("area_lfp_color", f_file));
+  QBrush casing_brush(TextFileHandler::getInstance().get_color("area_casing_color", f_file));
+  QBrush recess_brush(TextFileHandler::getInstance().get_color("area_recess_color", f_file));
+  QBrush rp_brush(TextFileHandler::getInstance().get_color("area_rp_color", f_file));
+  QBrush gaming_brush(TextFileHandler::getInstance().get_color("area_gaming_color", f_file));
+  QBrush locked_brush(TextFileHandler::getInstance().get_color("area_locked_color", f_file));
 
   int n_listed_areas = 0;
 
@@ -1037,7 +1039,7 @@ void Courtroom::list_areas()
 
 void Courtroom::append_ms_chatmessage(QString f_name, QString f_message)
 {
-  ui_ms_chatlog->append_chatmessage(f_name, f_message, ao_app->get_color("ooc_default_color", "courtroom_design.ini").name());
+  ui_ms_chatlog->append_chatmessage(f_name, f_message, TextFileHandler::getInstance().get_color("ooc_default_color", "courtroom_design.ini").name());
 }
 
 void Courtroom::append_server_chatmessage(QString p_name, QString p_message, QString p_colour)
@@ -1045,9 +1047,9 @@ void Courtroom::append_server_chatmessage(QString p_name, QString p_message, QSt
   QString colour = "#000000";
 
   if (p_colour == "0")
-    colour = ao_app->get_color("ooc_default_color", "courtroom_design.ini").name();
+    colour = TextFileHandler::getInstance().get_color("ooc_default_color", "courtroom_design.ini").name();
   if (p_colour == "1")
-    colour = ao_app->get_color("ooc_server_color", "courtroom_design.ini").name();
+    colour = TextFileHandler::getInstance().get_color("ooc_server_color", "courtroom_design.ini").name();
 
   ui_server_chatlog->append_chatmessage(p_name, p_message, colour);
 }
@@ -1087,32 +1089,32 @@ void Courtroom::on_chat_return_pressed()
 
   QStringList packet_contents;
 
-  QString f_side = ao_app->get_char_side(current_char);
+  QString f_side = TextFileHandler::getInstance().get_char_side(current_char);
 
   QString f_desk_mod = "chat";
 
   if (ao_app->desk_mod_enabled)
   {
-    f_desk_mod = QString::number(ao_app->get_desk_mod(current_char, current_emote));
+    f_desk_mod = QString::number(TextFileHandler::getInstance().get_desk_mod(current_char, current_emote));
     if (f_desk_mod == "-1")
       f_desk_mod = "chat";
   }
 
   packet_contents.append(f_desk_mod);
 
-  packet_contents.append(ao_app->get_pre_emote(current_char, current_emote));
+  packet_contents.append(TextFileHandler::getInstance().get_pre_emote(current_char, current_emote));
 
   packet_contents.append(current_char);
 
-  packet_contents.append(ao_app->get_emote(current_char, current_emote));
+  packet_contents.append(TextFileHandler::getInstance().get_emote(current_char, current_emote));
 
   packet_contents.append(ui_ic_chat_message->text());
 
   packet_contents.append(f_side);
 
-  packet_contents.append(ao_app->get_sfx_name(current_char, current_emote));
+  packet_contents.append(TextFileHandler::getInstance().get_sfx_name(current_char, current_emote));
 
-  int f_emote_mod = ao_app->get_emote_mod(current_char, current_emote);
+  int f_emote_mod = TextFileHandler::getInstance().get_emote_mod(current_char, current_emote);
 
   //needed or else legacy won't understand what we're saying
   if (objection_state > 0)
@@ -1143,7 +1145,7 @@ void Courtroom::on_chat_return_pressed()
   packet_contents.append(QString::number(f_emote_mod));
   packet_contents.append(QString::number(m_cid));
 
-  packet_contents.append(QString::number(ao_app->get_sfx_delay(current_char, current_emote)));
+  packet_contents.append(QString::number(TextFileHandler::getInstance().get_sfx_delay(current_char, current_emote)));
 
   QString f_obj_state;
 
@@ -1267,7 +1269,7 @@ void Courtroom::handle_chatmessage(QStringList *p_contents)
   QString f_showname;
   if (m_chatmessage[SHOWNAME].isEmpty() || !ui_showname_enable->isChecked())
   {
-      f_showname = ao_app->get_showname(char_list.at(f_char_id).name);
+      f_showname = TextFileHandler::getInstance().get_showname(char_list.at(f_char_id).name);
   }
   else
   {
@@ -1304,7 +1306,7 @@ void Courtroom::handle_chatmessage(QStringList *p_contents)
     ui_evidence_present->set_image("present_disabled.png");
   }
 
-  chatlogpiece* temp = new chatlogpiece(ao_app->get_showname(char_list.at(f_char_id).name), f_showname, ": " + m_chatmessage[MESSAGE], false);
+  chatlogpiece* temp = new chatlogpiece(TextFileHandler::getInstance().get_showname(char_list.at(f_char_id).name), f_showname, ": " + m_chatmessage[MESSAGE], false);
   ic_chatlog_history.append(*temp);
 
   while(ic_chatlog_history.size() > log_maximum_blocks)
@@ -1318,7 +1320,7 @@ void Courtroom::handle_chatmessage(QStringList *p_contents)
 
   int objection_mod = m_chatmessage[OBJECTION_MOD].toInt();
   QString f_char = m_chatmessage[CHAR_NAME];
-  QString f_custom_theme = ao_app->get_char_shouts(f_char);
+  QString f_custom_theme = TextFileHandler::getInstance().get_char_shouts(f_char);
 
   //if an objection is used
   if (objection_mod <= 4 && objection_mod >= 1)
@@ -1369,7 +1371,7 @@ void Courtroom::handle_chatmessage_2()
   {
       QString real_name = char_list.at(m_chatmessage[CHAR_ID].toInt()).name;
 
-      QString f_showname = ao_app->get_showname(real_name);
+      QString f_showname = TextFileHandler::getInstance().get_showname(real_name);
 
       ui_vp_showname->setText(f_showname);
   }
@@ -1381,13 +1383,13 @@ void Courtroom::handle_chatmessage_2()
   ui_vp_message->clear();
   ui_vp_chatbox->hide();
 
-  QString chatbox = ao_app->get_chat(m_chatmessage[CHAR_NAME]);
+  QString chatbox = TextFileHandler::getInstance().get_chat(m_chatmessage[CHAR_NAME]);
 
   if (chatbox == "")
     ui_vp_chatbox->set_image("chatmed.png");
   else
   {
-    QString chatbox_path = ao_app->get_base_path() + "misc/" + chatbox + "/chatbox.png";
+    QString chatbox_path = TextFileHandler::getInstance().get_base_path() + "misc/" + chatbox + "/chatbox.png";
     ui_vp_chatbox->set_image_from_path(chatbox_path);
   }
 
@@ -1584,7 +1586,7 @@ void Courtroom::handle_chatmessage_3()
   {
     realization_timer->start(60);
     ui_vp_realization->show();
-    sfx_player->play(ao_app->get_custom_realization(m_chatmessage[CHAR_NAME]));
+    sfx_player->play(TextFileHandler::getInstance().get_custom_realization(m_chatmessage[CHAR_NAME]));
   }
 
   int f_evi_id = m_chatmessage[EVIDENCE_ID].toInt();
@@ -1657,13 +1659,13 @@ void Courtroom::handle_chatmessage_3()
   }
 
   QString f_message = m_chatmessage[MESSAGE];
-  QStringList call_words = ao_app->get_call_words();
+  QStringList call_words = TextFileHandler::getInstance().get_call_words();
 
   for (QString word : call_words)
   {
     if (f_message.contains(word, Qt::CaseInsensitive))
     {
-      modcall_player->play(ao_app->get_sfx("word_call"));
+      modcall_player->play(TextFileHandler::getInstance().get_sfx("word_call"));
       ao_app->alert(this);
 
       break;
@@ -1986,19 +1988,19 @@ void Courtroom::play_preanim()
   QString f_preanim = m_chatmessage[PRE_EMOTE];
 
   //all time values in char.inis are multiplied by a constant(time_mod) to get the actual time
-  int ao2_duration = ao_app->get_ao2_preanim_duration(f_char, f_preanim);
-  int text_delay = ao_app->get_text_delay(f_char, f_preanim) * time_mod;
+  int ao2_duration = TextFileHandler::getInstance().get_ao2_preanim_duration(f_char, f_preanim);
+  int text_delay = TextFileHandler::getInstance().get_text_delay(f_char, f_preanim) * time_mod;
   int sfx_delay = m_chatmessage[SFX_DELAY].toInt() * 60;
 
   int preanim_duration;
 
   if (ao2_duration < 0)
-    preanim_duration = ao_app->get_preanim_duration(f_char, f_preanim);
+    preanim_duration = TextFileHandler::getInstance().get_preanim_duration(f_char, f_preanim);
   else
     preanim_duration = ao2_duration;
 
   sfx_delay_timer->start(sfx_delay);
-  QString anim_to_find = ao_app->get_image_suffix(ao_app->get_character_path(f_char, f_preanim));
+  QString anim_to_find = TextFileHandler::getInstance().get_image_suffix(TextFileHandler::getInstance().get_character_path(f_char, f_preanim));
   if (!file_exists(anim_to_find) ||
       preanim_duration < 0)
   {
@@ -2021,19 +2023,19 @@ void Courtroom::play_noninterrupting_preanim()
   QString f_preanim = m_chatmessage[PRE_EMOTE];
 
   //all time values in char.inis are multiplied by a constant(time_mod) to get the actual time
-  int ao2_duration = ao_app->get_ao2_preanim_duration(f_char, f_preanim);
-  int text_delay = ao_app->get_text_delay(f_char, f_preanim) * time_mod;
+  int ao2_duration = TextFileHandler::getInstance().get_ao2_preanim_duration(f_char, f_preanim);
+  int text_delay = TextFileHandler::getInstance().get_text_delay(f_char, f_preanim) * time_mod;
   int sfx_delay = m_chatmessage[SFX_DELAY].toInt() * 60;
 
   int preanim_duration;
 
   if (ao2_duration < 0)
-    preanim_duration = ao_app->get_preanim_duration(f_char, f_preanim);
+    preanim_duration = TextFileHandler::getInstance().get_preanim_duration(f_char, f_preanim);
   else
     preanim_duration = ao2_duration;
 
   sfx_delay_timer->start(sfx_delay);
-  QString anim_to_find = ao_app->get_image_suffix(ao_app->get_character_path(f_char, f_preanim));
+  QString anim_to_find = TextFileHandler::getInstance().get_image_suffix(TextFileHandler::getInstance().get_character_path(f_char, f_preanim));
   if (!file_exists(anim_to_find) ||
       preanim_duration < 0)
   {
@@ -2099,7 +2101,7 @@ void Courtroom::start_chat_ticking()
   current_display_speed = 3;
   chat_tick_timer->start(message_display_speed[current_display_speed]);
 
-  QString f_gender = ao_app->get_gender(m_chatmessage[CHAR_NAME]);
+  QString f_gender = TextFileHandler::getInstance().get_gender(m_chatmessage[CHAR_NAME]);
 
   blip_player->set_blips("sfx-blip" + f_gender + ".wav");
 
@@ -2419,7 +2421,7 @@ void Courtroom::play_sfx()
   if (sfx_name == "1")
     return;
 
-  sfx_player->play(ao_app->get_sfx_suffix(sfx_name));
+  sfx_player->play(TextFileHandler::getInstance().get_sfx_suffix(sfx_name));
 }
 
 void Courtroom::set_scene()
@@ -2518,7 +2520,7 @@ void Courtroom::set_scene()
 
 void Courtroom::set_text_color()
 {
-  QColor textcolor = ao_app->get_chat_color(m_chatmessage[TEXT_COLOR], ao_app->get_chat(m_chatmessage[CHAR_NAME]));
+  QColor textcolor = TextFileHandler::getInstance().get_chat_color(m_chatmessage[TEXT_COLOR], TextFileHandler::getInstance().get_chat(m_chatmessage[CHAR_NAME]));
 
   ui_vp_message->setTextBackgroundColor(QColor(0,0,0,0));
   ui_vp_message->setTextColor(textcolor);
@@ -2537,7 +2539,7 @@ void Courtroom::set_text_color()
 
 QColor Courtroom::get_text_color(QString color)
 {
-  return ao_app->get_chat_color(color, ao_app->get_chat(m_chatmessage[CHAR_NAME]));
+  return TextFileHandler::getInstance().get_chat_color(color, TextFileHandler::getInstance().get_chat(m_chatmessage[CHAR_NAME]));
 }
 
 void Courtroom::set_ip_list(QString p_list)
@@ -2627,7 +2629,7 @@ void Courtroom::handle_wtce(QString p_wtce, int variant)
   //witness testimony
   if (p_wtce == "testimony1")
   {
-    sfx_player->play(ao_app->get_sfx("witness_testimony"));
+    sfx_player->play(TextFileHandler::getInstance().get_sfx("witness_testimony"));
     ui_vp_wtce->play("witnesstestimony");
     testimony_in_progress = true;
     show_testimony();
@@ -2635,7 +2637,7 @@ void Courtroom::handle_wtce(QString p_wtce, int variant)
   //cross examination
   else if (p_wtce == "testimony2")
   {
-    sfx_player->play(ao_app->get_sfx("cross_examination"));
+    sfx_player->play(TextFileHandler::getInstance().get_sfx("cross_examination"));
     ui_vp_wtce->play("crossexamination");
     testimony_in_progress = false;
   }
@@ -2643,12 +2645,12 @@ void Courtroom::handle_wtce(QString p_wtce, int variant)
   {
     if (variant == 0)
     {
-        sfx_player->play(ao_app->get_sfx("not_guilty"));
+        sfx_player->play(TextFileHandler::getInstance().get_sfx("not_guilty"));
         ui_vp_wtce->play("notguilty");
         testimony_in_progress = false;
     }
     else if (variant == 1) {
-        sfx_player->play(ao_app->get_sfx("guilty"));
+        sfx_player->play(TextFileHandler::getInstance().get_sfx("guilty"));
         ui_vp_wtce->play("guilty");
         testimony_in_progress = false;
     }
@@ -2677,7 +2679,7 @@ void Courtroom::mod_called(QString p_ip)
   ui_server_chatlog->append(p_ip);
   if (ui_guard->isChecked())
   {
-    modcall_player->play(ao_app->get_sfx("mod_call"));
+    modcall_player->play(TextFileHandler::getInstance().get_sfx("mod_call"));
     ao_app->alert(this);
   }
 }
@@ -2687,13 +2689,13 @@ void Courtroom::case_called(QString msg, bool def, bool pro, bool jud, bool jur,
   if (ui_casing->isChecked())
   {
     ui_server_chatlog->append(msg);
-    if ((ao_app->get_casing_defence_enabled() && def) ||
-        (ao_app->get_casing_prosecution_enabled() && pro) ||
-        (ao_app->get_casing_judge_enabled() && jud) ||
-        (ao_app->get_casing_juror_enabled() && jur) ||
-        (ao_app->get_casing_steno_enabled() && steno))
+    if ((TextFileHandler::getInstance().get_casing_defence_enabled() && def) ||
+        (TextFileHandler::getInstance().get_casing_prosecution_enabled() && pro) ||
+        (TextFileHandler::getInstance().get_casing_judge_enabled() && jud) ||
+        (TextFileHandler::getInstance().get_casing_juror_enabled() && jur) ||
+        (TextFileHandler::getInstance().get_casing_steno_enabled() && steno))
     {
-        modcall_player->play(ao_app->get_sfx("case_call"));
+        modcall_player->play(TextFileHandler::getInstance().get_sfx("case_call"));
         ao_app->alert(this);
     }
   }
@@ -3368,7 +3370,7 @@ void Courtroom::on_change_character_clicked()
 
 void Courtroom::on_reload_theme_clicked()
 { 
-  ao_app->reload_theme();
+  TextFileHandler::getInstance().read_theme();
 
   //to update status on the background
   set_background(current_background);
@@ -3528,13 +3530,13 @@ void Courtroom::on_casing_clicked()
   {
     if (ui_casing->isChecked())
       ao_app->send_server_packet(new AOPacket("CT#" + ui_ooc_chat_name->text() + "#/setcase"
-                                            + " \"" + ao_app->get_casing_can_host_cases() + "\""
-                                            + " " + QString::number(ao_app->get_casing_cm_enabled())
-                                            + " " + QString::number(ao_app->get_casing_defence_enabled())
-                                            + " " + QString::number(ao_app->get_casing_prosecution_enabled())
-                                            + " " + QString::number(ao_app->get_casing_judge_enabled())
-                                            + " " + QString::number(ao_app->get_casing_juror_enabled())
-                                            + " " + QString::number(ao_app->get_casing_steno_enabled())
+                                            + " \"" + TextFileHandler::getInstance().get_casing_can_host_cases() + "\""
+                                            + " " + QString::number(TextFileHandler::getInstance().get_casing_cm_enabled())
+                                            + " " + QString::number(TextFileHandler::getInstance().get_casing_defence_enabled())
+                                            + " " + QString::number(TextFileHandler::getInstance().get_casing_prosecution_enabled())
+                                            + " " + QString::number(TextFileHandler::getInstance().get_casing_judge_enabled())
+                                            + " " + QString::number(TextFileHandler::getInstance().get_casing_juror_enabled())
+                                            + " " + QString::number(TextFileHandler::getInstance().get_casing_steno_enabled())
                                             + "#%"));
     else
       ao_app->send_server_packet(new AOPacket("CT#" + ui_ooc_chat_name->text() + "#/setcase \"\" 0 0 0 0 0 0#%"));

--- a/courtroom.cpp
+++ b/courtroom.cpp
@@ -1,9 +1,7 @@
 #include "courtroom.h"
 
-Courtroom::Courtroom(AOApplication *p_ao_app) : QMainWindow()
+Courtroom::Courtroom() : QMainWindow()
 {
-  ao_app = p_ao_app;
-
   // Change the default audio output device to be the one the user has given
   // in his config.ini file for now.
   int a = 0;

--- a/courtroom.h
+++ b/courtroom.h
@@ -57,7 +57,7 @@ class Courtroom : public QMainWindow
 {
   Q_OBJECT
 public:
-  explicit Courtroom(AOApplication *p_ao_app);
+  explicit Courtroom();
 
   void append_char(char_type p_char){char_list.append(p_char);}
   void append_evidence(evi_type p_evi){evidence_list.append(p_evi);}
@@ -208,8 +208,6 @@ public:
   ~Courtroom();
 
 private:
-  AOApplication *ao_app;
-
   int m_courtroom_width = 714;
   int m_courtroom_height = 668;
 

--- a/courtroom.h
+++ b/courtroom.h
@@ -210,6 +210,7 @@ public:
 
 private:
   AOApplication *ao_app;
+  TextFileHandler *filehandler;
 
   int m_courtroom_width = 714;
   int m_courtroom_height = 668;

--- a/courtroom.h
+++ b/courtroom.h
@@ -201,7 +201,8 @@ public:
   //state is an number between 0 and 10 inclusive
   void set_hp_bar(int p_bar, int p_state);
 
-  void announce_case(QString title, bool def, bool pro, bool jud, bool jur, bool steno);
+  // Does a modcall-like sound effect and OOC message about a case being called.
+  void case_called(QString msg, bool def, bool pro, bool jud, bool jur, bool steno);
 
   void check_connection_received();
 
@@ -541,6 +542,10 @@ private:
   void construct_evidence();
   void set_evidence_page();
 
+signals:
+  void send_server_packet(AOPacket *p_packet, bool encoded = true);
+  void send_ms_packet(AOPacket *p_packet);
+
 public slots:
   void objection_done();
   void preanim_done();
@@ -552,7 +557,7 @@ public slots:
 
   void mod_called(QString p_ip);
 
-  void case_called(QString msg, bool def, bool pro, bool jud, bool jur, bool steno);
+  void announce_case(QString* title, bool def, bool pro, bool jud, bool jur, bool steno);
 
 private slots:
   void start_chat_ticking();

--- a/courtroom.h
+++ b/courtroom.h
@@ -57,7 +57,7 @@ class Courtroom : public QMainWindow
 {
   Q_OBJECT
 public:
-  explicit Courtroom();
+  explicit Courtroom(AOApplication *p_ao_app);
 
   void append_char(char_type p_char){char_list.append(p_char);}
   void append_evidence(evi_type p_evi){evidence_list.append(p_evi);}
@@ -208,6 +208,8 @@ public:
   ~Courtroom();
 
 private:
+  AOApplication *ao_app;
+
   int m_courtroom_width = 714;
   int m_courtroom_height = 668;
 

--- a/emotes.cpp
+++ b/emotes.cpp
@@ -1,6 +1,7 @@
 #include "courtroom.h"
 
 #include "aoemotebutton.h"
+#include "text_file_functions.h"
 
 void Courtroom::construct_emotes()
 {
@@ -8,7 +9,7 @@ void Courtroom::construct_emotes()
 
   set_size_and_pos(ui_emotes, "emotes");
 
-  QPoint f_spacing = ao_app->get_button_spacing("emote_button_spacing", "courtroom_design.ini");
+  QPoint f_spacing = TextFileHandler::getInstance().get_button_spacing("emote_button_spacing", "courtroom_design.ini");
 
   const int button_width = 40;
   int x_spacing = f_spacing.x();
@@ -28,7 +29,7 @@ void Courtroom::construct_emotes()
     int x_pos = (button_width + x_spacing) * x_mod_count;
     int y_pos = (button_height + y_spacing) * y_mod_count;
 
-    AOEmoteButton *f_emote = new AOEmoteButton(ui_emotes, ao_app, x_pos, y_pos);
+    AOEmoteButton *f_emote = new AOEmoteButton(ui_emotes, x_pos, y_pos);
 
     ui_emote_list.append(f_emote);
 
@@ -51,7 +52,7 @@ void Courtroom::set_emote_page()
   if (m_cid == -1)
     return;
 
-  int total_emotes = ao_app->get_emote_number(current_char);
+  int total_emotes = TextFileHandler::getInstance().get_emote_number(current_char);
 
   ui_emote_left->hide();
   ui_emote_right->hide();
@@ -102,12 +103,12 @@ void Courtroom::set_emote_dropdown()
 {
   ui_emote_dropdown->clear();
 
-  int total_emotes = ao_app->get_emote_number(current_char);
+  int total_emotes = TextFileHandler::getInstance().get_emote_number(current_char);
   QStringList emote_list;
 
   for (int n = 0 ; n < total_emotes ; ++n)
   {
-    emote_list.append(ao_app->get_emote_comment(current_char, n));
+    emote_list.append(TextFileHandler::getInstance().get_emote_comment(current_char, n));
   }
 
   ui_emote_dropdown->addItems(emote_list);
@@ -128,7 +129,7 @@ void Courtroom::select_emote(int p_id)
   if (current_emote >= min && current_emote <= max)
     ui_emote_list.at(current_emote % max_emotes_on_page)->set_image(current_char, current_emote, "_on.png");
 
-  int emote_mod = ao_app->get_emote_mod(current_char, current_emote);
+  int emote_mod = TextFileHandler::getInstance().get_emote_mod(current_char, current_emote);
 
   if (old_emote == current_emote)
   {

--- a/emotes.cpp
+++ b/emotes.cpp
@@ -9,7 +9,7 @@ void Courtroom::construct_emotes()
 
   set_size_and_pos(ui_emotes, "emotes");
 
-  QPoint f_spacing = TextFileHandler::getInstance().get_button_spacing("emote_button_spacing", "courtroom_design.ini");
+  QPoint f_spacing = TextFileHandler::get_instance()->get_button_spacing("emote_button_spacing", "courtroom_design.ini");
 
   const int button_width = 40;
   int x_spacing = f_spacing.x();
@@ -52,7 +52,7 @@ void Courtroom::set_emote_page()
   if (m_cid == -1)
     return;
 
-  int total_emotes = TextFileHandler::getInstance().get_emote_number(current_char);
+  int total_emotes = TextFileHandler::get_instance()->get_emote_number(current_char);
 
   ui_emote_left->hide();
   ui_emote_right->hide();
@@ -103,12 +103,12 @@ void Courtroom::set_emote_dropdown()
 {
   ui_emote_dropdown->clear();
 
-  int total_emotes = TextFileHandler::getInstance().get_emote_number(current_char);
+  int total_emotes = TextFileHandler::get_instance()->get_emote_number(current_char);
   QStringList emote_list;
 
   for (int n = 0 ; n < total_emotes ; ++n)
   {
-    emote_list.append(TextFileHandler::getInstance().get_emote_comment(current_char, n));
+    emote_list.append(TextFileHandler::get_instance()->get_emote_comment(current_char, n));
   }
 
   ui_emote_dropdown->addItems(emote_list);
@@ -129,7 +129,7 @@ void Courtroom::select_emote(int p_id)
   if (current_emote >= min && current_emote <= max)
     ui_emote_list.at(current_emote % max_emotes_on_page)->set_image(current_char, current_emote, "_on.png");
 
-  int emote_mod = TextFileHandler::getInstance().get_emote_mod(current_char, current_emote);
+  int emote_mod = TextFileHandler::get_instance()->get_emote_mod(current_char, current_emote);
 
   if (old_emote == current_emote)
   {

--- a/evidence.cpp
+++ b/evidence.cpp
@@ -2,7 +2,7 @@
 
 void Courtroom::construct_evidence()
 {
-  ui_evidence = new AOImage(this, ao_app);
+  ui_evidence = new AOImage(this);
 
   //ui_evidence_name = new QLabel(ui_evidence);
   ui_evidence_name = new AOLineEdit(ui_evidence);
@@ -13,17 +13,17 @@ void Courtroom::construct_evidence()
 
   ui_evidence_buttons = new QWidget(ui_evidence);
 
-  ui_evidence_left = new AOButton(ui_evidence, ao_app);
-  ui_evidence_right = new AOButton(ui_evidence, ao_app);
-  ui_evidence_present = new AOButton(ui_evidence, ao_app);
+  ui_evidence_left = new AOButton(ui_evidence);
+  ui_evidence_right = new AOButton(ui_evidence);
+  ui_evidence_present = new AOButton(ui_evidence);
 
-  ui_evidence_overlay = new AOImage(ui_evidence, ao_app);
+  ui_evidence_overlay = new AOImage(ui_evidence);
 
-  ui_evidence_delete = new AOButton(ui_evidence_overlay, ao_app);
+  ui_evidence_delete = new AOButton(ui_evidence_overlay);
   ui_evidence_image_name = new AOLineEdit(ui_evidence_overlay);
-  ui_evidence_image_button = new AOButton(ui_evidence_overlay, ao_app);
+  ui_evidence_image_button = new AOButton(ui_evidence_overlay);
   ui_evidence_image_button->setText("Choose..");
-  ui_evidence_x = new AOButton(ui_evidence_overlay, ao_app);
+  ui_evidence_x = new AOButton(ui_evidence_overlay);
 
   ui_evidence_description = new AOTextEdit(ui_evidence_overlay);
   ui_evidence_description->setStyleSheet("background-color: rgba(0, 0, 0, 0);"
@@ -32,7 +32,7 @@ void Courtroom::construct_evidence()
   set_size_and_pos(ui_evidence, "evidence_background");
   set_size_and_pos(ui_evidence_buttons, "evidence_buttons");
 
-  QPoint f_spacing = ao_app->get_button_spacing("evidence_button_spacing", "courtroom_design.ini");
+  QPoint f_spacing = TextFileHandler::getInstance().get_button_spacing("evidence_button_spacing", "courtroom_design.ini");
 
   const int button_width = 70;
   int x_spacing = f_spacing.x();
@@ -52,7 +52,7 @@ void Courtroom::construct_evidence()
     int x_pos = (button_width + x_spacing) * x_mod_count;
     int y_pos = (button_height + y_spacing) * y_mod_count;
 
-    AOEvidenceButton *f_evidence = new AOEvidenceButton(ui_evidence_buttons, ao_app, x_pos, y_pos);
+    AOEvidenceButton *f_evidence = new AOEvidenceButton(ui_evidence_buttons, x_pos, y_pos);
 
     ui_evidence_list.append(f_evidence);
 
@@ -192,7 +192,7 @@ void Courtroom::on_evidence_image_button_clicked()
   dialog.setFileMode(QFileDialog::ExistingFile);
   dialog.setNameFilter(tr("Images (*.png)"));
   dialog.setViewMode(QFileDialog::List);
-  dialog.setDirectory(ao_app->get_base_path() + "evidence");
+  dialog.setDirectory(TextFileHandler::getInstance().get_base_path() + "evidence");
 
   QStringList filenames;
 

--- a/evidence.cpp
+++ b/evidence.cpp
@@ -166,7 +166,7 @@ void Courtroom::on_evidence_name_edited()
   f_contents.append(f_evi.description);
   f_contents.append(f_evi.image);
 
-  send_server_packet(new AOPacket("EE", f_contents));
+  emit send_server_packet(new AOPacket("EE", f_contents));
 }
 
 void Courtroom::on_evidence_image_name_edited()
@@ -183,7 +183,7 @@ void Courtroom::on_evidence_image_name_edited()
   f_contents.append(f_evi.description);
   f_contents.append(ui_evidence_image_name->text());
 
-  send_server_packet(new AOPacket("EE", f_contents));
+  emit send_server_packet(new AOPacket("EE", f_contents));
 }
 
 void Courtroom::on_evidence_image_button_clicked()
@@ -221,7 +221,7 @@ void Courtroom::on_evidence_clicked(int p_id)
 
   if (f_real_id == local_evidence_list.size())
   {
-    send_server_packet(new AOPacket("PE#<name>#<description>#empty.png#%"));
+    emit send_server_packet(new AOPacket("PE#<name>#<description>#empty.png#%"));
     return;
   }
   else if (f_real_id > local_evidence_list.size())
@@ -314,7 +314,7 @@ void Courtroom::on_evidence_delete_clicked()
   ui_evidence_description->setReadOnly(true);
   ui_evidence_overlay->hide();
 
-  send_server_packet(new AOPacket("DE#" + QString::number(current_evidence) + "#%"));
+  emit send_server_packet(new AOPacket("DE#" + QString::number(current_evidence) + "#%"));
 
   current_evidence = 0;
 
@@ -338,7 +338,7 @@ void Courtroom::on_evidence_x_clicked()
   f_contents.append(ui_evidence_description->toPlainText());
   f_contents.append(f_evi.image);
 
-  send_server_packet(new AOPacket("EE", f_contents));
+  emit send_server_packet(new AOPacket("EE", f_contents));
 
   ui_ic_chat_message->setFocus();
 }

--- a/evidence.cpp
+++ b/evidence.cpp
@@ -32,7 +32,7 @@ void Courtroom::construct_evidence()
   set_size_and_pos(ui_evidence, "evidence_background");
   set_size_and_pos(ui_evidence_buttons, "evidence_buttons");
 
-  QPoint f_spacing = TextFileHandler::getInstance().get_button_spacing("evidence_button_spacing", "courtroom_design.ini");
+  QPoint f_spacing = TextFileHandler::get_instance()->get_button_spacing("evidence_button_spacing", "courtroom_design.ini");
 
   const int button_width = 70;
   int x_spacing = f_spacing.x();
@@ -192,7 +192,7 @@ void Courtroom::on_evidence_image_button_clicked()
   dialog.setFileMode(QFileDialog::ExistingFile);
   dialog.setNameFilter(tr("Images (*.png)"));
   dialog.setViewMode(QFileDialog::List);
-  dialog.setDirectory(TextFileHandler::getInstance().get_base_path() + "evidence");
+  dialog.setDirectory(TextFileHandler::get_instance()->get_base_path() + "evidence");
 
   QStringList filenames;
 

--- a/evidence.cpp
+++ b/evidence.cpp
@@ -166,7 +166,7 @@ void Courtroom::on_evidence_name_edited()
   f_contents.append(f_evi.description);
   f_contents.append(f_evi.image);
 
-  ao_app->send_server_packet(new AOPacket("EE", f_contents));
+  send_server_packet(new AOPacket("EE", f_contents));
 }
 
 void Courtroom::on_evidence_image_name_edited()
@@ -183,7 +183,7 @@ void Courtroom::on_evidence_image_name_edited()
   f_contents.append(f_evi.description);
   f_contents.append(ui_evidence_image_name->text());
 
-  ao_app->send_server_packet(new AOPacket("EE", f_contents));
+  send_server_packet(new AOPacket("EE", f_contents));
 }
 
 void Courtroom::on_evidence_image_button_clicked()
@@ -221,7 +221,7 @@ void Courtroom::on_evidence_clicked(int p_id)
 
   if (f_real_id == local_evidence_list.size())
   {
-    ao_app->send_server_packet(new AOPacket("PE#<name>#<description>#empty.png#%"));
+    send_server_packet(new AOPacket("PE#<name>#<description>#empty.png#%"));
     return;
   }
   else if (f_real_id > local_evidence_list.size())
@@ -314,7 +314,7 @@ void Courtroom::on_evidence_delete_clicked()
   ui_evidence_description->setReadOnly(true);
   ui_evidence_overlay->hide();
 
-  ao_app->send_server_packet(new AOPacket("DE#" + QString::number(current_evidence) + "#%"));
+  send_server_packet(new AOPacket("DE#" + QString::number(current_evidence) + "#%"));
 
   current_evidence = 0;
 
@@ -338,7 +338,7 @@ void Courtroom::on_evidence_x_clicked()
   f_contents.append(ui_evidence_description->toPlainText());
   f_contents.append(f_evi.image);
 
-  ao_app->send_server_packet(new AOPacket("EE", f_contents));
+  send_server_packet(new AOPacket("EE", f_contents));
 
   ui_ic_chat_message->setFocus();
 }

--- a/lobby.cpp
+++ b/lobby.cpp
@@ -46,7 +46,7 @@ Lobby::Lobby(AOApplication *p_ao_app) : QMainWindow()
   connect(ui_about, SIGNAL(clicked()), this, SLOT(on_about_clicked()));
   connect(ui_server_list, SIGNAL(clicked(QModelIndex)), this, SLOT(on_server_list_clicked(QModelIndex)));
   connect(ui_chatmessage, SIGNAL(returnPressed()), this, SLOT(on_chatfield_return_pressed()));
-  connect(ui_cancel, SIGNAL(clicked()), this, SLOT(on_loading_cancelled()));
+  connect(ui_cancel, SIGNAL(clicked()), this, SIGNAL(cancel_clicked()));
 
   ui_connect->setEnabled(false);
 
@@ -226,7 +226,7 @@ void Lobby::on_refresh_released()
 
   AOPacket *f_packet = new AOPacket("ALL#%");
 
-  send_ms_packet(f_packet);
+  emit send_ms_packet(f_packet);
 }
 
 void Lobby::on_add_to_fav_pressed()
@@ -258,7 +258,7 @@ void Lobby::on_connect_released()
 
   f_packet = new AOPacket("askchaa#%");
 
-  send_server_packet(f_packet);
+  emit send_server_packet(f_packet);
 }
 
 void Lobby::on_about_clicked()
@@ -330,14 +330,9 @@ void Lobby::on_chatfield_return_pressed()
 
   AOPacket *f_packet = new AOPacket(f_header, f_contents);
 
-  send_ms_packet(f_packet);
+  emit send_ms_packet(f_packet);
 
   ui_chatmessage->clear();
-}
-
-void Lobby::on_loading_cancelled()
-{
-  cancel_clicked();
 }
 
 void Lobby::list_servers()

--- a/lobby.cpp
+++ b/lobby.cpp
@@ -1,24 +1,21 @@
 #include "lobby.h"
 
 #include "debug_functions.h"
-#include "aoapplication.h"
 #include "networkmanager.h"
 #include "aosfxplayer.h"
 
-Lobby::Lobby(AOApplication *p_ao_app) : QMainWindow()
+Lobby::Lobby() : QMainWindow()
 {
-  ao_app = p_ao_app;
-
   this->setWindowTitle("Attorney Online 2");
 
-  ui_background = new AOImage(this, ao_app);
-  ui_public_servers = new AOButton(this, ao_app);
-  ui_favorites = new AOButton(this, ao_app);
-  ui_refresh = new AOButton(this, ao_app);
-  ui_add_to_fav = new AOButton(this, ao_app);
-  ui_connect = new AOButton(this, ao_app);
+  ui_background = new AOImage(this);
+  ui_public_servers = new AOButton(this);
+  ui_favorites = new AOButton(this);
+  ui_refresh = new AOButton(this);
+  ui_add_to_fav = new AOButton(this);
+  ui_connect = new AOButton(this);
   ui_version = new QLabel(this);
-  ui_about = new AOButton(this, ao_app);
+  ui_about = new AOButton(this);
   ui_server_list = new QListWidget(this);
   ui_player_count = new QLabel(this);
   ui_description = new AOTextArea(this);
@@ -28,13 +25,13 @@ Lobby::Lobby(AOApplication *p_ao_app) : QMainWindow()
   ui_chatname->setPlaceholderText("Name");
   ui_chatname->setText(ao_app->get_ooc_name());
   ui_chatmessage = new QLineEdit(this);
-  ui_loading_background = new AOImage(this, ao_app);
+  ui_loading_background = new AOImage(this);
   ui_loading_text = new QTextEdit(ui_loading_background);
   ui_progress_bar = new QProgressBar(ui_loading_background);
   ui_progress_bar->setMinimum(0);
   ui_progress_bar->setMaximum(100);
   ui_progress_bar->setStyleSheet("QProgressBar{ color: white; }");
-  ui_cancel = new AOButton(ui_loading_background, ao_app);
+  ui_cancel = new AOButton(ui_loading_background);
 
   connect(ui_public_servers, SIGNAL(clicked()), this, SLOT(on_public_servers_clicked()));
   connect(ui_favorites, SIGNAL(clicked()), this, SLOT(on_favorites_clicked()));

--- a/lobby.cpp
+++ b/lobby.cpp
@@ -4,8 +4,10 @@
 #include "networkmanager.h"
 #include "aosfxplayer.h"
 
-Lobby::Lobby() : QMainWindow()
+Lobby::Lobby(AOApplication *p_ao_app) : QMainWindow()
 {
+  ao_app = p_ao_app;
+
   this->setWindowTitle("Attorney Online 2");
 
   ui_background = new AOImage(this);
@@ -23,7 +25,7 @@ Lobby::Lobby() : QMainWindow()
   ui_chatbox->setOpenExternalLinks(true);
   ui_chatname = new QLineEdit(this);
   ui_chatname->setPlaceholderText("Name");
-  ui_chatname->setText(ao_app->get_ooc_name());
+  ui_chatname->setText(TextFileHandler::getInstance().get_ooc_name());
   ui_chatmessage = new QLineEdit(this);
   ui_loading_background = new AOImage(this);
   ui_loading_text = new QTextEdit(ui_loading_background);
@@ -44,7 +46,7 @@ Lobby::Lobby() : QMainWindow()
   connect(ui_about, SIGNAL(clicked()), this, SLOT(on_about_clicked()));
   connect(ui_server_list, SIGNAL(clicked(QModelIndex)), this, SLOT(on_server_list_clicked(QModelIndex)));
   connect(ui_chatmessage, SIGNAL(returnPressed()), this, SLOT(on_chatfield_return_pressed()));
-  connect(ui_cancel, SIGNAL(clicked()), ao_app, SLOT(loading_cancelled()));
+  connect(ui_cancel, SIGNAL(clicked()), this, SLOT(on_loading_cancelled()));
 
   ui_connect->setEnabled(false);
 
@@ -54,11 +56,11 @@ Lobby::Lobby() : QMainWindow()
 //sets images, position and size
 void Lobby::set_widgets()
 {
-  ao_app->reload_theme();
+  TextFileHandler::getInstance().read_theme();
 
   QString filename = "lobby_design.ini";
 
-  pos_size_type f_lobby = ao_app->get_element_dimensions("lobby", filename);
+  pos_size_type f_lobby = TextFileHandler::getInstance().get_element_dimensions("lobby", filename);
 
   if (f_lobby.width < 0 || f_lobby.height < 0)
   {
@@ -152,7 +154,7 @@ void Lobby::set_size_and_pos(QWidget *p_widget, QString p_identifier)
 {
   QString filename = "lobby_design.ini";
 
-  pos_size_type design_ini_result = ao_app->get_element_dimensions(p_identifier, filename);
+  pos_size_type design_ini_result = TextFileHandler::getInstance().get_element_dimensions(p_identifier, filename);
 
   if (design_ini_result.width < 0 || design_ini_result.height < 0)
   {
@@ -333,6 +335,11 @@ void Lobby::on_chatfield_return_pressed()
   ui_chatmessage->clear();
 }
 
+void Lobby::on_loading_cancelled()
+{
+  cancel_clicked();
+}
+
 void Lobby::list_servers()
 {
   public_servers_selected = true;
@@ -359,7 +366,7 @@ void Lobby::list_favorites()
 
 void Lobby::append_chatmessage(QString f_name, QString f_message)
 {
-  ui_chatbox->append_chatmessage(f_name, f_message, ao_app->get_color("ooc_default_color", "courtroom_design.ini").name());
+  ui_chatbox->append_chatmessage(f_name, f_message, TextFileHandler::getInstance().get_color("ooc_default_color", "courtroom_design.ini").name());
 }
 
 void Lobby::append_error(QString f_message)

--- a/lobby.cpp
+++ b/lobby.cpp
@@ -226,7 +226,7 @@ void Lobby::on_refresh_released()
 
   AOPacket *f_packet = new AOPacket("ALL#%");
 
-  ao_app->send_ms_packet(f_packet);
+  send_ms_packet(f_packet);
 }
 
 void Lobby::on_add_to_fav_pressed()
@@ -258,7 +258,7 @@ void Lobby::on_connect_released()
 
   f_packet = new AOPacket("askchaa#%");
 
-  ao_app->send_server_packet(f_packet);
+  send_server_packet(f_packet);
 }
 
 void Lobby::on_about_clicked()
@@ -330,7 +330,7 @@ void Lobby::on_chatfield_return_pressed()
 
   AOPacket *f_packet = new AOPacket(f_header, f_contents);
 
-  ao_app->send_ms_packet(f_packet);
+  send_ms_packet(f_packet);
 
   ui_chatmessage->clear();
 }

--- a/lobby.cpp
+++ b/lobby.cpp
@@ -25,7 +25,7 @@ Lobby::Lobby(AOApplication *p_ao_app) : QMainWindow()
   ui_chatbox->setOpenExternalLinks(true);
   ui_chatname = new QLineEdit(this);
   ui_chatname->setPlaceholderText("Name");
-  ui_chatname->setText(TextFileHandler::getInstance().get_ooc_name());
+  ui_chatname->setText(TextFileHandler::get_instance()->get_ooc_name());
   ui_chatmessage = new QLineEdit(this);
   ui_loading_background = new AOImage(this);
   ui_loading_text = new QTextEdit(ui_loading_background);
@@ -56,11 +56,11 @@ Lobby::Lobby(AOApplication *p_ao_app) : QMainWindow()
 //sets images, position and size
 void Lobby::set_widgets()
 {
-  TextFileHandler::getInstance().read_theme();
+  TextFileHandler::get_instance()->read_theme();
 
   QString filename = "lobby_design.ini";
 
-  pos_size_type f_lobby = TextFileHandler::getInstance().get_element_dimensions("lobby", filename);
+  pos_size_type f_lobby = TextFileHandler::get_instance()->get_element_dimensions("lobby", filename);
 
   if (f_lobby.width < 0 || f_lobby.height < 0)
   {
@@ -154,7 +154,7 @@ void Lobby::set_size_and_pos(QWidget *p_widget, QString p_identifier)
 {
   QString filename = "lobby_design.ini";
 
-  pos_size_type design_ini_result = TextFileHandler::getInstance().get_element_dimensions(p_identifier, filename);
+  pos_size_type design_ini_result = TextFileHandler::get_instance()->get_element_dimensions(p_identifier, filename);
 
   if (design_ini_result.width < 0 || design_ini_result.height < 0)
   {
@@ -366,7 +366,7 @@ void Lobby::list_favorites()
 
 void Lobby::append_chatmessage(QString f_name, QString f_message)
 {
-  ui_chatbox->append_chatmessage(f_name, f_message, TextFileHandler::getInstance().get_color("ooc_default_color", "courtroom_design.ini").name());
+  ui_chatbox->append_chatmessage(f_name, f_message, TextFileHandler::get_instance()->get_color("ooc_default_color", "courtroom_design.ini").name());
 }
 
 void Lobby::append_error(QString f_message)

--- a/lobby.h
+++ b/lobby.h
@@ -24,7 +24,7 @@ class Lobby : public QMainWindow
   Q_OBJECT
 
 public:
-  Lobby();
+  Lobby(AOApplication *p_ao_app);
 
   void set_widgets();
   void list_servers();
@@ -45,7 +45,12 @@ public:
 
   ~Lobby();
 
+signals:
+  void cancel_clicked();
+
 private:
+  AOApplication *ao_app;
+
   AOImage *ui_background;
 
   AOButton *ui_public_servers;
@@ -88,6 +93,7 @@ private slots:
   void on_about_clicked();
   void on_server_list_clicked(QModelIndex p_model);
   void on_chatfield_return_pressed();
+  void on_loading_cancelled();
 };
 
 #endif // LOBBY_H

--- a/lobby.h
+++ b/lobby.h
@@ -47,6 +47,8 @@ public:
 
 signals:
   void cancel_clicked();
+  void send_server_packet(AOPacket *p_packet, bool encoded = true);
+  void send_ms_packet(AOPacket *p_packet);
 
 private:
   AOApplication *ao_app;

--- a/lobby.h
+++ b/lobby.h
@@ -24,7 +24,7 @@ class Lobby : public QMainWindow
   Q_OBJECT
 
 public:
-  Lobby(AOApplication *p_ao_app);
+  Lobby();
 
   void set_widgets();
   void list_servers();
@@ -46,8 +46,6 @@ public:
   ~Lobby();
 
 private:
-  AOApplication *ao_app;
-
   AOImage *ui_background;
 
   AOButton *ui_public_servers;

--- a/lobby.h
+++ b/lobby.h
@@ -95,7 +95,6 @@ private slots:
   void on_about_clicked();
   void on_server_list_clicked(QModelIndex p_model);
   void on_chatfield_return_pressed();
-  void on_loading_cancelled();
 };
 
 #endif // LOBBY_H

--- a/networkmanager.cpp
+++ b/networkmanager.cpp
@@ -104,7 +104,7 @@ void NetworkManager::handle_ms_packet()
   {
     AOPacket *f_packet = new AOPacket(packet);
 
-    ms_packet_received(f_packet);
+    emit ms_packet_received(f_packet);
   }
 }
 
@@ -243,7 +243,7 @@ void NetworkManager::handle_server_packet()
   {
     AOPacket *f_packet = new AOPacket(packet);
 
-    server_packet_received(f_packet);
+    emit server_packet_received(f_packet);
   }
 }
 

--- a/networkmanager.cpp
+++ b/networkmanager.cpp
@@ -16,7 +16,7 @@ NetworkManager::NetworkManager() : QObject()
   QObject::connect(ms_socket, SIGNAL(readyRead()), this, SLOT(handle_ms_packet()));
   QObject::connect(server_socket, SIGNAL(readyRead()), this, SLOT(handle_server_packet()));
 
-  QString master_config = TextFileHandler::getInstance().get_master_server();
+  QString master_config = TextFileHandler::get_instance()->get_master_server();
   if (master_config != "")
     ms_nosrv_hostname = master_config;
 }

--- a/networkmanager.cpp
+++ b/networkmanager.cpp
@@ -4,7 +4,7 @@
 #include "debug_functions.h"
 #include "lobby.h"
 
-NetworkManager::NetworkManager() : QObject(parent)
+NetworkManager::NetworkManager() : QObject()
 {
   ms_socket = new QTcpSocket(this);
   server_socket = new QTcpSocket(this);
@@ -15,9 +15,8 @@ NetworkManager::NetworkManager() : QObject(parent)
 
   QObject::connect(ms_socket, SIGNAL(readyRead()), this, SLOT(handle_ms_packet()));
   QObject::connect(server_socket, SIGNAL(readyRead()), this, SLOT(handle_server_packet()));
-  QObject::connect(server_socket, SIGNAL(disconnected()), ao_app, SLOT(server_disconnected()));
 
-  QString master_config = ao_app->configini->value("master", "").value<QString>();
+  QString master_config = TextFileHandler::getInstance().get_master_server();
   if (master_config != "")
     ms_nosrv_hostname = master_config;
 }
@@ -105,7 +104,7 @@ void NetworkManager::handle_ms_packet()
   {
     AOPacket *f_packet = new AOPacket(packet);
 
-    ao_app->ms_packet_received(f_packet);
+    ms_packet_received(f_packet);
   }
 }
 
@@ -141,7 +140,7 @@ void NetworkManager::on_srv_lookup()
       timer.start();
       do
       {
-        ao_app->processEvents();
+        force_process_events();
         if (ms_socket->state() == QAbstractSocket::ConnectedState)
         {
           connected = true;
@@ -244,7 +243,7 @@ void NetworkManager::handle_server_packet()
   {
     AOPacket *f_packet = new AOPacket(packet);
 
-    ao_app->server_packet_received(f_packet);
+    server_packet_received(f_packet);
   }
 }
 

--- a/networkmanager.cpp
+++ b/networkmanager.cpp
@@ -4,10 +4,8 @@
 #include "debug_functions.h"
 #include "lobby.h"
 
-NetworkManager::NetworkManager(AOApplication *parent) : QObject(parent)
+NetworkManager::NetworkManager() : QObject(parent)
 {
-  ao_app = parent;
-
   ms_socket = new QTcpSocket(this);
   server_socket = new QTcpSocket(this);
 

--- a/networkmanager.h
+++ b/networkmanager.h
@@ -15,6 +15,7 @@
 #endif
 
 #include "aopacket.h"
+#include "aoapplication.h"
 
 #include <QTcpSocket>
 #include <QDnsLookup>
@@ -68,6 +69,9 @@ public slots:
 
 signals:
   void ms_connect_finished(bool success, bool will_retry);
+  void ms_packet_received(AOPacket *f_packet);
+  void server_packet_received(AOPacket *f_packet);
+  void force_process_events();
 
 private:
   void perform_srv_lookup();

--- a/networkmanager.h
+++ b/networkmanager.h
@@ -15,7 +15,6 @@
 #endif
 
 #include "aopacket.h"
-#include "aoapplication.h"
 
 #include <QTcpSocket>
 #include <QDnsLookup>
@@ -28,10 +27,9 @@ class NetworkManager : public QObject
   Q_OBJECT
 
 public:
-  NetworkManager(AOApplication *parent);
+  NetworkManager();
   ~NetworkManager();
 
-  AOApplication *ao_app;
   QTcpSocket *ms_socket;
   QTcpSocket *server_socket;
   QDnsLookup *ms_dns;

--- a/packet_distribution.cpp
+++ b/packet_distribution.cpp
@@ -281,7 +281,7 @@ void AOApplication::server_packet_received(AOPacket *p_packet)
 
     QCryptographicHash hash(QCryptographicHash::Algorithm::Sha256);
     hash.addData(server_address.toUtf8());
-    if (TextFileHandler::getInstance().is_discord_enabled())
+    if (TextFileHandler::get_instance()->is_discord_enabled())
       discord->state_server(server_name.toStdString(), hash.result().toBase64().toStdString());
   }
   else if (header == "CI")

--- a/packet_distribution.cpp
+++ b/packet_distribution.cpp
@@ -281,7 +281,7 @@ void AOApplication::server_packet_received(AOPacket *p_packet)
 
     QCryptographicHash hash(QCryptographicHash::Algorithm::Sha256);
     hash.addData(server_address.toUtf8());
-    if (is_discord_enabled())
+    if (TextFileHandler::getInstance().is_discord_enabled())
       discord->state_server(server_name.toStdString(), hash.result().toBase64().toStdString());
   }
   else if (header == "CI")

--- a/path_functions.cpp
+++ b/path_functions.cpp
@@ -1,10 +1,5 @@
-#include "aoapplication.h"
+#include "text_file_functions.h"
 #include "courtroom.h"
-#include "file_functions.h"
-
-#include <QDir>
-#include <QStandardPaths>
-#include <QRegExp>
 
 #ifdef BASE_OVERRIDE
 #include "base_override.h"
@@ -18,7 +13,7 @@
 #define CASE_SENSITIVE_FILESYSTEM
 #endif
 
-QString AOApplication::get_base_path()
+QString TextFileHandler::get_base_path()
 {
   QString base_path = "";
 #ifdef ANDROID
@@ -37,12 +32,12 @@ QString AOApplication::get_base_path()
   return base_path;
 }
 
-QString AOApplication::get_data_path()
+QString TextFileHandler::get_data_path()
 {
   return get_base_path() + "data/";
 }
 
-QString AOApplication::get_default_theme_path(QString p_file)
+QString TextFileHandler::get_default_theme_path(QString p_file)
 {
   QString path = get_base_path() + "themes/default/" + p_file;
 #ifndef CASE_SENSITIVE_FILESYSTEM
@@ -52,7 +47,7 @@ QString AOApplication::get_default_theme_path(QString p_file)
 #endif
 }
 
-QString AOApplication::get_custom_theme_path(QString p_theme, QString p_file)
+QString TextFileHandler::get_custom_theme_path(QString p_theme, QString p_file)
 {
   QString path = get_base_path() + "themes/" + p_theme + "/" + p_file;
 #ifndef CASE_SENSITIVE_FILESYSTEM
@@ -62,7 +57,7 @@ QString AOApplication::get_custom_theme_path(QString p_theme, QString p_file)
 #endif
 }
 
-QString AOApplication::get_theme_path(QString p_file)
+QString TextFileHandler::get_theme_path(QString p_file)
 {
   QString path = get_base_path() + "themes/" + current_theme + "/" + p_file;
 #ifndef CASE_SENSITIVE_FILESYSTEM
@@ -72,7 +67,7 @@ QString AOApplication::get_theme_path(QString p_file)
 #endif
 }
 
-QString AOApplication::get_character_path(QString p_char, QString p_file)
+QString TextFileHandler::get_character_path(QString p_char, QString p_file)
 {
   QString path = get_base_path() + "characters/" + p_char + "/" + p_file;
 #ifndef CASE_SENSITIVE_FILESYSTEM
@@ -82,7 +77,7 @@ QString AOApplication::get_character_path(QString p_char, QString p_file)
 #endif
 }
 
-QString AOApplication::get_sounds_path(QString p_file)
+QString TextFileHandler::get_sounds_path(QString p_file)
 {
   QString path = get_base_path() + "sounds/general/" + p_file;
 #ifndef CASE_SENSITIVE_FILESYSTEM
@@ -92,7 +87,7 @@ QString AOApplication::get_sounds_path(QString p_file)
 #endif
 }
 
-QString AOApplication::get_music_path(QString p_song)
+QString TextFileHandler::get_music_path(QString p_song)
 {
   QString path = get_base_path() + "sounds/music/" + p_song;
 #ifndef CASE_SENSITIVE_FILESYSTEM
@@ -102,10 +97,10 @@ QString AOApplication::get_music_path(QString p_song)
 #endif
 }
 
-QString AOApplication::get_background_path(QString p_file)
+QString TextFileHandler::get_background_path(QString p_file)
 {
-  QString path = get_base_path() + "background/" + w_courtroom->get_current_background() + "/" + p_file;
-  if (courtroom_constructed) {
+  QString path = get_base_path() + "background/" + ao_app->w_courtroom->get_current_background() + "/" + p_file;
+  if (ao_app->courtroom_constructed) {
 #ifndef CASE_SENSITIVE_FILESYSTEM
     return path;
 #else
@@ -115,7 +110,7 @@ QString AOApplication::get_background_path(QString p_file)
   return get_default_background_path(p_file);
 }
 
-QString AOApplication::get_default_background_path(QString p_file)
+QString TextFileHandler::get_default_background_path(QString p_file)
 {
   QString path = get_base_path() + "background/default/" + p_file;
 #ifndef CASE_SENSITIVE_FILESYSTEM
@@ -125,7 +120,7 @@ QString AOApplication::get_default_background_path(QString p_file)
 #endif
 }
 
-QString AOApplication::get_evidence_path(QString p_file)
+QString TextFileHandler::get_evidence_path(QString p_file)
 {
   QString path = get_base_path() + "evidence/" + p_file;
 #ifndef CASE_SENSITIVE_FILESYSTEM
@@ -135,7 +130,7 @@ QString AOApplication::get_evidence_path(QString p_file)
 #endif
 }
 
-QString AOApplication::get_case_sensitive_path(QString p_file) {
+QString TextFileHandler::get_case_sensitive_path(QString p_file) {
   //first, check to see if it's actually there (also serves as base case for recursion)
   if (exists(p_file)) return p_file;
 

--- a/path_functions.cpp
+++ b/path_functions.cpp
@@ -136,6 +136,8 @@ QString TextFileHandler::get_case_sensitive_path(QString p_file) {
 
   QFileInfo file(p_file);
 
+  //qDebug() << file.fileName() << "//" << file.filePath();
+
   QString file_basename = file.fileName();
   QString file_parent_dir = get_case_sensitive_path(file.absolutePath());
 

--- a/text_file_functions.cpp
+++ b/text_file_functions.cpp
@@ -1,18 +1,18 @@
 #include "text_file_functions.h"
 
-TextFileHandler& TextFileHandler::getInstance()
+TextFileHandler* TextFileHandler::singleton = new TextFileHandler();
+
+void TextFileHandler::createInstance(AOApplication *p_ao_app)
 {
-  static TextFileHandler instance;
+  singleton->ao_app = p_ao_app;
 
   // Create the QSettings class that points to the config.ini.
-  instance.configini = new QSettings(instance.get_base_path() + "config.ini", QSettings::IniFormat);
-
-  return instance;
+  singleton->configini = new QSettings(singleton->get_base_path() + "config.ini", QSettings::IniFormat);
 }
 
-void TextFileHandler::give_ao_app_pointer(AOApplication *p_ao_app)
+TextFileHandler* TextFileHandler::getInstance()
 {
-  ao_app = p_ao_app;
+  return singleton;
 }
 
 QString TextFileHandler::get_master_server()

--- a/text_file_functions.cpp
+++ b/text_file_functions.cpp
@@ -26,6 +26,11 @@ void TextFileHandler::read_theme()
   current_theme = result;
 }
 
+QString TextFileHandler::get_current_theme()
+{
+  return current_theme;
+}
+
 int TextFileHandler::read_blip_rate()
 {
   int result = configini->value("blip_rate", 1).toInt();

--- a/text_file_functions.cpp
+++ b/text_file_functions.cpp
@@ -2,7 +2,7 @@
 
 TextFileHandler* TextFileHandler::singleton = new TextFileHandler();
 
-void TextFileHandler::createInstance(AOApplication *p_ao_app)
+void TextFileHandler::create_instance(AOApplication *p_ao_app)
 {
   singleton->ao_app = p_ao_app;
 
@@ -10,7 +10,7 @@ void TextFileHandler::createInstance(AOApplication *p_ao_app)
   singleton->configini = new QSettings(singleton->get_base_path() + "config.ini", QSettings::IniFormat);
 }
 
-TextFileHandler* TextFileHandler::getInstance()
+TextFileHandler* TextFileHandler::get_instance()
 {
   return singleton;
 }

--- a/text_file_functions.cpp
+++ b/text_file_functions.cpp
@@ -1,60 +1,80 @@
 #include "text_file_functions.h"
 
-QString AOApplication::read_theme()
+TextFileHandler& TextFileHandler::getInstance()
 {
-  QString result = configini->value("theme", "default").value<QString>();
-  return result;
+  static TextFileHandler instance;
+
+  // Create the QSettings class that points to the config.ini.
+  instance.configini = new QSettings(instance.get_base_path() + "config.ini", QSettings::IniFormat);
+
+  return instance;
 }
 
-int AOApplication::read_blip_rate()
+void TextFileHandler::give_ao_app_pointer(AOApplication *p_ao_app)
+{
+  ao_app = p_ao_app;
+}
+
+QString TextFileHandler::get_master_server()
+{
+  return configini->value("master", "").value<QString>();
+}
+
+void TextFileHandler::read_theme()
+{
+  QString result = configini->value("theme", "default").value<QString>();
+  current_theme = result;
+}
+
+int TextFileHandler::read_blip_rate()
 {
   int result = configini->value("blip_rate", 1).toInt();
   return result;
 }
 
-QString AOApplication::get_ooc_name()
+QString TextFileHandler::get_ooc_name()
 {
   QString result = configini->value("ooc_name").value<QString>();
   return result;
 }
 
-int AOApplication::get_default_music()
+int TextFileHandler::get_default_music()
 {
   int result = configini->value("default_music", 50).toInt();
   return result;
 }
 
-int AOApplication::get_default_sfx()
+int TextFileHandler::get_default_sfx()
 {
   int result = configini->value("default_sfx", 50).toInt();
   return result;
 }
 
-int AOApplication::get_default_blip()
+int TextFileHandler::get_default_blip()
 {
   int result = configini->value("default_blip", 50).toInt();
   return result;
 }
 
-int AOApplication::get_max_log_size()
+int TextFileHandler::get_max_log_size()
 {
   int result = configini->value("log_maximum", 200).toInt();
   return result;
 }
 
-bool AOApplication::get_log_goes_downwards()
+bool TextFileHandler::get_log_goes_downwards()
 {
   QString result = configini->value("log_goes_downwards", "false").value<QString>();
   return result.startsWith("true");
 }
 
-bool AOApplication::get_showname_enabled_by_default()
+bool TextFileHandler::get_showname_enabled_by_default()
 {
   QString result = configini->value("show_custom_shownames", "false").value<QString>();
   return result.startsWith("true");
 }
 
-QString AOApplication::get_default_username()
+QString TextFileHandler::get_default_username()
 {
   QString result = configini->value("default_username", "").value<QString>();
   if (result.isEmpty())
@@ -63,13 +83,13 @@ QString AOApplication::get_default_username()
       return result;
 }
 
-QString AOApplication::get_audio_output_device()
+QString TextFileHandler::get_audio_output_device()
 {
   QString result = configini->value("default_audio_device", "default").value<QString>();
   return result;
 }
 
-QStringList AOApplication::get_call_words()
+QStringList TextFileHandler::get_call_words()
 {
   QStringList return_value;
 
@@ -91,7 +111,7 @@ QStringList AOApplication::get_call_words()
   return return_value;
 }
 
-void AOApplication::write_to_serverlist_txt(QString p_line)
+void TextFileHandler::write_to_serverlist_txt(QString p_line)
 {
   QFile serverlist_txt;
   QString serverlist_txt_path = get_base_path() + "serverlist.txt";
@@ -110,7 +130,7 @@ void AOApplication::write_to_serverlist_txt(QString p_line)
   serverlist_txt.close();
 }
 
-QVector<server_type> AOApplication::read_serverlist_txt()
+QVector<server_type> TextFileHandler::read_serverlist_txt()
 {
   QVector<server_type> f_server_list;
 
@@ -146,7 +166,7 @@ QVector<server_type> AOApplication::read_serverlist_txt()
   return f_server_list;
 }
 
-QString AOApplication::read_design_ini(QString p_identifier, QString p_design_path)
+QString TextFileHandler::read_design_ini(QString p_identifier, QString p_design_path)
 {
   QSettings settings(p_design_path, QSettings::IniFormat);
   QVariant value = settings.value(p_identifier);
@@ -157,7 +177,7 @@ QString AOApplication::read_design_ini(QString p_identifier, QString p_design_pa
   }
 }
 
-QPoint AOApplication::get_button_spacing(QString p_identifier, QString p_file)
+QPoint TextFileHandler::get_button_spacing(QString p_identifier, QString p_file)
 {
   QString design_ini_path = get_theme_path(p_file);
   QString default_path = get_default_theme_path(p_file);
@@ -187,7 +207,7 @@ QPoint AOApplication::get_button_spacing(QString p_identifier, QString p_file)
   return return_value;
 }
 
-pos_size_type AOApplication::get_element_dimensions(QString p_identifier, QString p_file)
+pos_size_type TextFileHandler::get_element_dimensions(QString p_identifier, QString p_file)
 {
   QString design_ini_path = get_theme_path(p_file);
   QString default_path = get_default_theme_path(p_file);
@@ -221,7 +241,7 @@ pos_size_type AOApplication::get_element_dimensions(QString p_identifier, QStrin
   return return_value;
 }
 
-int AOApplication::get_font_size(QString p_identifier, QString p_file)
+int TextFileHandler::get_font_size(QString p_identifier, QString p_file)
 {
   QString design_ini_path = get_theme_path(p_file);
   QString default_path = get_default_theme_path(p_file);
@@ -238,7 +258,7 @@ int AOApplication::get_font_size(QString p_identifier, QString p_file)
   return f_result.toInt();
 }
 
-QColor AOApplication::get_color(QString p_identifier, QString p_file)
+QColor TextFileHandler::get_color(QString p_identifier, QString p_file)
 {
   QString design_ini_path = get_theme_path(p_file);
   QString default_path = get_default_theme_path(p_file);
@@ -266,7 +286,7 @@ QColor AOApplication::get_color(QString p_identifier, QString p_file)
   return return_color;
 }
 
-QColor AOApplication::get_chat_color(QString p_identifier, QString p_chat)
+QColor TextFileHandler::get_chat_color(QString p_identifier, QString p_chat)
 {
   p_identifier = p_identifier.prepend("c");
   QString design_ini_path = get_base_path() + "misc/" + p_chat + "/config.ini";
@@ -294,7 +314,7 @@ QColor AOApplication::get_chat_color(QString p_identifier, QString p_chat)
   return return_color;
 }
 
-QString AOApplication::get_sfx(QString p_identifier)
+QString TextFileHandler::get_sfx(QString p_identifier)
 {
   QString design_ini_path = get_theme_path("courtroom_sounds.ini");
   QString default_path = get_default_theme_path("courtroom_sounds.ini");
@@ -315,7 +335,7 @@ QString AOApplication::get_sfx(QString p_identifier)
   return return_sfx;
 }
 
-QString AOApplication::get_sfx_suffix(QString sound_to_check)
+QString TextFileHandler::get_sfx_suffix(QString sound_to_check)
 {
     QString mp3_check = get_sounds_path(sound_to_check + ".mp3");
     QString opus_check = get_sounds_path(sound_to_check + ".opus");
@@ -330,7 +350,7 @@ QString AOApplication::get_sfx_suffix(QString sound_to_check)
     return sound_to_check + ".wav";
 }
 
-QString AOApplication::get_image_suffix(QString path_to_check)
+QString TextFileHandler::get_image_suffix(QString path_to_check)
 {
     QString apng_check = get_sounds_path(path_to_check + ".apng");
     if (file_exists(apng_check))
@@ -343,7 +363,7 @@ QString AOApplication::get_image_suffix(QString path_to_check)
 
 //returns whatever is to the right of "search_line =" within target_tag and terminator_tag, trimmed
 //returns the empty string if the search line couldnt be found
-QString AOApplication::read_char_ini(QString p_char, QString p_search_line, QString target_tag)
+QString TextFileHandler::read_char_ini(QString p_char, QString p_search_line, QString target_tag)
 {
   QSettings settings(get_character_path(p_char, "char.ini"), QSettings::IniFormat);
   settings.beginGroup(target_tag);
@@ -352,7 +372,7 @@ QString AOApplication::read_char_ini(QString p_char, QString p_search_line, QStr
   return value;
 }
 
-QString AOApplication::get_char_name(QString p_char)
+QString TextFileHandler::get_char_name(QString p_char)
 {
   QString f_result = read_char_ini(p_char, "name", "Options");
 
@@ -361,7 +381,7 @@ QString AOApplication::get_char_name(QString p_char)
   else return f_result;
 }
 
-QString AOApplication::get_showname(QString p_char)
+QString TextFileHandler::get_showname(QString p_char)
 {
   QString f_result = read_char_ini(p_char, "showname", "Options");
   QString f_needed = read_char_ini(p_char, "needs_showname", "Options");
@@ -373,7 +393,7 @@ QString AOApplication::get_showname(QString p_char)
   else return f_result;
 }
 
-QString AOApplication::get_char_side(QString p_char)
+QString TextFileHandler::get_char_side(QString p_char)
 {
   QString f_result = read_char_ini(p_char, "side", "Options");
 
@@ -382,7 +402,7 @@ QString AOApplication::get_char_side(QString p_char)
   else return f_result;
 }
 
-QString AOApplication::get_gender(QString p_char)
+QString TextFileHandler::get_gender(QString p_char)
 {
   QString f_result = read_char_ini(p_char, "gender", "Options");
 
@@ -391,7 +411,7 @@ QString AOApplication::get_gender(QString p_char)
   else return f_result;
 }
 
-QString AOApplication::get_chat(QString p_char)
+QString TextFileHandler::get_chat(QString p_char)
 {
   QString f_result = read_char_ini(p_char, "chat", "Options");
 
@@ -399,14 +419,14 @@ QString AOApplication::get_chat(QString p_char)
   return f_result;
 }
 
-QString AOApplication::get_char_shouts(QString p_char)
+QString TextFileHandler::get_char_shouts(QString p_char)
 {
   QString f_result = read_char_ini(p_char, "shouts", "Options");
 
   return f_result;
 }
 
-int AOApplication::get_preanim_duration(QString p_char, QString p_emote)
+int TextFileHandler::get_preanim_duration(QString p_char, QString p_emote)
 {
   QString f_result = read_char_ini(p_char, p_emote, "Time");
 
@@ -415,7 +435,7 @@ int AOApplication::get_preanim_duration(QString p_char, QString p_emote)
   else return f_result.toInt();
 }
 
-int AOApplication::get_ao2_preanim_duration(QString p_char, QString p_emote)
+int TextFileHandler::get_ao2_preanim_duration(QString p_char, QString p_emote)
 {
   QString f_result = read_char_ini(p_char, "%" + p_emote, "Time");
 
@@ -424,7 +444,7 @@ int AOApplication::get_ao2_preanim_duration(QString p_char, QString p_emote)
   else return f_result.toInt();
 }
 
-int AOApplication::get_emote_number(QString p_char)
+int TextFileHandler::get_emote_number(QString p_char)
 {
   QString f_result = read_char_ini(p_char, "number", "Emotions");
 
@@ -433,7 +453,7 @@ int AOApplication::get_emote_number(QString p_char)
   else return f_result.toInt();
 }
 
-QString AOApplication::get_emote_comment(QString p_char, int p_emote)
+QString TextFileHandler::get_emote_comment(QString p_char, int p_emote)
 {
   QString f_result = read_char_ini(p_char, QString::number(p_emote + 1), "Emotions");
 
@@ -447,7 +467,7 @@ QString AOApplication::get_emote_comment(QString p_char, int p_emote)
   else return result_contents.at(0);
 }
 
-QString AOApplication::get_pre_emote(QString p_char, int p_emote)
+QString TextFileHandler::get_pre_emote(QString p_char, int p_emote)
 {
   QString f_result = read_char_ini(p_char, QString::number(p_emote + 1), "Emotions");
 
@@ -461,7 +481,7 @@ QString AOApplication::get_pre_emote(QString p_char, int p_emote)
   else return result_contents.at(1);
 }
 
-QString AOApplication::get_emote(QString p_char, int p_emote)
+QString TextFileHandler::get_emote(QString p_char, int p_emote)
 {
   QString f_result = read_char_ini(p_char, QString::number(p_emote + 1), "Emotions");
 
@@ -475,7 +495,7 @@ QString AOApplication::get_emote(QString p_char, int p_emote)
   else return result_contents.at(2);
 }
 
-int AOApplication::get_emote_mod(QString p_char, int p_emote)
+int TextFileHandler::get_emote_mod(QString p_char, int p_emote)
 {
   QString f_result = read_char_ini(p_char, QString::number(p_emote + 1), "Emotions");
 
@@ -489,7 +509,7 @@ int AOApplication::get_emote_mod(QString p_char, int p_emote)
   else return result_contents.at(3).toInt();
 }
 
-int AOApplication::get_desk_mod(QString p_char, int p_emote)
+int TextFileHandler::get_desk_mod(QString p_char, int p_emote)
 {
   QString f_result = read_char_ini(p_char, QString::number(p_emote + 1), "Emotions");
 
@@ -505,7 +525,7 @@ int AOApplication::get_desk_mod(QString p_char, int p_emote)
   else return string_result.toInt();
 }
 
-QString AOApplication::get_sfx_name(QString p_char, int p_emote)
+QString TextFileHandler::get_sfx_name(QString p_char, int p_emote)
 {
   QString f_result = read_char_ini(p_char, QString::number(p_emote + 1), "SoundN");
 
@@ -514,7 +534,7 @@ QString AOApplication::get_sfx_name(QString p_char, int p_emote)
   else return f_result;
 }
 
-int AOApplication::get_sfx_delay(QString p_char, int p_emote)
+int TextFileHandler::get_sfx_delay(QString p_char, int p_emote)
 {
   QString f_result = read_char_ini(p_char, QString::number(p_emote + 1), "SoundT");
 
@@ -523,7 +543,7 @@ int AOApplication::get_sfx_delay(QString p_char, int p_emote)
   else return f_result.toInt();
 }
 
-int AOApplication::get_text_delay(QString p_char, QString p_emote)
+int TextFileHandler::get_text_delay(QString p_char, QString p_emote)
 {
   QString f_result = read_char_ini(p_char, p_emote, "TextDelay");
 
@@ -532,7 +552,7 @@ int AOApplication::get_text_delay(QString p_char, QString p_emote)
   else return f_result.toInt();
 }
 
-QString AOApplication::get_custom_realization(QString p_char)
+QString TextFileHandler::get_custom_realization(QString p_char)
 {
   QString f_result = read_char_ini(p_char, "realization", "Options");
 
@@ -541,61 +561,61 @@ QString AOApplication::get_custom_realization(QString p_char)
   else return f_result;
 }
 
-bool AOApplication::get_blank_blip()
+bool TextFileHandler::get_blank_blip()
 {
     QString result = configini->value("blank_blip", "false").value<QString>();
     return result.startsWith("true");
 }
 
-bool AOApplication::is_discord_enabled()
+bool TextFileHandler::is_discord_enabled()
 {
     QString result = configini->value("discord", "true").value<QString>();
     return result.startsWith("true");
 }
 
-bool AOApplication::get_casing_enabled()
+bool TextFileHandler::get_casing_enabled()
 {
     QString result = configini->value("casing_enabled", "false").value<QString>();
     return result.startsWith("true");
 }
 
-bool AOApplication::get_casing_defence_enabled()
+bool TextFileHandler::get_casing_defence_enabled()
 {
     QString result = configini->value("casing_defence_enabled", "false").value<QString>();
     return result.startsWith("true");
 }
 
-bool AOApplication::get_casing_prosecution_enabled()
+bool TextFileHandler::get_casing_prosecution_enabled()
 {
     QString result = configini->value("casing_prosecution_enabled", "false").value<QString>();
     return result.startsWith("true");
 }
 
-bool AOApplication::get_casing_judge_enabled()
+bool TextFileHandler::get_casing_judge_enabled()
 {
     QString result = configini->value("casing_judge_enabled", "false").value<QString>();
     return result.startsWith("true");
 }
 
-bool AOApplication::get_casing_juror_enabled()
+bool TextFileHandler::get_casing_juror_enabled()
 {
     QString result = configini->value("casing_juror_enabled", "false").value<QString>();
     return result.startsWith("true");
 }
 
-bool AOApplication::get_casing_steno_enabled()
+bool TextFileHandler::get_casing_steno_enabled()
 {
   QString result = configini->value("casing_steno_enabled", "false").value<QString>();
   return result.startsWith("true");
 }
 
-bool AOApplication::get_casing_cm_enabled()
+bool TextFileHandler::get_casing_cm_enabled()
 {
     QString result = configini->value("casing_cm_enabled", "false").value<QString>();
     return result.startsWith("true");
 }
 
-QString AOApplication::get_casing_can_host_cases()
+QString TextFileHandler::get_casing_can_host_cases()
 {
   QString result = configini->value("casing_can_host_cases", "Turnabout Check Your Settings").value<QString>();
   return result;

--- a/text_file_functions.h
+++ b/text_file_functions.h
@@ -9,5 +9,209 @@
 #include <QDebug>
 #include <QColor>
 #include <QSettings>
+#include <QDir>
+#include <QStandardPaths>
+#include <QRegExp>
+
+/// A singleton designed to handle the config.ini file.
+/// Call upon it with TextFileHandler::getInstance().
+class TextFileHandler
+{
+  private:
+    TextFileHandler() {}
+
+    // Isn't this ironic? To eliminate pointers to the AO app,
+    // I must still keep one.
+    AOApplication *ao_app;
+    QSettings *configini;
+
+    QString current_theme = "default";
+
+  public:
+    static TextFileHandler& getInstance();
+    TextFileHandler(TextFileHandler const&) = delete;
+    void operator=(TextFileHandler const&) = delete;
+
+    // Gives the pointer to the AO app to it.
+    // Should be called right as the AO app itself is created.
+    void give_ao_app_pointer(AOApplication *p_ao_app);
+
+    // Gets the IP of the master server.
+    QString get_master_server();
+
+    //Reads the theme from config.ini and loads it into the current_theme variable
+    void read_theme();
+
+    //Returns the value of ooc_name in config.ini
+    QString get_ooc_name();
+
+    //Returns the blip rate from config.ini
+    int read_blip_rate();
+
+    //Returns true if blank blips is enabled in config.ini and false otherwise
+    bool get_blank_blip();
+
+    //Returns the value of default_music in config.ini
+    int get_default_music();
+
+    //Returns the value of default_sfx in config.ini
+    int get_default_sfx();
+
+    //Returns the value of default_blip in config.ini
+    int get_default_blip();
+
+    // Returns the value of whether Discord should be enabled on startup
+    // from the config.ini.
+    bool is_discord_enabled();
+
+    // Returns the value of the maximum amount of lines the IC chatlog
+    // may contain, from config.ini.
+    int get_max_log_size();
+
+    // Returns whether the log should go upwards (new behaviour)
+    // or downwards (vanilla behaviour).
+    bool get_log_goes_downwards();
+
+    // Returns the username the user may have set in config.ini.
+    QString get_default_username();
+
+    // Returns the audio device used for the client.
+    QString get_audio_output_device();
+
+    // Returns whether the user would like to have custom shownames on by default.
+    bool get_showname_enabled_by_default();
+
+    //Returns the list of words in callwords.ini
+    QStringList get_call_words();
+
+    //Appends the argument string to serverlist.txt
+    void write_to_serverlist_txt(QString p_line);
+
+    //Returns the contents of serverlist.txt
+    QVector<server_type> read_serverlist_txt();
+
+    //Returns the value of p_identifier in the design.ini file in p_design_path
+    QString read_design_ini(QString p_identifier, QString p_design_path);
+
+    //Returns the coordinates of widget with p_identifier from p_file
+    QPoint get_button_spacing(QString p_identifier, QString p_file);
+
+    //Returns the dimensions of widget with specified identifier from p_file
+    pos_size_type get_element_dimensions(QString p_identifier, QString p_file);
+
+    //Returns the value of font_size with p_identifier from p_file
+    int get_font_size(QString p_identifier, QString p_file);
+
+    //Returns the color with p_identifier from p_file
+    QColor get_color(QString p_identifier, QString p_file);
+
+    // Returns the colour from the misc folder.
+    QColor get_chat_color(QString p_identifier, QString p_chat);
+
+    //Returns the sfx with p_identifier from sounds.ini in the current theme path
+    QString get_sfx(QString p_identifier);
+
+    //Figure out if we can opus this or if we should fall back to wav
+    QString get_sfx_suffix(QString sound_to_check);
+
+    // Can we use APNG for this? If not, fall back to a gif.
+    QString get_image_suffix(QString path_to_check);
+
+    //Returns the value of p_search_line within target_tag and terminator_tag
+    QString read_char_ini(QString p_char, QString p_search_line, QString target_tag);
+
+    //Returns the side of the p_char character from that characters ini file
+    QString get_char_side(QString p_char);
+
+    //Returns the showname from the ini of p_char
+    QString get_showname(QString p_char);
+
+    //Returns the value of chat from the specific p_char's ini file
+    QString get_chat(QString p_char);
+
+    //Returns the value of shouts from the specified p_char's ini file
+    QString get_char_shouts(QString p_char);
+
+    //Returns the preanim duration of p_char's p_emote
+    int get_preanim_duration(QString p_char, QString p_emote);
+
+    //Same as above, but only returns if it has a % in front(refer to Preanims section in the manual)
+    int get_ao2_preanim_duration(QString p_char, QString p_emote);
+
+    //Not in use
+    int get_text_delay(QString p_char, QString p_emote);
+
+    // Returns the custom realisation used by the character.
+    QString get_custom_realization(QString p_char);
+
+    //Returns the name of p_char
+    QString get_char_name(QString p_char);
+
+    //Returns the total amount of emotes of p_char
+    int get_emote_number(QString p_char);
+
+    //Returns the emote comment of p_char's p_emote
+    QString get_emote_comment(QString p_char, int p_emote);
+
+    //Returns the base name of p_char's p_emote
+    QString get_emote(QString p_char, int p_emote);
+
+    //Returns the preanimation name of p_char's p_emote
+    QString get_pre_emote(QString p_char, int p_emote);
+
+    //Returns the sfx of p_char's p_emote
+    QString get_sfx_name(QString p_char, int p_emote);
+
+    //Not in use
+    int get_sfx_delay(QString p_char, int p_emote);
+
+    //Returns the modifier for p_char's p_emote
+    int get_emote_mod(QString p_char, int p_emote);
+
+    //Returns the desk modifier for p_char's p_emote
+    int get_desk_mod(QString p_char, int p_emote);
+
+    //Returns p_char's gender
+    QString get_gender(QString p_char);
+
+    // Returns if the user has casing alerts enabled.
+    bool get_casing_enabled();
+
+    // Returns if the user wants to get alerts for the defence role.
+    bool get_casing_defence_enabled();
+
+    // Same for prosecution.
+    bool get_casing_prosecution_enabled();
+
+    // Same for judge.
+    bool get_casing_judge_enabled();
+
+    // Same for juror.
+    bool get_casing_juror_enabled();
+
+    // Same for steno.
+    bool get_casing_steno_enabled();
+
+    // Same for CM.
+    bool get_casing_cm_enabled();
+
+    // Get the message for the CM for casing alerts.
+    QString get_casing_can_host_cases();
+
+    // These below are all implemented in path_functions.cpp.
+
+    QString get_base_path();
+    QString get_data_path();
+    QString get_theme_path(QString p_file);
+    QString get_default_theme_path(QString p_file);
+    QString get_custom_theme_path(QString p_theme, QString p_file);
+    QString get_character_path(QString p_char, QString p_file);
+    QString get_sounds_path(QString p_file);
+    QString get_music_path(QString p_song);
+    QString get_background_path(QString p_file);
+    QString get_default_background_path(QString p_file);
+    QString get_evidence_path(QString p_file);
+    QString get_case_sensitive_path(QString p_file);
+};
 
 #endif // TEXT_FILE_FUNCTIONS_H

--- a/text_file_functions.h
+++ b/text_file_functions.h
@@ -23,7 +23,6 @@ class TextFileHandler
     // Isn't this ironic? To eliminate pointers to the AO app,
     // I must still keep one.
     AOApplication *ao_app;
-    QSettings *configini;
 
     QString current_theme = "default";
 
@@ -31,6 +30,8 @@ class TextFileHandler
     static TextFileHandler& getInstance();
     TextFileHandler(TextFileHandler const&) = delete;
     void operator=(TextFileHandler const&) = delete;
+
+    QSettings *configini;
 
     // Gives the pointer to the AO app to it.
     // Should be called right as the AO app itself is created.
@@ -41,6 +42,10 @@ class TextFileHandler
 
     //Reads the theme from config.ini and loads it into the current_theme variable
     void read_theme();
+
+    // Since read_theme() now only manipulates this object only, in return, a new get_current_theme() function
+    // is included here if you need the current theme for some reason.
+    QString get_current_theme();
 
     //Returns the value of ooc_name in config.ini
     QString get_ooc_name();

--- a/text_file_functions.h
+++ b/text_file_functions.h
@@ -14,11 +14,13 @@
 #include <QRegExp>
 
 /// A singleton designed to handle the config.ini file.
-/// Call upon it with TextFileHandler::getInstance().
+/// Call upon it with TextFileHandler::getInstance()->
 class TextFileHandler
 {
   private:
     TextFileHandler() {}
+
+    static TextFileHandler* singleton;
 
     // Isn't this ironic? To eliminate pointers to the AO app,
     // I must still keep one.
@@ -27,15 +29,12 @@ class TextFileHandler
     QString current_theme = "default";
 
   public:
-    static TextFileHandler& getInstance();
+    static void create_instance(AOApplication *p_ao_app);
+    static TextFileHandler* get_instance();
     TextFileHandler(TextFileHandler const&) = delete;
     void operator=(TextFileHandler const&) = delete;
 
     QSettings *configini;
-
-    // Gives the pointer to the AO app to it.
-    // Should be called right as the AO app itself is created.
-    void give_ao_app_pointer(AOApplication *p_ao_app);
 
     // Gets the IP of the master server.
     QString get_master_server();


### PR DESCRIPTION
This pull request removes access to the AO app through a pointer from most objects, limiting it mostly just to itself, `Courtroom`, and `Lobby`.

In most cases, these accesses are instead redirected to a new singleton class, `TextFileHandler`, which inherits every function that accesses a file (be it `config.ini`, `callwords.ini` or any other text files) from the AO app.

In the rest, mostly at `Courtroom` and `Lobby`, direct accesses to the AO app are replaced with signal emitting, and the AO app connects these signals after the creation of `Lobby` or `Courtroom` to its slots as needed.

Further culling is definitely possible, but probably should be done later, when the UI elements are separated from the game logic in `Courtroom` and `Lobby`.