### PR TITLE
AO 2.6 bugfixes.

### DIFF
--- a/courtroom.cpp
+++ b/courtroom.cpp
@@ -3294,7 +3294,6 @@ void Courtroom::on_reload_theme_clicked()
 void Courtroom::on_back_to_lobby_clicked()
 {
   ao_app->construct_lobby();
-  ao_app->w_lobby->list_servers();
   ao_app->destruct_courtroom();
 }
 

--- a/lobby.cpp
+++ b/lobby.cpp
@@ -52,6 +52,8 @@ Lobby::Lobby(AOApplication *p_ao_app) : QMainWindow()
 
   ui_connect->setEnabled(false);
 
+  list_servers();
+
   set_widgets();
 }
 

--- a/path_functions.cpp
+++ b/path_functions.cpp
@@ -31,7 +31,7 @@ QString AOApplication::get_base_path()
     base_path = external_storage + "/AO2/";
   }
 #else
-  base_path = QDir::currentPath() + "/base/";
+  base_path = applicationDirPath() + "/base/";
 #endif
 
   return base_path;

--- a/text_file_functions.cpp
+++ b/text_file_functions.cpp
@@ -50,7 +50,7 @@ bool AOApplication::get_log_goes_downwards()
 
 bool AOApplication::get_showname_enabled_by_default()
 {
-  QString result = configini->value("show_custom_shownames", "false").value<QString>();
+  QString result = configini->value("show_custom_shownames", "true").value<QString>();
   return result.startsWith("true");
 }
 


### PR DESCRIPTION
- The `base/` folder's path is now determined based on where the
executable was executed, not where its workspace is. This fixes #42 .
- Showing custom shownames is now assumed to be `true` by default,
unless the `config.ini` says otherwise. This fixes #45 .
- The Lobby's listing of servers has now been moved into its constructor
(previously only specifically called by the "Back to Lobby" button).
This makes it list servers even if the user was kicked, banned, or left
due to timeout. This fixes #43 .