### PR TITLE
Music loop fix

### DIFF
--- a/include/aomusicplayer.h
+++ b/include/aomusicplayer.h
@@ -25,8 +25,8 @@ public:
   const int m_channelmax = 4;
 
   // These have to be public for the stupid sync thing
-  int loop_start = 0;
-  int loop_end = 0;
+  int loop_start[4] = {0, 0, 0, 0};
+  int loop_end[4] = {0, 0, 0, 0};
 
 public slots:
   void play(QString p_song, int channel = 0, bool loop = false,


### PR DESCRIPTION
Fix an issue where the Ambience layer would break looping points for all other channels due to loop_start and loop_end only being a single variable.
This occurs due to BASS not having any private variables of its own, so it was simply using the public variables loop_start and loop_end as reference - since those changed for any new song playing on another channel, the old looping points got replaced, and the seamless looping stops working.
The solution was easy - just make a  loop_start/loop_end variable for every supported channel - so 4 variables in our case.
