### PR TITLE
Change some viewport elements from AOImage into AOMovie and expand AOMovie widget

### DIFF
--- a/include/aomovie.h
+++ b/include/aomovie.h
@@ -15,13 +15,15 @@ public:
   AOMovie(QWidget *p_parent, AOApplication *p_ao_app);
 
   void set_play_once(bool p_play_once);
-  void play(QString p_gif, QString p_char = "", QString p_custom_theme = "");
+  void start_timer(int delay);
+  void play(QString p_gif, QString p_char = "", QString p_custom_theme = "", int duration = 0);
   void combo_resize(int w, int h);
   void stop();
 
 private:
   QMovie *m_movie;
   AOApplication *ao_app;
+  QTimer *timer;
   bool play_once = true;
 
 signals:
@@ -29,6 +31,7 @@ signals:
 
 private slots:
   void frame_change(int n_frame);
+  void timer_done();
 };
 
 #endif // AOMOVIE_H

--- a/include/aomovie.h
+++ b/include/aomovie.h
@@ -16,7 +16,7 @@ public:
 
   void set_play_once(bool p_play_once);
   void start_timer(int delay);
-  void play(QString p_gif, QString p_char = "", QString p_custom_theme = "", int duration = 0);
+  void play(QString p_gif, QString p_char = "", QString p_custom_theme = "", int default_duration = 0);
   void combo_resize(int w, int h);
   void stop();
 

--- a/include/courtroom.h
+++ b/include/courtroom.h
@@ -306,9 +306,6 @@ private:
   //delay before sfx plays
   QTimer *sfx_delay_timer;
 
-  //keeps track of how long realization is visible(it's just a white square and should be visible less than a second)
-  QTimer *realization_timer;
-
   //every time point in char.inis times this equals the final time
   const int time_mod = 40;
 
@@ -394,7 +391,7 @@ private:
   AOImage *ui_vp_chatbox;
   QLabel *ui_vp_showname;
   QTextEdit *ui_vp_message;
-  AOImage *ui_vp_realization;
+  AOMovie *ui_vp_realization;
   AOMovie *ui_vp_testimony;
   AOMovie *ui_vp_wtce;
   AOMovie *ui_vp_objection;
@@ -537,11 +534,6 @@ private:
 public slots:
   void objection_done();
   void preanim_done();
-
-  void realization_done();
-
-  void show_testimony();
-  void hide_testimony();
 
   void mod_called(QString p_ip);
 

--- a/include/courtroom.h
+++ b/include/courtroom.h
@@ -309,6 +309,15 @@ private:
   //every time point in char.inis times this equals the final time
   const int time_mod = 40;
 
+  //the amount of time non-animated objection/hold it/takethat images stay onscreen for in ms
+  const int shout_stay_time = 724;
+
+  //the amount of time non-animated guilty/not guilty images stay onscreen for in ms
+  const int verdict_stay_time = 3000;
+
+  //the amount of time non-animated witness testimony/cross-examination images stay onscreen for in ms
+  const int wtce_stay_time = 1500;
+
   static const int chatmessage_size = 23;
   QString m_chatmessage[chatmessage_size];
   bool chatmessage_is_empty = false;

--- a/include/courtroom.h
+++ b/include/courtroom.h
@@ -309,11 +309,6 @@ private:
   //keeps track of how long realization is visible(it's just a white square and should be visible less than a second)
   QTimer *realization_timer;
 
-  //times how long the blinking testimony should be shown(green one in the corner)
-  QTimer *testimony_show_timer;
-  //times how long the blinking testimony should be hidden
-  QTimer *testimony_hide_timer;
-
   //every time point in char.inis times this equals the final time
   const int time_mod = 40;
 
@@ -322,14 +317,6 @@ private:
   bool chatmessage_is_empty = false;
 
   QString previous_ic_message = "";
-
-  bool testimony_in_progress = false;
-
-  //in milliseconds
-  const int testimony_show_time = 1500;
-
-  //in milliseconds
-  const int testimony_hide_time = 500;
 
   //char id, muted or not
   QMap<int, bool> mute_map;
@@ -407,8 +394,8 @@ private:
   AOImage *ui_vp_chatbox;
   QLabel *ui_vp_showname;
   QTextEdit *ui_vp_message;
-  AOImage *ui_vp_testimony;
   AOImage *ui_vp_realization;
+  AOMovie *ui_vp_testimony;
   AOMovie *ui_vp_wtce;
   AOMovie *ui_vp_objection;
 

--- a/src/aocharmovie.cpp
+++ b/src/aocharmovie.cpp
@@ -19,28 +19,28 @@ AOCharMovie::AOCharMovie(QWidget *p_parent, AOApplication *p_ao_app) : QLabel(p_
 
 void AOCharMovie::play(QString p_char, QString p_emote, QString emote_prefix)
 {
-  QString original_path = ao_app->get_character_path(p_char, emote_prefix + p_emote + ".gif");
-  QString alt_path = ao_app->get_character_path(p_char, p_emote + ".png");
-  QString apng_path = ao_app->get_character_path(p_char, emote_prefix + p_emote + ".apng");
-  QString placeholder_path = ao_app->get_theme_path("placeholder.gif");
-  QString placeholder_default_path = ao_app->get_default_theme_path("placeholder.gif");
-  QString gif_path;
+  QString emote_path;
+  QList<QString> pathlist;
+  pathlist = {
+      ao_app->get_image_suffix(ao_app->get_character_path(p_char, emote_prefix + p_emote)), //Default path
+      ao_app->get_character_path(p_char, p_emote + ".png"),                                 //Non-animated path if emote_prefix fails
+      ao_app->get_image_suffix(ao_app->get_theme_path("placeholder")),                      //Theme placeholder path
+      ao_app->get_image_suffix(ao_app->get_default_theme_path("placeholder")),              //Default theme placeholder path
+  };
 
-  if (file_exists(apng_path))
-    gif_path = apng_path;
-  else if (file_exists(original_path))
-    gif_path = original_path;
-  else if (file_exists(alt_path))
-    gif_path = alt_path;
-  else if (file_exists(placeholder_path))
-    gif_path = placeholder_path;
-  else
-    gif_path = placeholder_default_path;
+  for (QString path : pathlist)
+  {
+      if (file_exists(path))
+      {
+          emote_path = path;
+          break;
+      }
+  }
 
   m_movie->stop();
-  m_movie->setFileName(gif_path);
+  m_movie->setFileName(emote_path);
 
-  QImageReader *reader = new QImageReader(gif_path);
+  QImageReader *reader = new QImageReader(emote_path);
 
   movie_frames.clear();
   QImage f_image = reader->read();
@@ -61,11 +61,11 @@ void AOCharMovie::play(QString p_char, QString p_emote, QString emote_prefix)
 
 void AOCharMovie::play_pre(QString p_char, QString p_emote, int duration)
 {
-  QString gif_path = ao_app->get_character_path(p_char, p_emote);
+  QString emote_path = ao_app->get_character_path(p_char, p_emote);
 
   m_movie->stop();
   this->clear();
-  m_movie->setFileName(gif_path);
+  m_movie->setFileName(emote_path);
   m_movie->jumpToFrame(0);
 
   int full_duration = duration * time_mod;
@@ -116,11 +116,11 @@ void AOCharMovie::play_pre(QString p_char, QString p_emote, int duration)
 
 void AOCharMovie::play_talking(QString p_char, QString p_emote)
 {
-  QString gif_path = ao_app->get_character_path(p_char, "(b)" + p_emote);
+  QString emote_path = ao_app->get_character_path(p_char, "(b)" + p_emote);
 
   m_movie->stop();
   this->clear();
-  m_movie->setFileName(gif_path);
+  m_movie->setFileName(emote_path);
 
   play_once = false;
   m_movie->setSpeed(100);
@@ -129,11 +129,11 @@ void AOCharMovie::play_talking(QString p_char, QString p_emote)
 
 void AOCharMovie::play_idle(QString p_char, QString p_emote)
 {
-  QString gif_path = ao_app->get_character_path(p_char, "(a)" + p_emote);
+  QString emote_path = ao_app->get_character_path(p_char, "(a)" + p_emote);
 
   m_movie->stop();
   this->clear();
-  m_movie->setFileName(gif_path);
+  m_movie->setFileName(emote_path);
 
   play_once = false;
   m_movie->setSpeed(100);

--- a/src/aomovie.cpp
+++ b/src/aomovie.cpp
@@ -29,23 +29,27 @@ void AOMovie::start_timer(int delay)
   timer->start(delay);
 }
 
-void AOMovie::play(QString p_gif, QString p_char, QString p_custom_theme, int duration)
+void AOMovie::play(QString p_image, QString p_char, QString p_custom_theme, int duration)
 {
   m_movie->stop();
 
   QString shout_path;
   QList<QString> pathlist;
-  if (p_gif == "custom")
-    pathlist << ao_app->get_image_suffix(ao_app->get_character_path(p_char, p_gif));
-  else
-    pathlist << ao_app->get_image_suffix(ao_app->get_character_path(p_char, p_gif + "_bubble"));
 
-  pathlist << ao_app->get_image_suffix(ao_app->get_base_path() + "misc/" + p_custom_theme + "/" + p_gif + "_bubble") << //Misc path
-              ao_app->get_image_suffix(ao_app->get_custom_theme_path(p_custom_theme, p_gif)) << //Custom theme path
-              ao_app->get_image_suffix(ao_app->get_theme_path(p_gif)) << //Theme path
-              ao_app->get_image_suffix(ao_app->get_default_theme_path(p_gif)) << //Default theme path
-              ao_app->get_image_suffix(ao_app->get_theme_path("placeholder")) << //Placeholder path
-              ao_app->get_image_suffix( ao_app->get_default_theme_path("placeholder")); //Default placeholder path
+  pathlist = {
+      ao_app->get_image_suffix(ao_app->get_base_path() + "misc/" + p_custom_theme + "/" + p_image + "_bubble"),   //Misc path
+      ao_app->get_image_suffix(ao_app->get_custom_theme_path(p_custom_theme, p_image)),                           //Custom theme path
+      ao_app->get_image_suffix(ao_app->get_theme_path(p_image)),                                                  //Theme path
+      ao_app->get_image_suffix(ao_app->get_default_theme_path(p_image)),                                          //Default theme path
+      ao_app->get_image_suffix(ao_app->get_theme_path("placeholder")),                                          //Placeholder path
+      ao_app->get_image_suffix( ao_app->get_default_theme_path("placeholder")),                                 //Default placeholder path
+  };
+
+  //Add this at the beginning of the list - order matters.
+  if (p_image == "custom")
+    pathlist.prepend(ao_app->get_image_suffix(ao_app->get_character_path(p_char, p_image)));
+  else
+    pathlist.prepend(ao_app->get_image_suffix(ao_app->get_character_path(p_char, p_image + "_bubble")));
 
   for (QString path : pathlist)
   {

--- a/src/aomovie.cpp
+++ b/src/aomovie.cpp
@@ -12,7 +12,11 @@ AOMovie::AOMovie(QWidget *p_parent, AOApplication *p_ao_app) : QLabel(p_parent)
 
   this->setMovie(m_movie);
 
+  timer = new QTimer(this);
+  timer->setSingleShot(true);
+
   connect(m_movie, SIGNAL(frameChanged(int)), this, SLOT(frame_change(int)));
+  connect(timer, SIGNAL(timeout()), this, SLOT(timer_done()));
 }
 
 void AOMovie::set_play_once(bool p_play_once)
@@ -20,46 +24,44 @@ void AOMovie::set_play_once(bool p_play_once)
   play_once = p_play_once;
 }
 
-void AOMovie::play(QString p_gif, QString p_char, QString p_custom_theme)
+void AOMovie::start_timer(int delay)
+{
+  timer->start(delay);
+}
+
+void AOMovie::play(QString p_gif, QString p_char, QString p_custom_theme, int duration)
 {
   m_movie->stop();
 
-  QString gif_path;
-
-  QString custom_path;
+  QString shout_path;
+  QList<QString> pathlist;
   if (p_gif == "custom")
-    custom_path = ao_app->get_image_suffix(ao_app->get_character_path(p_char, p_gif));
+    pathlist << ao_app->get_image_suffix(ao_app->get_character_path(p_char, p_gif));
   else
-    custom_path = ao_app->get_image_suffix(ao_app->get_character_path(p_char, p_gif + "_bubble"));
+    pathlist << ao_app->get_image_suffix(ao_app->get_character_path(p_char, p_gif + "_bubble"));
 
-  QString misc_path = ao_app->get_base_path() + "misc/" + p_custom_theme + "/" + p_gif + "_bubble.gif";
-  QString custom_theme_path = ao_app->get_custom_theme_path(p_custom_theme, p_gif + ".gif");
-  QString theme_path = ao_app->get_theme_path(p_gif + ".gif");
-  QString default_theme_path = ao_app->get_default_theme_path(p_gif + ".gif");
-  QString placeholder_path = ao_app->get_theme_path("placeholder.gif");
-  QString default_placeholder_path = ao_app->get_default_theme_path("placeholder.gif");
+  pathlist << ao_app->get_image_suffix(ao_app->get_base_path() + "misc/" + p_custom_theme + "/" + p_gif + "_bubble") << //Misc path
+              ao_app->get_image_suffix(ao_app->get_custom_theme_path(p_custom_theme, p_gif)) << //Custom theme path
+              ao_app->get_image_suffix(ao_app->get_theme_path(p_gif)) << //Theme path
+              ao_app->get_image_suffix(ao_app->get_default_theme_path(p_gif)) << //Default theme path
+              ao_app->get_image_suffix(ao_app->get_theme_path("placeholder")) << //Placeholder path
+              ao_app->get_image_suffix( ao_app->get_default_theme_path("placeholder")); //Default placeholder path
 
-  if (file_exists(custom_path))
-    gif_path = custom_path;
-  else if (file_exists(misc_path))
-    gif_path = misc_path;
-  else if (file_exists(custom_theme_path))
-    gif_path = custom_theme_path;
-  else if (file_exists(theme_path))
-    gif_path = theme_path;
-  else if (file_exists(default_theme_path))
-    gif_path = default_theme_path;
-  else if (file_exists(placeholder_path))
-    gif_path = placeholder_path;
-  else if (file_exists(default_placeholder_path))
-    gif_path = default_placeholder_path;
-  else
-    gif_path = "";
+  for (QString path : pathlist)
+  {
+      if (file_exists(path))
+      {
+          shout_path = path;
+          break;
+      }
+  }
 
-  m_movie->setFileName(gif_path);
+  m_movie->setFileName(shout_path);
 
   this->show();
   m_movie->start();
+  if (m_movie->frameCount() == 0 && duration > 0)
+      this->start_timer(duration);
 }
 
 void AOMovie::stop()
@@ -70,16 +72,23 @@ void AOMovie::stop()
 
 void AOMovie::frame_change(int n_frame)
 {
-  if (n_frame == (m_movie->frameCount() - 1) && play_once)
-  {
-    //we need this or else the last frame wont show
-    delay(m_movie->nextFrameDelay());
+  //If it's a "static movie" (only one frame - png image), we can't change frames - ignore this function (use timer instead).
+  //If the frame didn't reach the last frame or the movie is continuous, don't stop the movie.
+  if (m_movie->frameCount() == 0 || n_frame < (m_movie->frameCount() - 1) || !play_once)
+      return;
+  //we need this or else the last frame wont show
+  delay(m_movie->nextFrameDelay());
 
-    this->stop();
+  this->stop();
 
-    //signal connected to courtroom object, let it figure out what to do
-    done();
-  }
+  //signal connected to courtroom object, let it figure out what to do
+  done();
+}
+
+void AOMovie::timer_done()
+{
+  this->stop();
+  done();
 }
 
 void AOMovie::combo_resize(int w, int h)

--- a/src/courtroom.cpp
+++ b/src/courtroom.cpp
@@ -1332,20 +1332,20 @@ void Courtroom::handle_chatmessage(QStringList *p_contents)
     switch (objection_mod)
     {
     case 1:
-      ui_vp_objection->play("holdit", f_char, f_custom_theme, 724);
+      ui_vp_objection->play("holdit", f_char, f_custom_theme, shout_stay_time);
       objection_player->play("holdit.wav", f_char, f_custom_theme);
       break;
     case 2:
-      ui_vp_objection->play("objection", f_char, f_custom_theme, 724);
+      ui_vp_objection->play("objection", f_char, f_custom_theme, shout_stay_time);
       objection_player->play("objection.wav", f_char, f_custom_theme);
       break;
     case 3:
-      ui_vp_objection->play("takethat", f_char, f_custom_theme, 724);
+      ui_vp_objection->play("takethat", f_char, f_custom_theme, shout_stay_time);
       objection_player->play("takethat.wav", f_char, f_custom_theme);
       break;
     //case 4 is AO2 only
     case 4:
-      ui_vp_objection->play("custom", f_char, f_custom_theme, 724);
+      ui_vp_objection->play("custom", f_char, f_custom_theme, shout_stay_time);
       objection_player->play("custom.wav", f_char, f_custom_theme);
       break;
     default:
@@ -2527,14 +2527,14 @@ void Courtroom::handle_wtce(QString p_wtce, int variant)
   if (p_wtce == "testimony1")
   {
     sfx_player->play(ao_app->get_sfx("witness_testimony"));
-    ui_vp_wtce->play("witnesstestimony", "", "", 1500);
+    ui_vp_wtce->play("witnesstestimony", "", "", wtce_stay_time);
     ui_vp_testimony->play("testimony");
   }
   //cross examination
   else if (p_wtce == "testimony2")
   {
     sfx_player->play(ao_app->get_sfx("cross_examination"));
-    ui_vp_wtce->play("crossexamination", "", "", 1500);
+    ui_vp_wtce->play("crossexamination", "", "", wtce_stay_time);
     ui_vp_testimony->stop();
   }
   else if (p_wtce == "judgeruling")
@@ -2542,12 +2542,12 @@ void Courtroom::handle_wtce(QString p_wtce, int variant)
     if (variant == 0)
     {
         sfx_player->play(ao_app->get_sfx("not_guilty"));
-        ui_vp_wtce->play("notguilty", "", "", 3000);
+        ui_vp_wtce->play("notguilty", "", "", verdict_stay_time);
         ui_vp_testimony->stop();
     }
     else if (variant == 1) {
         sfx_player->play(ao_app->get_sfx("guilty"));
-        ui_vp_wtce->play("guilty", "", "", 3000);
+        ui_vp_wtce->play("guilty", "", "", verdict_stay_time);
         ui_vp_testimony->stop();
     }
   }

--- a/src/courtroom.cpp
+++ b/src/courtroom.cpp
@@ -55,9 +55,6 @@ Courtroom::Courtroom(AOApplication *p_ao_app) : QMainWindow()
   sfx_delay_timer = new QTimer(this);
   sfx_delay_timer->setSingleShot(true);
 
-  realization_timer = new QTimer(this);
-  realization_timer->setSingleShot(true);
-
   music_player = new AOMusicPlayer(this, ao_app);
   music_player->set_volume(0);
 
@@ -97,7 +94,7 @@ Courtroom::Courtroom(AOApplication *p_ao_app) : QMainWindow()
 
   ui_vp_testimony = new AOMovie(this, ao_app);
   ui_vp_testimony->set_play_once(false);
-  ui_vp_realization = new AOImage(this, ao_app);
+  ui_vp_realization = new AOMovie(this, ao_app);
   ui_vp_wtce = new AOMovie(this, ao_app);
   ui_vp_objection = new AOMovie(this, ao_app);
 
@@ -272,8 +269,6 @@ Courtroom::Courtroom(AOApplication *p_ao_app) : QMainWindow()
   connect(sfx_delay_timer, SIGNAL(timeout()), this, SLOT(play_sfx()));
 
   connect(chat_tick_timer, SIGNAL(timeout()), this, SLOT(chat_tick()));
-
-  connect(realization_timer, SIGNAL(timeout()), this, SLOT(realization_done()));
 
   connect(ui_emote_left, SIGNAL(clicked()), this, SLOT(on_emote_left_clicked()));
   connect(ui_emote_right, SIGNAL(clicked()), this, SLOT(on_emote_right_clicked()));
@@ -487,9 +482,7 @@ void Courtroom::set_widgets()
   ui_vp_testimony->combo_resize(ui_viewport->width(), ui_viewport->height());
 
   ui_vp_realization->move(ui_viewport->x(), ui_viewport->y());
-  ui_vp_realization->resize(ui_viewport->width(), ui_viewport->height());
-  ui_vp_realization->set_image("realizationflash.png");
-  ui_vp_realization->hide();
+  ui_vp_realization->combo_resize(ui_viewport->width(), ui_viewport->height());
 
   ui_vp_wtce->move(ui_viewport->x(), ui_viewport->y());
   ui_vp_wtce->combo_resize(ui_viewport->width(), ui_viewport->height());
@@ -1972,10 +1965,6 @@ void Courtroom::preanim_done()
   handle_chatmessage_3();
 }
 
-void Courtroom::realization_done()
-{
-  ui_vp_realization->hide();
-}
 
 void Courtroom::start_chat_ticking()
 {
@@ -1985,8 +1974,7 @@ void Courtroom::start_chat_ticking()
 
   if (m_chatmessage[REALIZATION] == "1")
   {
-    realization_timer->start(60);
-    ui_vp_realization->show();
+    ui_vp_realization->play("realizationflash", "", "", 60);
     sfx_player->play(ao_app->get_custom_realization(m_chatmessage[CHAR_NAME]));
   }
 

--- a/src/courtroom.cpp
+++ b/src/courtroom.cpp
@@ -58,12 +58,6 @@ Courtroom::Courtroom(AOApplication *p_ao_app) : QMainWindow()
   realization_timer = new QTimer(this);
   realization_timer->setSingleShot(true);
 
-  testimony_show_timer = new QTimer(this);
-  testimony_show_timer->setSingleShot(true);
-
-  testimony_hide_timer = new QTimer(this);
-  testimony_hide_timer->setSingleShot(true);
-
   music_player = new AOMusicPlayer(this, ao_app);
   music_player->set_volume(0);
 
@@ -101,7 +95,8 @@ Courtroom::Courtroom(AOApplication *p_ao_app) : QMainWindow()
   ui_vp_message->setVerticalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
   ui_vp_message->setReadOnly(true);
 
-  ui_vp_testimony = new AOImage(this, ao_app);
+  ui_vp_testimony = new AOMovie(this, ao_app);
+  ui_vp_testimony->set_play_once(false);
   ui_vp_realization = new AOImage(this, ao_app);
   ui_vp_wtce = new AOMovie(this, ao_app);
   ui_vp_objection = new AOMovie(this, ao_app);
@@ -279,9 +274,6 @@ Courtroom::Courtroom(AOApplication *p_ao_app) : QMainWindow()
   connect(chat_tick_timer, SIGNAL(timeout()), this, SLOT(chat_tick()));
 
   connect(realization_timer, SIGNAL(timeout()), this, SLOT(realization_done()));
-
-  connect(testimony_show_timer, SIGNAL(timeout()), this, SLOT(hide_testimony()));
-  connect(testimony_hide_timer, SIGNAL(timeout()), this, SLOT(show_testimony()));
 
   connect(ui_emote_left, SIGNAL(clicked()), this, SLOT(on_emote_left_clicked()));
   connect(ui_emote_right, SIGNAL(clicked()), this, SLOT(on_emote_right_clicked()));
@@ -492,9 +484,7 @@ void Courtroom::set_widgets()
                                "color: white");
 
   ui_vp_testimony->move(ui_viewport->x(), ui_viewport->y());
-  ui_vp_testimony->resize(ui_viewport->width(), ui_viewport->height());
-  ui_vp_testimony->set_image("testimony.png");
-  ui_vp_testimony->hide();
+  ui_vp_testimony->combo_resize(ui_viewport->width(), ui_viewport->height());
 
   ui_vp_realization->move(ui_viewport->x(), ui_viewport->y());
   ui_vp_realization->resize(ui_viewport->width(), ui_viewport->height());
@@ -824,8 +814,7 @@ void Courtroom::done_received()
 
 void Courtroom::set_background(QString p_background)
 {
-  testimony_in_progress = false;
-
+  ui_vp_testimony->stop();
   current_background = p_background;
 
   is_ao2_bg = file_exists(ao_app->get_background_path("defensedesk.png")) &&
@@ -933,7 +922,7 @@ void Courtroom::enter_courtroom(int p_cid)
   objection_player->set_volume(ui_sfx_slider->value());
   blip_player->set_volume(ui_blip_slider->value());
 
-  testimony_in_progress = false;
+  ui_vp_testimony->stop();
 
   set_widgets();
 
@@ -2335,27 +2324,6 @@ void Courtroom::chat_tick()
   }
 }
 
-
-void Courtroom::show_testimony()
-{
-  if (!testimony_in_progress || m_chatmessage[SIDE] != "wit")
-    return;
-
-  ui_vp_testimony->show();
-
-  testimony_show_timer->start(testimony_show_time);
-}
-
-void Courtroom::hide_testimony()
-{
-  ui_vp_testimony->hide();
-
-  if (!testimony_in_progress)
-    return;
-
-  testimony_hide_timer->start(testimony_hide_time);
-}
-
 void Courtroom::play_sfx()
 {
   QString sfx_name = m_chatmessage[SFX_NAME];
@@ -2368,9 +2336,6 @@ void Courtroom::play_sfx()
 
 void Courtroom::set_scene()
 {
-  if (testimony_in_progress)
-    show_testimony();
-
   //witness is default if pos is invalid
   QString f_background = "witnessempty";
   QString f_desk_image = "stand";
@@ -2575,15 +2540,14 @@ void Courtroom::handle_wtce(QString p_wtce, int variant)
   {
     sfx_player->play(ao_app->get_sfx("witness_testimony"));
     ui_vp_wtce->play("witnesstestimony", "", "", 1500);
-    testimony_in_progress = true;
-    show_testimony();
+    ui_vp_testimony->play("testimony");
   }
   //cross examination
   else if (p_wtce == "testimony2")
   {
     sfx_player->play(ao_app->get_sfx("cross_examination"));
     ui_vp_wtce->play("crossexamination", "", "", 1500);
-    testimony_in_progress = false;
+    ui_vp_testimony->stop();
   }
   else if (p_wtce == "judgeruling")
   {
@@ -2591,12 +2555,12 @@ void Courtroom::handle_wtce(QString p_wtce, int variant)
     {
         sfx_player->play(ao_app->get_sfx("not_guilty"));
         ui_vp_wtce->play("notguilty", "", "", 3000);
-        testimony_in_progress = false;
+        ui_vp_testimony->stop();
     }
     else if (variant == 1) {
         sfx_player->play(ao_app->get_sfx("guilty"));
         ui_vp_wtce->play("guilty", "", "", 3000);
-        testimony_in_progress = false;
+        ui_vp_testimony->stop();
     }
   }
 }

--- a/src/courtroom.cpp
+++ b/src/courtroom.cpp
@@ -1350,20 +1350,20 @@ void Courtroom::handle_chatmessage(QStringList *p_contents)
     switch (objection_mod)
     {
     case 1:
-      ui_vp_objection->play("holdit", f_char, f_custom_theme);
+      ui_vp_objection->play("holdit", f_char, f_custom_theme, 724);
       objection_player->play("holdit.wav", f_char, f_custom_theme);
       break;
     case 2:
-      ui_vp_objection->play("objection", f_char, f_custom_theme);
+      ui_vp_objection->play("objection", f_char, f_custom_theme, 724);
       objection_player->play("objection.wav", f_char, f_custom_theme);
       break;
     case 3:
-      ui_vp_objection->play("takethat", f_char, f_custom_theme);
+      ui_vp_objection->play("takethat", f_char, f_custom_theme, 724);
       objection_player->play("takethat.wav", f_char, f_custom_theme);
       break;
     //case 4 is AO2 only
     case 4:
-      ui_vp_objection->play("custom", f_char, f_custom_theme);
+      ui_vp_objection->play("custom", f_char, f_custom_theme, 724);
       objection_player->play("custom.wav", f_char, f_custom_theme);
       break;
     default:
@@ -2574,7 +2574,7 @@ void Courtroom::handle_wtce(QString p_wtce, int variant)
   if (p_wtce == "testimony1")
   {
     sfx_player->play(ao_app->get_sfx("witness_testimony"));
-    ui_vp_wtce->play("witnesstestimony");
+    ui_vp_wtce->play("witnesstestimony", "", "", 1500);
     testimony_in_progress = true;
     show_testimony();
   }
@@ -2582,7 +2582,7 @@ void Courtroom::handle_wtce(QString p_wtce, int variant)
   else if (p_wtce == "testimony2")
   {
     sfx_player->play(ao_app->get_sfx("cross_examination"));
-    ui_vp_wtce->play("crossexamination");
+    ui_vp_wtce->play("crossexamination", "", "", 1500);
     testimony_in_progress = false;
   }
   else if (p_wtce == "judgeruling")
@@ -2590,12 +2590,12 @@ void Courtroom::handle_wtce(QString p_wtce, int variant)
     if (variant == 0)
     {
         sfx_player->play(ao_app->get_sfx("not_guilty"));
-        ui_vp_wtce->play("notguilty");
+        ui_vp_wtce->play("notguilty", "", "", 3000);
         testimony_in_progress = false;
     }
     else if (variant == 1) {
         sfx_player->play(ao_app->get_sfx("guilty"));
-        ui_vp_wtce->play("guilty");
+        ui_vp_wtce->play("guilty", "", "", 3000);
         testimony_in_progress = false;
     }
   }

--- a/src/text_file_functions.cpp
+++ b/src/text_file_functions.cpp
@@ -592,7 +592,7 @@ QString AOApplication::get_custom_realization(QString p_char)
 
   if (f_result == "")
     return get_sfx("realization");
-  else return f_result;
+  else return get_sfx_suffix(f_result);
 }
 
 bool AOApplication::get_blank_blip()


### PR DESCRIPTION
Affects witness testimony indicator, realization flash, allows shouts to safely use .png's and removes unnecessary timer systems for realization flash and witness testimony indicator (as AOMovie now succesfully should handle that)