### PR TITLE
Fix ui_vp_evidence_display being incorrectly displayed relative to the entire window instead of the viewport

### DIFF
--- a/src/aoevidencedisplay.cpp
+++ b/src/aoevidencedisplay.cpp
@@ -49,7 +49,7 @@ void AOEvidenceDisplay::show_evidence(QString p_evidence_image,
 
   evidence_icon->move(icon_dimensions.x, icon_dimensions.y);
   if (icon_dimensions.width == -1 || icon_dimensions.height == -1) // user's default theme is missing the values
-    evidence_icon->resize(70,70);
+    evidence_icon->resize(70, 70);
   else
     evidence_icon->resize(icon_dimensions.width, icon_dimensions.height);
 

--- a/src/aoevidencedisplay.cpp
+++ b/src/aoevidencedisplay.cpp
@@ -32,6 +32,9 @@ void AOEvidenceDisplay::show_evidence(QString p_evidence_image,
   QString gif_name;
   QString icon_identifier;
 
+  pos_size_type viewport_dimensions =
+      ao_app->get_element_dimensions("viewport", "courtroom_design.ini");
+
   if (is_left_side) {
     icon_identifier = "left_evidence_icon";
     gif_name = "evidence_appear_left.gif";
@@ -45,7 +48,10 @@ void AOEvidenceDisplay::show_evidence(QString p_evidence_image,
       ao_app->get_element_dimensions(icon_identifier, "courtroom_design.ini");
 
   evidence_icon->move(icon_dimensions.x, icon_dimensions.y);
-  evidence_icon->resize(icon_dimensions.width, icon_dimensions.height);
+  if (icon_dimensions.width == -1 || icon_dimensions.height == -1) // user's default theme is missing the values
+    evidence_icon->resize(70,70);
+  else
+    evidence_icon->resize(icon_dimensions.width, icon_dimensions.height);
 
   evidence_icon->setPixmap(f_pixmap.scaled(
       evidence_icon->width(), evidence_icon->height(), Qt::IgnoreAspectRatio));
@@ -59,6 +65,7 @@ void AOEvidenceDisplay::show_evidence(QString p_evidence_image,
     final_gif_path = f_default_gif_path;
 
   evidence_movie->setFileName(final_gif_path);
+  evidence_movie->setScaledSize(QSize(viewport_dimensions.width, viewport_dimensions.height));
 
   if (evidence_movie->frameCount() < 1)
     return;

--- a/src/courtroom.cpp
+++ b/src/courtroom.cpp
@@ -545,7 +545,7 @@ void Courtroom::set_widgets()
   ui_vp_legacy_desk->move(0, final_y);
   ui_vp_legacy_desk->hide();
 
-  ui_vp_evidence_display->move(0, 0);
+  ui_vp_evidence_display->move(ui_viewport->x(), ui_viewport->y());
   ui_vp_evidence_display->resize(ui_viewport->width(), ui_viewport->height());
 
   set_size_and_pos(ui_vp_showname, "showname");


### PR DESCRIPTION
Additionally, adds a safeguard for a somewhat common issue related to broken default themes - evidence icons will now be displayed at 0,0 relative to the viewport and at 70px when the theme values `left_evidence_icon` and `right_evidence_icon` are not present.

Fixes #151.