### PR TITLE
Fix the no sound on Windows at start bug.

### DIFF
--- a/aoblipplayer.cpp
+++ b/aoblipplayer.cpp
@@ -29,7 +29,7 @@ void AOBlipPlayer::blip_tick()
 
   HSTREAM f_stream = m_stream_list[f_cycle];
 
-  if (ao_app->get_audio_output_device() != "Default")
+  if (ao_app->get_audio_output_device() != "default")
     BASS_ChannelSetDevice(f_stream, BASS_GetDevice());
   BASS_ChannelPlay(f_stream, false);
 }

--- a/aomusicplayer.cpp
+++ b/aomusicplayer.cpp
@@ -21,7 +21,7 @@ void AOMusicPlayer::play(QString p_song)
 
   this->set_volume(m_volume);
 
-  if (ao_app->get_audio_output_device() != "Default")
+  if (ao_app->get_audio_output_device() != "default")
     BASS_ChannelSetDevice(m_stream, BASS_GetDevice());
   BASS_ChannelPlay(m_stream, false);
 }

--- a/aooptionsdialog.cpp
+++ b/aooptionsdialog.cpp
@@ -224,7 +224,7 @@ AOOptionsDialog::AOOptionsDialog(QWidget *parent, AOApplication *p_ao_app) : QDi
 
     if (needs_default_audiodev())
     {
-        ui_audio_device_combobox->addItem("Default");
+        ui_audio_device_combobox->addItem("default");
     }
 
     for (a = 0; BASS_GetDeviceInfo(a, &info); a++)

--- a/aosfxplayer.cpp
+++ b/aosfxplayer.cpp
@@ -31,7 +31,7 @@ void AOSfxPlayer::play(QString p_sfx, QString p_char, QString shout)
 
   set_volume(m_volume);
 
-  if (ao_app->get_audio_output_device() != "Default")
+  if (ao_app->get_audio_output_device() != "default")
     BASS_ChannelSetDevice(m_stream, BASS_GetDevice());
   BASS_ChannelPlay(m_stream, false);
 }

--- a/courtroom.cpp
+++ b/courtroom.cpp
@@ -9,7 +9,7 @@ Courtroom::Courtroom(AOApplication *p_ao_app) : QMainWindow()
   int a = 0;
   BASS_DEVICEINFO info;
 
-  if (ao_app->get_audio_output_device() == "Default")
+  if (ao_app->get_audio_output_device() == "default")
   {
       BASS_Init(-1, 48000, BASS_DEVICE_LATENCY, nullptr, nullptr);
       load_bass_opus_plugin();


### PR DESCRIPTION
Hoooo boy, this is a thing.

So setting the default audio output device isn't really hard either on Windows or Linux. You just give the `BASS_Init` the audio device of `-1`, system default. The trick is in `BASS_GetDeviceInfo`.

Said function is used a few times to detect which audio output device the user has chosen, and is also used in the `AOOptionsDialog` to list the devices to the user. But it doesn't have a `-1` device, it starts counting from `0`. `0` is no sound / device, and afterwards come the real devices. Except on Linux, where device `1` is system default, which Windows does not have.

So to avoid this problem, I brought in a `Default` audio device for Windows users, manually inserting it to the available devices in the Options dialog, and manually checking for it during the playing of sounds. But this is not the same as the Linux `default` because of case sensitivity.

So all in all, I lowercased all `Default`s to `default`, as the Linux `default` is functionally equivalent to the audio device of `-1`, too, anyway.