### PR TITLE
Automatically truncate labels if they are too long to fit in the theme-specified bounds

### DIFF
--- a/include/courtroom.h
+++ b/include/courtroom.h
@@ -29,6 +29,7 @@
 #include <QCheckBox>
 #include <QCloseEvent>
 #include <QComboBox>
+#include <QCoreApplication>
 #include <QDebug>
 #include <QFileDialog>
 #include <QFont>
@@ -256,6 +257,10 @@ public:
   void check_connection_received();
 
   void refresh_iclog(bool skiplast);
+
+  // Truncates text so it fits within theme-specified boundaries and sets the tooltip to the full string
+  void truncate_label_text(QCheckBox* p_checkbox, QString p_identifier);
+  void truncate_label_text(QLabel* p_label, QString p_identifier);
 
   ~Courtroom();
 

--- a/src/charselect.cpp
+++ b/src/charselect.cpp
@@ -110,6 +110,9 @@ void Courtroom::construct_char_select()
           SLOT(on_char_passworded_clicked()));
   connect(ui_char_taken, SIGNAL(stateChanged(int)), this,
           SLOT(on_char_taken_clicked()));
+
+  truncate_label_text(ui_char_taken, "char_taken");
+  truncate_label_text(ui_char_passworded, "char_passworded");
 }
 
 void Courtroom::set_char_select()


### PR DESCRIPTION
This PR adds a bit of QoL functionality to label text by truncating it with an ellipse when it's too long for the bounds given by the theme and setting the widget's tooltip to the full text. You can see it in action [here](https://cdn.discordapp.com/attachments/691103597747765278/703447004277374996/unknown.png).

This is mainly in order to allow translations to translate these labels instead of leaving them as-is. Note that for this to take effect **all current translations will need to be updated** with the missing labels.

I've also moved setting of most widgets' text to the `set_widgets()` function, both for consistency and to make sure labels can be re-truncated if the theme is edited and reloaded.

Finally, this PR removes the qDebug message in the `chat_tick` function and replaces it with a friendly reminder not to leave those in there. Lots of spam. Ungood.

I'm making a PR mainly because I see this as more of a fix than a feature, but it certainly needs quite a bit of refinement so it may be better served as part of a later release (>2.7).