### PR TITLE
Theme, interface, and pointer magic fixes.

### DIFF
--- a/aoapplication.cpp
+++ b/aoapplication.cpp
@@ -57,6 +57,7 @@ void AOApplication::destruct_lobby()
   }
 
   delete w_lobby;
+  w_lobby = nullptr;
   lobby_constructed = false;
 }
 
@@ -86,6 +87,7 @@ void AOApplication::destruct_courtroom()
   }
 
   delete w_courtroom;
+  w_courtroom = nullptr;
   courtroom_constructed = false;
 }
 
@@ -157,7 +159,7 @@ void AOApplication::ms_connect_finished(bool connected, bool will_retry)
   {
     if (will_retry)
     {
-      if (w_lobby != nullptr)
+      if (lobby_constructed)
         w_lobby->append_error("Error connecting to master server. Will try again in "
                             + QString::number(net_manager->ms_reconnect_delay_ms / 1000.f) + " seconds.");
     }

--- a/base/themes/default/courtroom_design.ini
+++ b/base/themes/default/courtroom_design.ini
@@ -72,12 +72,12 @@ blip_slider = 326, 648, 140, 16
 ; page. Having either number lower than 49 crashes the client when you try to
 ; pick a character. If you want X columns and Y rows, you would change it to
 ; 49X, 49Y (ie. 490, 147 if you want 10 columns and 3 rows)
-emotes = 10, 342, 490, 98
+emotes = 5, 342, 490, 98
 emote_button_spacing = 9, 9
 
 ; Page togglers for emotes
-emote_left = 373, 475, 17, 17
-emote_right = 392, 475, 17, 17
+emote_left = 5, 438, 17, 17
+emote_right = 470, 438, 17, 17
 
 ; Emote dropdown/emote names - Change '125' to make it longer/shorter and
 ; display the full emote name or truncate it based on length
@@ -234,3 +234,10 @@ area_rp_color = 200, 52, 252
 area_gaming_color = 55, 255, 255
 area_locked_color = 165, 43, 43
 
+; These two are casing-related inputs.
+; "casing" is a tickbox that toggles whether you should receive case alerts or
+; not (you can set your preferences, and its default value, in the Settings!)
+; "casing_button" is an interface to help you announce a case (you have to be
+; a CM first to be able to announce cases).
+casing = 200, 560, 80, 21
+casing_button = 173, 637, 60, 23

--- a/courtroom.cpp
+++ b/courtroom.cpp
@@ -2585,6 +2585,32 @@ void Courtroom::set_hp_bar(int p_bar, int p_state)
   }
 }
 
+void Courtroom::toggle_judge_buttons(bool is_on)
+{
+  if (is_on)
+  {
+    ui_witness_testimony->show();
+    ui_cross_examination->show();
+    ui_guilty->show();
+    ui_not_guilty->show();
+    ui_defense_minus->show();
+    ui_defense_plus->show();
+    ui_prosecution_minus->show();
+    ui_prosecution_plus->show();
+  }
+  else
+  {
+    ui_witness_testimony->hide();
+    ui_cross_examination->hide();
+    ui_guilty->hide();
+    ui_not_guilty->hide();
+    ui_defense_minus->hide();
+    ui_defense_plus->hide();
+    ui_prosecution_minus->hide();
+    ui_prosecution_plus->hide();
+  }
+}
+
 void Courtroom::mod_called(QString p_ip)
 {
   ui_server_chatlog->append(p_ip);
@@ -2621,27 +2647,13 @@ void Courtroom::on_ooc_return_pressed()
 
   if (ooc_message.startsWith("/pos"))
   {
-    if (ooc_message.startsWith("/pos jud"))
+    if (ooc_message == "/pos jud")
     {
-      ui_witness_testimony->show();
-      ui_cross_examination->show();
-      ui_guilty->show();
-      ui_not_guilty->show();
-      ui_defense_minus->show();
-      ui_defense_plus->show();
-      ui_prosecution_minus->show();
-      ui_prosecution_plus->show();
+      toggle_judge_buttons(true);
     }
     else
     {
-      ui_witness_testimony->hide();
-      ui_cross_examination->hide();
-      ui_guilty->hide();
-      ui_not_guilty->hide();
-      ui_defense_minus->hide();
-      ui_defense_plus->hide();
-      ui_prosecution_minus->hide();
-      ui_prosecution_plus->hide();
+      toggle_judge_buttons(false);
     }
   }
   else if (ooc_message.startsWith("/login"))
@@ -2891,6 +2903,8 @@ void Courtroom::on_pos_dropdown_changed(int p_index)
   if (p_index < 0 || p_index > 5)
     return;
 
+  toggle_judge_buttons(false);
+
   QString f_pos;
 
   switch (p_index)
@@ -2906,6 +2920,7 @@ void Courtroom::on_pos_dropdown_changed(int p_index)
     break;
   case 3:
     f_pos = "jud";
+    toggle_judge_buttons(true);
     break;
   case 4:
     f_pos = "hld";

--- a/courtroom.h
+++ b/courtroom.h
@@ -204,6 +204,9 @@ public:
   //state is an number between 0 and 10 inclusive
   void set_hp_bar(int p_bar, int p_state);
 
+  //Toggles the judge buttons, whether they should appear or not.
+  void toggle_judge_buttons(bool is_on);
+
   void announce_case(QString title, bool def, bool pro, bool jud, bool jur, bool steno);
 
   void check_connection_received();


### PR DESCRIPTION
This PR fixes three issues:
- It places down the emote left & right buttons in an area where it is accessible, and places down the casing related buttons (once again fixing #41 ),
- It reworks the judge button logic, so now using the position dropdown or the OOC commands both work, fixing #47 
   - (It also fixes the issue(?) where you could type `/pos juddddd` or variants to get the (still usable) judge buttons in positions other than the judge position.)
- It fixes the crash when the master server connection is lost during game (actually fixing #12 ).
   - This came about because though we destroyed the Lobby or the Courtroom, we never set their pointers to a null-pointer -- so a check of `w_lobby != nullptr` failed, because it still pointed to (trash) data.
   - I also made the destruction of the Courtroom / Lobby set their pointers to `nullptr` now, so a check like above could be used freely.