### PR TITLE
Re-add support for 2.4-style custom chatboxes

### DIFF
--- a/src/courtroom.cpp
+++ b/src/courtroom.cpp
@@ -1655,7 +1655,21 @@ void Courtroom::handle_chatmessage_2()
     ui_vp_chatbox->set_image("chatmed.png");
   else
   {
-    QString chatbox_path = ao_app->get_base_path() + "misc/" + chatbox + "/chatbox.png";
+    QString chatbox_path;
+    QString misc_path = ao_app->get_base_path() + "misc/" + chatbox + "/chatbox.png";
+    // support for 2.4 legacy chatboxes
+    QString legacy_path = ao_app->get_base_path() + "misc/" + chatbox + ".png";
+    if (file_exists(misc_path)) 
+    {
+      chatbox_path = misc_path;
+    }
+    else if (file_exists(legacy_path))
+      chatbox_path = legacy_path;
+    else
+    {
+      QString hnngh_colonel = ao_app->get_theme_path("chatmed.png");
+      chatbox_path = hnngh_colonel;
+    }
     ui_vp_chatbox->set_image_from_path(chatbox_path);
   }
 

--- a/src/courtroom.cpp
+++ b/src/courtroom.cpp
@@ -1667,8 +1667,8 @@ void Courtroom::handle_chatmessage_2()
       chatbox_path = legacy_path;
     else
     {
-      QString hnngh_colonel = ao_app->get_theme_path("chatmed.png");
-      chatbox_path = hnngh_colonel;
+      QString default_chatbox_path = ao_app->get_theme_path("chatmed.png");
+      chatbox_path = default_chatbox_path;
     }
     ui_vp_chatbox->set_image_from_path(chatbox_path);
   }


### PR DESCRIPTION
Adds a conditional check - if the "chat" value in char.ini doesn't match a folder in base/misc, check if it matches a PNG under base/misc and if so use that. Fixes #78.