### PR TITLE
Fix sounds/blips folder not properly seeking for the default male sfx

### DIFF
--- a/src/text_file_functions.cpp
+++ b/src/text_file_functions.cpp
@@ -633,7 +633,7 @@ QString AOApplication::get_gender(QString p_char)
   QString f_result = read_char_ini(p_char, "gender", "Options");
 
   if (f_result == "")
-    return "sfx-blipmale";
+    f_result = "male";
 
   if (!file_exists(get_sfx_suffix(get_sounds_path(f_result)))) {
     if (file_exists(get_sfx_suffix(get_sounds_path("../blips/" + f_result))))


### PR DESCRIPTION
If a blipsound was not defined on the character, the client would try to seek for sfx-blipmale in base/general/ folder. However, with the introduction of the base/sounds/blips/ folder, it *SHOULD* look for base/sounds/blips/male first.

This resolves that particular issue and implements expected behavior. During my testing, defined gender= in char.ini works with blips/ folder and prioritizes that folder over the sounds folder.