### PR TITLE
Fix missing talk animation when colors in base/misc/default/config.ini are improperly defined

### DIFF
--- a/src/courtroom.cpp
+++ b/src/courtroom.cpp
@@ -4245,7 +4245,7 @@ void Courtroom::set_text_color_dropdown()
                                   current_char) == "1");
     color_markdown_talking_list.append(
         ao_app->get_chat_markdown("c" + QString::number(c) + "_talking",
-                                  current_char) == "1");
+                                  current_char) != "0");
 
     QString color_name = ao_app->get_chat_markdown(
         "c" + QString::number(c) + "_name", current_char);

--- a/src/text_file_functions.cpp
+++ b/src/text_file_functions.cpp
@@ -449,38 +449,6 @@ QColor AOApplication::get_chat_color(QString p_identifier, QString p_chat)
 {
   QColor return_color(255, 255, 255);
 
-  switch (p_identifier.toInt()) {
-  case 0: // White
-    return_color = QColor(255, 255, 255);
-    break;
-  case 1: // Green
-    return_color = QColor(0, 255, 0);
-    break;
-  case 2: // Red
-    return_color = QColor(255, 0, 0);
-    break;
-  case 3: // Orange
-    return_color = QColor(255, 165, 0);
-    break;
-  case 4: // Blue
-    return_color = QColor(45, 150, 255);
-    break;
-  case 5: // Yellow
-    return_color = QColor(255, 255, 0);
-    break;
-  case 6: // Pink
-    return_color = QColor(255, 192, 203);
-    break;
-  case 7: // Cyan
-    return_color = QColor(0, 255, 255);
-    break;
-  case 8: // Grey
-    return_color = QColor(187, 187, 187);
-    break;
-  default:
-    return_color = QColor(255, 255, 255);
-    break;
-  }
   QString design_ini_path = get_base_path() + "misc/" + p_chat + "/config.ini";
   QString default_path = get_base_path() + "misc/default/config.ini";
   QString f_result = read_design_ini("c" + p_identifier, design_ini_path);


### PR DESCRIPTION
base/misc/default/config.ini with properly defined "baseline" colors will have to be supplied with vanilla content later.
Remove hardcoded colors - user has no access to these unless config.ini is valid, yet when others speak using these ID's their text shows up just fine.
Either reimplement full on hardcoding madness (NOOOOOOOOOOOOOOOOOOOOOOOO NO NO NO NOOOOOOOOOOOOOOOO NOOOOO!!!!) or yeet.
I chose the sensible option :^)