### PR TITLE
Add double quotes around ${ROOT_DIR}

### DIFF
--- a/scripts/configure_ubuntu.sh
+++ b/scripts/configure_ubuntu.sh
@@ -7,7 +7,7 @@ set -eu
 
 ROOT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )/"
 
-cd ${ROOT_DIR}
+cd "${ROOT_DIR}"
 
 #need some openGL stuff
 sudo apt install libgl1-mesa-dev


### PR DESCRIPTION
Without this the script fails with `./configure_ubuntu.sh: line 10: cd: too many arguments` if there's any space in the path of the root folder.