### PR TITLE
Fix an oversight with the pos dropdown, add a small feature

### DIFF
--- a/src/courtroom.cpp
+++ b/src/courtroom.cpp
@@ -991,6 +991,12 @@ void Courtroom::enter_courtroom(int p_cid)
 
   QString side = ao_app->get_char_side(current_char);
 
+  // We block signals from ui_pos_dropdown to stop on_pos_dropdown_changed from firing here.
+  // Per the Qt docs, QSignalBlocker only affects the rest of this function,
+  // so it doesn't stop the dropdown from working once we finish here.
+  const QSignalBlocker blocker(ui_pos_dropdown);
+  ui_pos_dropdown->setCurrentText(side);
+
   if (side == "jud")
   {
     ui_witness_testimony->show();
@@ -3436,7 +3442,7 @@ void Courtroom::on_pos_dropdown_changed(int p_index)
 {
   ui_ic_chat_message->setFocus();
 
-  if (p_index < 0 || p_index > 5)
+  if (p_index < 0 || p_index > 7)
     return;
 
   toggle_judge_buttons(false);
@@ -3463,6 +3469,12 @@ void Courtroom::on_pos_dropdown_changed(int p_index)
     break;
   case 5:
     f_pos = "hlp";
+    break;
+  case 6:
+    f_pos = "jur";
+    break;
+  case 7:
+    f_pos = "sea";
     break;
   default:
     f_pos = "";


### PR DESCRIPTION
This PR does two things:

1. It fixes an oversight that would cause the `jur` and `sea` options in the dropdown to not do anything, and
2. It adds a couple lines to `enter_courtroom` that update the dropdown to reflect the character's position as defined by `current_char`, piggybacking off the existing `side` var used to show or hide judge buttons.