### PR TITLE
Add Spanish translation

### DIFF
--- a/resource/translations/ao_es.ts
+++ b/resource/translations/ao_es.ts
@@ -1,0 +1,811 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="es">
+<context>
+    <name>AOApplication</name>
+    <message>
+        <location filename="../../src/aoapplication.cpp" line="138"/>
+        <source>Disconnected from server.</source>
+        <translation>Desconectado del servidor.</translation>
+    </message>
+    <message>
+        <location filename="../../src/aoapplication.cpp" line="163"/>
+        <source>Error connecting to master server. Will try again in %1 seconds.</source>
+        <translation>Error al conectarse a la lista de servidores. Se intentará nuevamente en %1 segundos.</translation>
+    </message>
+    <message>
+        <location filename="../../src/aoapplication.cpp" line="167"/>
+        <source>There was an error connecting to the master server.
+We deploy multiple master servers to mitigate any possible downtime, but the client appears to have exhausted all possible methods of finding and connecting to one.
+Please check your Internet connection and firewall, and please try again.</source>
+        <translatorcomment>I translated master servers as &quot;lista de servidores&quot; because literally nobody will understand if i make the literal translation &quot;servidor maestro&quot;. And in the end a master server is just a list of servers. Also removed the part about having multiple master servers, i just don&apos;t think the average user will understand this even if i do a good translation.</translatorcomment>
+        <translation>Hubo un error al obtener la lista de servidores. Verifique su conexión a Internet y firewall, y vuelva a intentarlo.</translation>
+    </message>
+    <message>
+        <location filename="../../src/packet_distribution.cpp" line="106"/>
+        <source>Outdated version! Your version: %1
+Please go to aceattorneyonline.com to update.</source>
+        <translation>¡Versión desactualizada! Su versión: %1 Vaya a aceattorneyonline.com para actualizar.</translation>
+    </message>
+    <message>
+        <location filename="../../src/packet_distribution.cpp" line="114"/>
+        <source>You have been exiled from AO.
+Have a nice day.</source>
+        <translation>Has sido exiliado de AO.
+Que tengas un buen día.</translation>
+    </message>
+    <message>
+        <location filename="../../src/packet_distribution.cpp" line="249"/>
+        <source>Attorney Online 2</source>
+        <translation>Attorney Online 2</translation>
+    </message>
+    <message>
+        <location filename="../../src/packet_distribution.cpp" line="275"/>
+        <source>Loading</source>
+        <translation>Cargando</translation>
+    </message>
+    <message>
+        <location filename="../../src/packet_distribution.cpp" line="363"/>
+        <source>Loading evidence:
+%1/%2</source>
+        <translation>Cargando evidencia:
+%1/%2</translation>
+    </message>
+    <message>
+        <location filename="../../src/packet_distribution.cpp" line="395"/>
+        <location filename="../../src/packet_distribution.cpp" line="490"/>
+        <source>Loading music:
+%1/%2</source>
+        <translation>Cargando música:
+%1/%2</translation>
+    </message>
+    <message>
+        <location filename="../../src/packet_distribution.cpp" line="467"/>
+        <source>Loading chars:
+%1/%2</source>
+        <translation>Cargando personajes:
+%1/%2</translation>
+    </message>
+    <message>
+        <location filename="../../src/packet_distribution.cpp" line="642"/>
+        <source>You have been kicked from the server.
+Reason: </source>
+        <translation>Has sido expulsado del servidor.
+Razón: </translation>
+    </message>
+    <message>
+        <location filename="../../src/packet_distribution.cpp" line="659"/>
+        <source>You are banned on this server.
+Reason: </source>
+        <translation>Has sido baneado en este servidor.
+Razón: </translation>
+    </message>
+</context>
+<context>
+    <name>AOCaseAnnouncerDialog</name>
+    <message>
+        <location filename="../../src/aocaseannouncerdialog.cpp" line="9"/>
+        <source>Case Announcer</source>
+        <translation>Anunciar caso</translation>
+    </message>
+    <message>
+        <location filename="../../src/aocaseannouncerdialog.cpp" line="38"/>
+        <source>Case title:</source>
+        <translation>Título del caso:</translation>
+    </message>
+    <message>
+        <location filename="../../src/aocaseannouncerdialog.cpp" line="48"/>
+        <source>Defense needed</source>
+        <translation>Se necesita defensa</translation>
+    </message>
+    <message>
+        <location filename="../../src/aocaseannouncerdialog.cpp" line="50"/>
+        <source>Prosecution needed</source>
+        <translation>Se necesita fiscal</translation>
+    </message>
+    <message>
+        <location filename="../../src/aocaseannouncerdialog.cpp" line="52"/>
+        <source>Judge needed</source>
+        <translation>Se necesita juez</translation>
+    </message>
+    <message>
+        <location filename="../../src/aocaseannouncerdialog.cpp" line="54"/>
+        <source>Jurors needed</source>
+        <translation>Se necesita jurado</translation>
+    </message>
+    <message>
+        <location filename="../../src/aocaseannouncerdialog.cpp" line="56"/>
+        <source>Stenographer needed</source>
+        <translation>Se necesita taquígrafo</translation>
+    </message>
+</context>
+<context>
+    <name>AOOptionsDialog</name>
+    <message>
+        <location filename="../../src/aooptionsdialog.cpp" line="11"/>
+        <source>Settings</source>
+        <translation>Ajustes</translation>
+    </message>
+    <message>
+        <location filename="../../src/aooptionsdialog.cpp" line="40"/>
+        <source>Gameplay</source>
+        <translation>Jugabilidad</translation>
+    </message>
+    <message>
+        <location filename="../../src/aooptionsdialog.cpp" line="51"/>
+        <source>Theme:</source>
+        <translation>Tema visual:</translation>
+    </message>
+    <message>
+        <location filename="../../src/aooptionsdialog.cpp" line="52"/>
+        <source>Sets the theme used in-game. If the new theme changes the lobby&apos;s look as well, you&apos;ll need to reload the lobby for the changes to take effect, such as by joining a server and leaving it.</source>
+        <translation>Establece el tema visual utilizado en el juego. Si el nuevo tema también cambia el aspecto del lobby, deberá volver a cargar el lobby para que los cambios surtan efecto, como unirse a un servidor y volver al lobby.</translation>
+    </message>
+    <message>
+        <location filename="../../src/aooptionsdialog.cpp" line="81"/>
+        <source>Log goes downwards:</source>
+        <translation>Invertir historial IC:</translation>
+    </message>
+    <message>
+        <location filename="../../src/aooptionsdialog.cpp" line="82"/>
+        <source>If ticked, new messages will appear at the bottom (like the OOC chatlog). The traditional (AO1) behaviour is equivalent to this being unticked.</source>
+        <translation>Si está marcado, los nuevos mensajes aparecerán en la parte inferior (como el chat OOC).</translation>
+    </message>
+    <message>
+        <location filename="../../src/aooptionsdialog.cpp" line="94"/>
+        <source>Log length:</source>
+        <translation>Longitud del historial:</translation>
+    </message>
+    <message>
+        <location filename="../../src/aooptionsdialog.cpp" line="95"/>
+        <source>The amount of messages the IC chatlog will keep before deleting older messages. A value of 0 or below counts as &apos;infinite&apos;.</source>
+        <translation>La cantidad de mensajes que mantendrá el historial del chat IC antes de eliminar mensajes más antiguos. 0 significa &apos;infinito&apos;.</translation>
+    </message>
+    <message>
+        <location filename="../../src/aooptionsdialog.cpp" line="113"/>
+        <source>Default username:</source>
+        <translation>Usuario predeterminado:</translation>
+    </message>
+    <message>
+        <location filename="../../src/aooptionsdialog.cpp" line="114"/>
+        <source>Your OOC name will be automatically set to this value when you join a server.</source>
+        <translation>Su nombre OOC se establecerá automáticamente a este cuando se una a un servidor.</translation>
+    </message>
+    <message>
+        <location filename="../../src/aooptionsdialog.cpp" line="126"/>
+        <source>Custom shownames:</source>
+        <translation>Mostrar nombres:</translation>
+    </message>
+    <message>
+        <location filename="../../src/aooptionsdialog.cpp" line="127"/>
+        <source>Gives the default value for the in-game &apos;Custom shownames&apos; tickbox, which in turn determines whether the client should display custom in-character names.</source>
+        <translation>Activa la casilla &apos;Mostrar nombres&apos; de forma predeterminada en el juego, que a su vez determina si el cliente debe mostrar nombres personalizados en los personajes.</translation>
+    </message>
+    <message>
+        <location filename="../../src/aooptionsdialog.cpp" line="145"/>
+        <source>Backup MS:</source>
+        <translation>MS de respaldo:</translation>
+    </message>
+    <message>
+        <location filename="../../src/aooptionsdialog.cpp" line="146"/>
+        <source>If the built-in server lookups fail, the game will try the address given here and use it as a backup master server address.</source>
+        <translation>Si la lista de servidores predeterminada falla, el juego probará la dirección proporcionada aquí.</translation>
+    </message>
+    <message>
+        <location filename="../../src/aooptionsdialog.cpp" line="158"/>
+        <source>Discord:</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../../src/aooptionsdialog.cpp" line="159"/>
+        <source>Allows others on Discord to see what server you are in, what character are you playing, and how long you have been playing for.</source>
+        <translation>Permite a otros en Discord ver en qué servidor estás, qué personaje juegas y cuánto tiempo has estado jugando.</translation>
+    </message>
+    <message>
+        <location filename="../../src/aooptionsdialog.cpp" line="171"/>
+        <source>Language:</source>
+        <translation>Idioma:</translation>
+    </message>
+    <message>
+        <location filename="../../src/aooptionsdialog.cpp" line="172"/>
+        <source>Sets the language if you don&apos;t want to use your system language.</source>
+        <translation>Establece el idioma si no desea utilizar el idioma de su sistema.</translation>
+    </message>
+    <message>
+        <location filename="../../src/aooptionsdialog.cpp" line="184"/>
+        <source>Callwords</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../../src/aooptionsdialog.cpp" line="209"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;Enter as many callwords as you would like. These are case insensitive. Make sure to leave every callword in its own line!&lt;br&gt;Do not leave a line with a space at the end -- you will be alerted everytime someone uses a space in their messages.&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;Ingrese tantas palabras de llamada como desee.&lt;br&gt;Esto no distingue entre mayúsculas y minúsculas. ¡Asegúrese de dejar cada palabra en su propia línea!&lt;br&gt;No deje una línea con un espacio al final; recibirá una alerta cada vez que alguien use un espacio en sus mensajes.&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <location filename="../../src/aooptionsdialog.cpp" line="215"/>
+        <source>Audio</source>
+        <translation>Audio</translation>
+    </message>
+    <message>
+        <location filename="../../src/aooptionsdialog.cpp" line="226"/>
+        <source>Audio device:</source>
+        <translation>Dispositivo:</translation>
+    </message>
+    <message>
+        <location filename="../../src/aooptionsdialog.cpp" line="227"/>
+        <source>Sets the audio device for all sounds.</source>
+        <translation>Establece el dispositivo de audio.</translation>
+    </message>
+    <message>
+        <location filename="../../src/aooptionsdialog.cpp" line="261"/>
+        <source>Music:</source>
+        <translation>Música:</translation>
+    </message>
+    <message>
+        <location filename="../../src/aooptionsdialog.cpp" line="262"/>
+        <source>Sets the music&apos;s default volume.</source>
+        <translation>Establece el volumen predeterminado de la música.</translation>
+    </message>
+    <message>
+        <location filename="../../src/aooptionsdialog.cpp" line="274"/>
+        <source>SFX:</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../../src/aooptionsdialog.cpp" line="275"/>
+        <source>Sets the SFX&apos;s default volume. Interjections and actual sound effects count as &apos;SFX&apos;.</source>
+        <translation>Establece el volumen predeterminado de SFX. Las interjecciones y los efectos de sonido reales cuentan como &apos;SFX&apos;.</translation>
+    </message>
+    <message>
+        <location filename="../../src/aooptionsdialog.cpp" line="288"/>
+        <source>Blips:</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../../src/aooptionsdialog.cpp" line="289"/>
+        <source>Sets the volume of the blips, the talking sound effects.</source>
+        <translation>Establece el volumen de los blips, el sonido al hablar.</translation>
+    </message>
+    <message>
+        <location filename="../../src/aooptionsdialog.cpp" line="307"/>
+        <source>Blip rate:</source>
+        <translation>Tasa de blips:</translation>
+    </message>
+    <message>
+        <location filename="../../src/aooptionsdialog.cpp" line="308"/>
+        <source>Sets the delay between playing the blip sounds.</source>
+        <translation>Establece el retraso entre la reproducción de los sonidos blip.</translation>
+    </message>
+    <message>
+        <location filename="../../src/aooptionsdialog.cpp" line="319"/>
+        <source>Blank blips:</source>
+        <translation>Blips en blanco:</translation>
+    </message>
+    <message>
+        <location filename="../../src/aooptionsdialog.cpp" line="320"/>
+        <source>If true, the game will play a blip sound even when a space is &apos;being said&apos;.</source>
+        <translation>Si está marcada, el juego reproducirá un sonido blip incluso cuando se &apos;dice&apos; un espacio.</translation>
+    </message>
+    <message>
+        <location filename="../../src/aooptionsdialog.cpp" line="332"/>
+        <source>Casing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/aooptionsdialog.cpp" line="346"/>
+        <source>This server supports case alerts.</source>
+        <translation>Este servidor admite alertas de casos.</translation>
+    </message>
+    <message>
+        <location filename="../../src/aooptionsdialog.cpp" line="348"/>
+        <source>This server does not support case alerts.</source>
+        <translation>Este servidor no admite alertas de casos.</translation>
+    </message>
+    <message>
+        <location filename="../../src/aooptionsdialog.cpp" line="349"/>
+        <source>Pretty self-explanatory.</source>
+        <translation>Bastante autoexplicativo.</translation>
+    </message>
+    <message>
+        <location filename="../../src/aooptionsdialog.cpp" line="356"/>
+        <source>Casing:</source>
+        <translation>Caso:</translation>
+    </message>
+    <message>
+        <location filename="../../src/aooptionsdialog.cpp" line="357"/>
+        <source>If checked, you will get alerts about case announcements.</source>
+        <translation>Si está marcado, recibirá anuncios de casos.</translation>
+    </message>
+    <message>
+        <location filename="../../src/aooptionsdialog.cpp" line="370"/>
+        <source>Defense:</source>
+        <translation>Defensa:</translation>
+    </message>
+    <message>
+        <location filename="../../src/aooptionsdialog.cpp" line="371"/>
+        <source>If checked, you will get alerts about case announcements if a defense spot is open.</source>
+        <translation>Si está marcado, recibirá alertas sobre anuncios de casos si hay un lugar de defensa abierto.</translation>
+    </message>
+    <message>
+        <location filename="../../src/aooptionsdialog.cpp" line="384"/>
+        <source>Prosecution:</source>
+        <translation>Fiscal:</translation>
+    </message>
+    <message>
+        <location filename="../../src/aooptionsdialog.cpp" line="385"/>
+        <source>If checked, you will get alerts about case announcements if a prosecutor spot is open.</source>
+        <translation>Si está marcada, recibirá alertas sobre anuncios de casos si hay un puesto de fiscal abierto.</translation>
+    </message>
+    <message>
+        <location filename="../../src/aooptionsdialog.cpp" line="398"/>
+        <source>Judge:</source>
+        <translation>Juez:</translation>
+    </message>
+    <message>
+        <location filename="../../src/aooptionsdialog.cpp" line="399"/>
+        <source>If checked, you will get alerts about case announcements if the judge spot is open.</source>
+        <translation>Si está marcado, recibirá alertas sobre anuncios de casos si el puesto de juez está abierto.</translation>
+    </message>
+    <message>
+        <location filename="../../src/aooptionsdialog.cpp" line="412"/>
+        <source>Juror:</source>
+        <translation>Jurado:</translation>
+    </message>
+    <message>
+        <location filename="../../src/aooptionsdialog.cpp" line="413"/>
+        <source>If checked, you will get alerts about case announcements if a juror spot is open.</source>
+        <translation>Si está marcado, recibirá alertas sobre anuncios de casos si hay un puesto de jurado abierto.</translation>
+    </message>
+    <message>
+        <location filename="../../src/aooptionsdialog.cpp" line="426"/>
+        <source>Stenographer:</source>
+        <translation>Taquígrafo:</translation>
+    </message>
+    <message>
+        <location filename="../../src/aooptionsdialog.cpp" line="427"/>
+        <source>If checked, you will get alerts about case announcements if a stenographer spot is open.</source>
+        <translation>Si está marcado, recibirá alertas sobre anuncios de casos si hay un lugar de taquígrafo abierto.</translation>
+    </message>
+    <message>
+        <location filename="../../src/aooptionsdialog.cpp" line="440"/>
+        <source>CM:</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../../src/aooptionsdialog.cpp" line="441"/>
+        <source>If checked, you will appear amongst the potential CMs on the server.</source>
+        <translation>Si está marcado, aparecerá entre los posibles CM en el servidor.</translation>
+    </message>
+    <message>
+        <location filename="../../src/aooptionsdialog.cpp" line="454"/>
+        <source>Hosting cases:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/aooptionsdialog.cpp" line="455"/>
+        <source>If you&apos;re a CM, enter what cases you are willing to host.</source>
+        <translation>Si eres un CM, ingresa qué casos estás dispuesto a organizar.</translation>
+    </message>
+</context>
+<context>
+    <name>Courtroom</name>
+    <message>
+        <location filename="../../src/charselect.cpp" line="21"/>
+        <source>Password</source>
+        <translation>Contraseña</translation>
+    </message>
+    <message>
+        <location filename="../../src/charselect.cpp" line="27"/>
+        <source>Spectator</source>
+        <translation>Espectador</translation>
+    </message>
+    <message>
+        <location filename="../../src/charselect.cpp" line="30"/>
+        <location filename="../../src/courtroom.cpp" line="138"/>
+        <source>Search</source>
+        <translation>Buscar</translation>
+    </message>
+    <message>
+        <location filename="../../src/charselect.cpp" line="35"/>
+        <source>Passworded</source>
+        <translation>Contraseña</translation>
+    </message>
+    <message>
+        <location filename="../../src/charselect.cpp" line="39"/>
+        <source>Taken</source>
+        <translation>En uso</translation>
+    </message>
+    <message>
+        <location filename="../../src/charselect.cpp" line="217"/>
+        <source>Generating chars:
+%1/%2</source>
+        <translation>Generando personajes:
+%1/%2</translation>
+    </message>
+    <message>
+        <source>Generating chars:
+</source>
+        <translation type="obsolete">Generando personajes:
+</translation>
+    </message>
+    <message>
+        <location filename="../../src/courtroom.cpp" line="116"/>
+        <source>Showname</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/courtroom.cpp" line="120"/>
+        <source>Message</source>
+        <translation>Mensaje</translation>
+    </message>
+    <message>
+        <location filename="../../src/courtroom.cpp" line="130"/>
+        <source>Name</source>
+        <translation>Nombre</translation>
+    </message>
+    <message>
+        <location filename="../../src/courtroom.cpp" line="183"/>
+        <source>Pre</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/courtroom.cpp" line="186"/>
+        <source>Flip</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/courtroom.cpp" line="190"/>
+        <source>Guard</source>
+        <translation>Guardia</translation>
+    </message>
+    <message>
+        <location filename="../../src/courtroom.cpp" line="195"/>
+        <source>Casing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/courtroom.cpp" line="200"/>
+        <source>Shownames</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/courtroom.cpp" line="203"/>
+        <source>No Interrupt</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/courtroom.cpp" line="217"/>
+        <source>White</source>
+        <translation>Blanco</translation>
+    </message>
+    <message>
+        <location filename="../../src/courtroom.cpp" line="218"/>
+        <source>Green</source>
+        <translation>Verde</translation>
+    </message>
+    <message>
+        <location filename="../../src/courtroom.cpp" line="219"/>
+        <source>Red</source>
+        <translation>Rojo</translation>
+    </message>
+    <message>
+        <location filename="../../src/courtroom.cpp" line="220"/>
+        <source>Orange</source>
+        <translation>Naranja</translation>
+    </message>
+    <message>
+        <location filename="../../src/courtroom.cpp" line="221"/>
+        <source>Blue</source>
+        <translation>Azul</translation>
+    </message>
+    <message>
+        <location filename="../../src/courtroom.cpp" line="222"/>
+        <source>Yellow</source>
+        <translation>Amarillo</translation>
+    </message>
+    <message>
+        <location filename="../../src/courtroom.cpp" line="223"/>
+        <source>Rainbow</source>
+        <translation>Arcoíris</translation>
+    </message>
+    <message>
+        <location filename="../../src/courtroom.cpp" line="224"/>
+        <source>Pink</source>
+        <translation>Rosado</translation>
+    </message>
+    <message>
+        <location filename="../../src/courtroom.cpp" line="225"/>
+        <source>Cyan</source>
+        <translation>Cian</translation>
+    </message>
+    <message>
+        <location filename="../../src/courtroom.cpp" line="248"/>
+        <source>% offset</source>
+        <translation>% desplazamiento</translation>
+    </message>
+    <message>
+        <location filename="../../src/courtroom.cpp" line="692"/>
+        <source>Back to Lobby</source>
+        <translation>Volver al lobby</translation>
+    </message>
+    <message>
+        <location filename="../../src/courtroom.cpp" line="2681"/>
+        <source>You were granted the Guard button.</source>
+        <translation>Te ha sido otorgado el botón Guardia.</translation>
+    </message>
+    <message>
+        <location filename="../../src/courtroom.cpp" line="2688"/>
+        <source>This does nothing, but there you go.</source>
+        <translation>Esto no hace nada, pero ahí lo tienes.</translation>
+    </message>
+    <message>
+        <location filename="../../src/courtroom.cpp" line="2695"/>
+        <source>You opened the settings menu.</source>
+        <translation>Abriste el menú de configuración.</translation>
+    </message>
+    <message>
+        <location filename="../../src/courtroom.cpp" line="2710"/>
+        <source>You will now pair up with </source>
+        <translation>Ahora te emparejarás con </translation>
+    </message>
+    <message>
+        <location filename="../../src/courtroom.cpp" line="2712"/>
+        <source> if they also choose your character in return.</source>
+        <translation> si ellos también eligen a tu personaje a cambio.</translation>
+    </message>
+    <message>
+        <location filename="../../src/courtroom.cpp" line="2718"/>
+        <source>You are no longer paired with anyone.</source>
+        <translation>Ya no estás emparejado con nadie.</translation>
+    </message>
+    <message>
+        <location filename="../../src/courtroom.cpp" line="2723"/>
+        <source>Are you sure you typed that well? The char ID could not be recognised.</source>
+        <translation>¿Estás seguro de que lo escribiste bien? El ID de personaje no pudo ser reconocido.</translation>
+    </message>
+    <message>
+        <location filename="../../src/courtroom.cpp" line="2739"/>
+        <source>You have set your offset to </source>
+        <translation>Ha configurado su desplazamiento en </translation>
+    </message>
+    <message>
+        <location filename="../../src/courtroom.cpp" line="2746"/>
+        <source>Your offset must be between -100% and 100%!</source>
+        <translation>¡Su desplazamiento debe estar entre -100% y 100%!</translation>
+    </message>
+    <message>
+        <location filename="../../src/courtroom.cpp" line="2751"/>
+        <source>That offset does not look like one.</source>
+        <translation>Ese desplazamiento no se parece a uno.</translation>
+    </message>
+    <message>
+        <location filename="../../src/courtroom.cpp" line="2757"/>
+        <source>You switched your music and area list.</source>
+        <translation>Cambiaste tu lista de música y área.</translation>
+    </message>
+    <message>
+        <location filename="../../src/courtroom.cpp" line="2764"/>
+        <source>You have forcefully enabled features that the server may not support. You may not be able to talk IC, or worse, because of this.</source>
+        <translation>Ha habilitado forzosamente funciones que el servidor puede no admitir. Es posible que no pueda hablar IC, o peor, debido a esto.</translation>
+    </message>
+    <message>
+        <location filename="../../src/courtroom.cpp" line="2775"/>
+        <source>Your pre-animations interrupt again.</source>
+        <translation>Sus pre-animaciones interrumpen de nuevo.</translation>
+    </message>
+    <message>
+        <location filename="../../src/courtroom.cpp" line="2777"/>
+        <source>Your pre-animations will not interrupt text.</source>
+        <translation>Sus pre-animaciones no interrumpirán el texto.</translation>
+    </message>
+    <message>
+        <location filename="../../src/courtroom.cpp" line="2788"/>
+        <source>Couldn&apos;t open chatlog.txt to write into.</source>
+        <translation>No se pudo abrir chatlog.txt para escribir.</translation>
+    </message>
+    <message>
+        <location filename="../../src/courtroom.cpp" line="2801"/>
+        <source>The IC chatlog has been saved.</source>
+        <translation>El chat IC se ha guardado.</translation>
+    </message>
+    <message>
+        <location filename="../../src/courtroom.cpp" line="2813"/>
+        <source>You don&apos;t have a `base/cases/` folder! It was just made for you, but seeing as it WAS just made for you, it&apos;s likely the case file you&apos;re looking for can&apos;t be found in there.</source>
+        <translation>¡No tienes una carpeta `base/cases /`! Ha sido creada para ti. Pero debido a que no existia la carpeta, tampoco habían casos guardados ahí.</translation>
+    </message>
+    <message>
+        <location filename="../../src/courtroom.cpp" line="2824"/>
+        <source>You need to give a filename to load (extension not needed)! Make sure that it is in the `base/cases/` folder, and that it is a correctly formatted ini.
+Cases you can load: %1</source>
+        <translation>¡Debe dar un nombre de archivo para cargar (no se necesita extensión)! Asegúrese de que esté en la carpeta `base/cases/` y de que tenga el formato correcto.
+Casos que puede cargar: %1</translation>
+    </message>
+    <message>
+        <location filename="../../src/courtroom.cpp" line="2845"/>
+        <source>Case made by %1.</source>
+        <translation>Caso hecho por %1.</translation>
+    </message>
+    <message>
+        <location filename="../../src/courtroom.cpp" line="2851"/>
+        <source>Navigate to %1 for the CM doc.</source>
+        <translation>Navegue a %1 para el documento del CM.</translation>
+    </message>
+    <message>
+        <location filename="../../src/courtroom.cpp" line="2870"/>
+        <source>Your case &quot;%1&quot; was loaded!</source>
+        <translation>Su caso &quot;%1&quot; fue cargado!</translation>
+    </message>
+    <message>
+        <source>You need to give a filename to load (extension not needed)! Make sure that it is in the `base/cases/` folder, and that it is a correctly formatted ini.
+Cases you can load: </source>
+        <translation type="obsolete">¡Debe dar un nombre de archivo para cargar (no se necesita extensión)! Asegúrese de que esté en la carpeta `base/cases/` y de que tenga el formato correcto.
+Casos que puede cargar: </translation>
+    </message>
+    <message>
+        <location filename="../../src/courtroom.cpp" line="2832"/>
+        <source>Too many arguments to load a case! You only need one filename, without extension.</source>
+        <translation>¡Demasiados argumentos para cargar un caso! Solo necesita un nombre de archivo, sin extensión.</translation>
+    </message>
+    <message>
+        <source>Case made by </source>
+        <translation type="obsolete">Caso hecho por </translation>
+    </message>
+    <message>
+        <source>Navigate to </source>
+        <translation type="obsolete">Navegue a </translation>
+    </message>
+    <message>
+        <source> for the CM doc.</source>
+        <translation type="obsolete"> para el documento de CM.</translation>
+    </message>
+    <message>
+        <source>Your case &quot;</source>
+        <translation type="obsolete">Su caso &quot;</translation>
+    </message>
+    <message>
+        <source>&quot; was loaded!</source>
+        <translation type="obsolete">&quot; fue cargado!</translation>
+    </message>
+    <message>
+        <location filename="../../src/courtroom.cpp" line="2882"/>
+        <source>You don&apos;t have a `base/cases/` folder! It was just made for you, but seeing as it WAS just made for you, it&apos;s likely that you somehow deleted it.</source>
+        <translation>¡No tienes una carpeta `base/cases /`! Fue creada para ti.</translation>
+    </message>
+    <message>
+        <location filename="../../src/courtroom.cpp" line="2893"/>
+        <source>You need to give a filename to save (extension not needed) and the courtroom status!</source>
+        <translation>¡Debe dar un nombre de archivo para guardar (no se necesita la extensión) y el estado de la sala del tribunal!</translation>
+    </message>
+    <message>
+        <location filename="../../src/courtroom.cpp" line="2901"/>
+        <source>Too many arguments to save a case! You only need a filename without extension and the courtroom status!</source>
+        <translatorcomment>why two exclamations, seems excesive.</translatorcomment>
+        <translation>¡Demasiados argumentos para salvar un caso! Solo necesita un nombre de archivo sin extensión y el estado de la sala del tribunal.</translation>
+    </message>
+    <message>
+        <location filename="../../src/courtroom.cpp" line="2923"/>
+        <source>Succesfully saved, edit doc and cmdoc link on the ini!</source>
+        <translation>¡Guardado con éxito, puede editar el doc y doc link en el archivo ini!</translation>
+    </message>
+    <message>
+        <location filename="../../src/courtroom.cpp" line="2951"/>
+        <source>Master</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/courtroom.cpp" line="2959"/>
+        <source>Server</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/courtroom.cpp" line="3422"/>
+        <source>Reason:</source>
+        <translation>Razón:</translation>
+    </message>
+    <message>
+        <location filename="../../src/courtroom.cpp" line="3423"/>
+        <source>Call Moderator</source>
+        <translation>Llamar Moderador</translation>
+    </message>
+    <message>
+        <location filename="../../src/courtroom.cpp" line="3431"/>
+        <location filename="../../src/courtroom.cpp" line="3434"/>
+        <source>Error</source>
+        <translation>Error</translation>
+    </message>
+    <message>
+        <location filename="../../src/courtroom.cpp" line="3431"/>
+        <source>You must provide a reason.</source>
+        <translation>Debes proporcionar una razón.</translation>
+    </message>
+    <message>
+        <location filename="../../src/courtroom.cpp" line="3434"/>
+        <source>The message is too long.</source>
+        <translation>El mensaje es muy largo.</translation>
+    </message>
+    <message>
+        <location filename="../../src/evidence.cpp" line="25"/>
+        <source>Choose...</source>
+        <translation>Elegir...</translation>
+    </message>
+    <message>
+        <location filename="../../src/evidence.cpp" line="194"/>
+        <source>Images (*.png)</source>
+        <translation>Imágenes (* .png)</translation>
+    </message>
+    <message>
+        <location filename="../../src/evidence.cpp" line="268"/>
+        <source>Add new evidence...</source>
+        <translation>Añadir nueva evidencia...</translation>
+    </message>
+</context>
+<context>
+    <name>Lobby</name>
+    <message>
+        <location filename="../../src/lobby.cpp" line="12"/>
+        <source>Attorney Online 2</source>
+        <translation>Attorney Online 2</translation>
+    </message>
+    <message>
+        <location filename="../../src/lobby.cpp" line="29"/>
+        <source>Name</source>
+        <translation>Nombre</translation>
+    </message>
+    <message>
+        <location filename="../../src/lobby.cpp" line="74"/>
+        <source>It doesn&apos;t look like your client is set up correctly.
+Did you download all resources correctly from tiny.cc/getao, including the large &apos;base&apos; folder?</source>
+        <translation>No parece que su cliente esté configurado correctamente.
+¿Descargó todos los recursos correctamente desde tiny.cc/getao, incluida la gran carpeta &apos;base&apos;?</translation>
+    </message>
+    <message>
+        <location filename="../../src/lobby.cpp" line="104"/>
+        <source>Version: %1</source>
+        <translation>Versión: %1</translation>
+    </message>
+    <message>
+        <location filename="../../src/lobby.cpp" line="147"/>
+        <source>Loading</source>
+        <translation>Cargando</translation>
+    </message>
+    <message>
+        <location filename="../../src/lobby.cpp" line="151"/>
+        <source>Cancel</source>
+        <translation>Cancelar</translation>
+    </message>
+    <message>
+        <location filename="../../src/lobby.cpp" line="270"/>
+        <source>&lt;h2&gt;Attorney Online %1&lt;/h2&gt;The courtroom drama simulator&lt;p&gt;&lt;b&gt;Source code:&lt;/b&gt; &lt;a href=&apos;https://github.com/AttorneyOnline/AO2-Client&apos;&gt;https://github.com/AttorneyOnline/AO2-Client&lt;/a&gt;&lt;p&gt;&lt;b&gt;Major development:&lt;/b&gt;&lt;br&gt;OmniTroid, stonedDiscord, longbyte1, gameboyprinter, Cerapter&lt;p&gt;&lt;b&gt;Special thanks:&lt;/b&gt;&lt;br&gt;Remy, Iamgoofball, Hibiki, Qubrick (webAO), Ruekasu (UI design), Draxirch (UI design), Unishred, Argoneus (tsuserver), Fiercy, Noevain, Cronnicossy</source>
+        <translation>&lt;h2&gt;Attorney Online %1&lt;/h2&gt;El simulador de drama de la sala del tribunal&lt;p&gt;&lt;b&gt;Código fuente:&lt;/b&gt; &lt;a href=&apos;https://github.com/AttorneyOnline/AO2-Client&apos;&gt;https: //github.com/AttorneyOnline/AO2-Client&lt;/a&gt;&lt;p&gt;&lt;b&gt;Desarrollo mayor:&lt;/b&gt; &lt;br&gt;OmniTroid, stonedDiscord, longbyte1, gameboyprinter, Cerapter&lt;p&gt;&lt;b&gt;Agradecimiento especial:&lt;/b&gt;&lt;br&gt;Remy, Iamgoofball, Hibiki, Qubrick (webAO), Ruekasu (diseño de interfaz de usuario), Draxirch (diseño de interfaz de usuario), Unishred, Argoneus (tsuserver), Fiercy, Noevain, Cronnicossy</translation>
+    </message>
+    <message>
+        <location filename="../../src/lobby.cpp" line="376"/>
+        <source>Online: %1/%2</source>
+        <translation>En línea: %1/%2</translation>
+    </message>
+    <message>
+        <location filename="../../src/lobby.cpp" line="114"/>
+        <location filename="../../src/lobby.cpp" line="316"/>
+        <source>Offline</source>
+        <translation>Fuera de línea</translation>
+    </message>
+</context>
+<context>
+    <name>debug_functions</name>
+    <message>
+        <location filename="../../src/debug_functions.cpp" line="10"/>
+        <source>Error: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/debug_functions.cpp" line="11"/>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/debug_functions.cpp" line="23"/>
+        <source>Notice</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+</TS>


### PR DESCRIPTION
Translation notes:
- Translated Master Server as "lista de servidores" or "server list".
- Didn't translate any strings in debug_functions, this was on purpose.
- In the Courtroom interface I decided that for now it will be best to leave everything (except the colors) untranslated as this will probably break every theme.
- Almost everything else is translated except "Casing" and "Hosting cases:", couldn't think of anything that would fit in the same space.