### PR TITLE
Additional theme support

### DIFF
--- a/include/courtroom.h
+++ b/include/courtroom.h
@@ -209,6 +209,9 @@ public:
   void append_ms_chatmessage(QString f_name, QString f_message);
   void append_server_chatmessage(QString p_name, QString p_message, QString p_colour);
 
+  //check whether or not current theme has images for buttons with fallback text
+  void detect_fallback_text();
+
   //these functions handle chatmessages sequentially.
   //The process itself is very convoluted and merits separate documentation
   //But the general idea is objection animation->pre animation->talking->idle
@@ -411,6 +414,15 @@ private:
 
   //is set to true if the bg folder contains defensedesk.png, prosecutiondesk.png and stand.png
   bool is_ao2_bg = false;
+
+  // whether or not to use text for buttons instead of images, true is text
+  bool change_char_fallback = true;
+  bool reload_theme_fallback = true;
+  bool settings_fallback = true;
+  bool call_mod_fallback = true;
+  bool casing_fallback = true;
+  bool amswap_fallback = true;
+  bool ooc_toggle_fallback = true;
 
   //whether the ooc chat is server or master chat, true is server
   bool server_ooc = true;

--- a/src/courtroom.cpp
+++ b/src/courtroom.cpp
@@ -367,6 +367,7 @@ Courtroom::Courtroom(AOApplication *p_ao_app) : QMainWindow()
   set_widgets();
 
   set_char_select();
+  detect_fallback_text();
 }
 
 void Courtroom::set_mute_list()
@@ -609,7 +610,15 @@ void Courtroom::set_widgets()
   ui_take_that->set_image("takethat.png");
 
   set_size_and_pos(ui_ooc_toggle, "ooc_toggle");
-  ui_ooc_toggle->setText(tr("Server"));
+  if (ooc_toggle_fallback)
+  {
+    ui_ooc_toggle->setText(tr("Server"));
+  }
+  else
+  {
+    ui_ooc_toggle->set_image("ooc_toggle_server.png");
+    ui_ooc_toggle->setText(tr(""));
+  }
 
   set_size_and_pos(ui_witness_testimony, "witness_testimony");
   ui_witness_testimony->set_image("witnesstestimony.png");
@@ -622,22 +631,70 @@ void Courtroom::set_widgets()
   ui_not_guilty->set_image("notguilty.png");
 
   set_size_and_pos(ui_change_character, "change_character");
-  ui_change_character->setText(tr("Change character"));
+  if (change_char_fallback) 
+    {
+      ui_change_character->setText(tr("Change character"));
+    }
+  else 
+    {
+      ui_change_character->set_image("change_character.png");
+      ui_change_character->setText(tr("")); // set text to empty otherwise it just sits there
+    }
 
   set_size_and_pos(ui_reload_theme, "reload_theme");
-  ui_reload_theme->setText(tr("Reload theme"));
+  if (reload_theme_fallback) 
+    {
+      ui_reload_theme->setText(tr("Reload theme"));
+    }
+  else 
+    {
+      ui_reload_theme->set_image("reload_theme.png");
+      ui_reload_theme->setText(tr("")); 
+    }
 
   set_size_and_pos(ui_call_mod, "call_mod");
-  ui_call_mod->setText(tr("Call mod"));
+  if (call_mod_fallback)
+    {
+      ui_call_mod->setText(tr("Call mod"));
+    }
+  else
+    {
+      ui_call_mod->set_image("call_mod.png");
+      ui_call_mod->setText(tr(""));
+    }
 
   set_size_and_pos(ui_settings, "settings");
-  ui_settings->setText(tr("Settings"));
+  if (settings_fallback)
+  {
+    ui_settings->setText(tr("Settings"));
+  }
+  else
+  {
+    ui_settings->set_image("settings.png");
+    ui_settings->setText(tr(""));
+  }
 
   set_size_and_pos(ui_announce_casing, "casing_button");
-  ui_announce_casing->setText(tr("Casing"));
-
+  if (casing_fallback)
+  {
+    ui_announce_casing->setText(tr("Casing"));
+  }
+  else
+  {
+    ui_announce_casing->set_image("casing.png");
+    ui_announce_casing->setText(tr(""));
+  }
+  
   set_size_and_pos(ui_switch_area_music, "switch_area_music");
-  ui_switch_area_music->setText(tr("A/M"));
+  if (amswap_fallback)
+  {
+    ui_switch_area_music->setText(tr("A/M"));
+  }
+  else
+  {
+    ui_switch_area_music->set_image("amswap.png");
+    ui_switch_area_music->setText(tr(""));
+  }
 
   set_size_and_pos(ui_pre, "pre");
   ui_pre->setText(tr("Preanim"));
@@ -1129,6 +1186,32 @@ void Courtroom::append_server_chatmessage(QString p_name, QString p_message, QSt
   }
 
   ui_server_chatlog->append_chatmessage(p_name, p_message, colour);
+}
+
+void Courtroom::detect_fallback_text()
+{
+  QString change_char_path = ao_app->get_theme_path("change_character.png");
+  QString reload_theme_path = ao_app->get_theme_path("reload_theme.png");
+  QString settings_path = ao_app->get_theme_path("settings.png");
+  QString call_mod_path = ao_app->get_theme_path("call_mod.png");
+  QString casing_path = ao_app->get_theme_path("casing.png");
+  QString amswap_path = ao_app->get_theme_path("amswap.png");
+  QString ooc_toggle_path = ao_app->get_theme_path("ooc_toggle_ms.png");
+
+  if (file_exists(change_char_path)) {change_char_fallback = false;}
+  else {change_char_fallback = true;}
+  if (file_exists(reload_theme_path)) {reload_theme_fallback = false;}
+  else {reload_theme_fallback = true;}
+  if (file_exists(settings_path)) {settings_fallback = false;}
+  else {settings_fallback = true;}
+  if (file_exists(call_mod_path)) {call_mod_fallback = false;}
+  else {call_mod_fallback = true;}
+  if (file_exists(casing_path)) {casing_fallback = false;}
+  else {casing_fallback = true;}
+  if (file_exists(amswap_path)) {amswap_fallback = false;}
+  else {amswap_fallback = true;}
+  if (file_exists(ooc_toggle_path)) {ooc_toggle_fallback = false;}
+  else {ooc_toggle_fallback = true;}
 }
 
 class AOFrameThreadingPre : public QRunnable
@@ -3314,16 +3397,24 @@ void Courtroom::on_ooc_toggle_clicked()
   {
     ui_ms_chatlog->show();
     ui_server_chatlog->hide();
-    ui_ooc_toggle->setText(tr("Master"));
-
+    ui_ooc_toggle->setText(tr(""));
+    ui_ooc_toggle->set_image("ooc_toggle_ms.png");
+    if (ooc_toggle_fallback)
+    {
+      ui_ooc_toggle->setText(tr("Master"));
+    }
     server_ooc = false;
   }
   else
   {
     ui_ms_chatlog->hide();
     ui_server_chatlog->show();
-    ui_ooc_toggle->setText(tr("Server"));
-
+    ui_ooc_toggle->setText(tr(""));
+    ui_ooc_toggle->set_image("ooc_toggle_server.png");
+    if (ooc_toggle_fallback)
+    {
+      ui_ooc_toggle->setText(tr("Server"));
+    }
     server_ooc = true;
   }
 }
@@ -3764,6 +3855,8 @@ void Courtroom::on_reload_theme_clicked()
 
   //to update status on the background
   set_background(current_background);
+  //to update fallback text bools
+  detect_fallback_text();
   enter_courtroom(m_cid);
 
   anim_state = 4;


### PR DESCRIPTION
These UI elements can now be themed:
- 'Change character' button
- 'Reload theme' button
- 'Settings' button
- 'Call mod' button
- 'Casing' button
- 'A/M' (Area/Music list toggle) button
- 'Master/Server' (OOC toggle) button

Additionally, these elements will fall back on the original behavior (simple text) if the correct image is not present in the current theme's folder.