### PR TITLE
2.8 Bug fixes and QoL changes

### DIFF
--- a/include/aoapplication.h
+++ b/include/aoapplication.h
@@ -427,6 +427,9 @@ public:
   // Get the message for the CM for casing alerts.
   QString get_casing_can_host_cases();
 
+  // Get if automatic logging is enabled
+  bool get_casing_auto_logging_enabled();
+
   // The file name of the log file in base/logs.
   QString log_filename;
 

--- a/include/aoemotebutton.h
+++ b/include/aoemotebutton.h
@@ -25,6 +25,7 @@ private:
 
   int m_id = 0;
 
+
 signals:
   void emote_clicked(int p_id);
 

--- a/include/aoemotebutton.h
+++ b/include/aoemotebutton.h
@@ -2,7 +2,7 @@
 #define AOEMOTEBUTTON_H
 
 #include "aoapplication.h"
-
+#include "qpainter.h"
 #include <QDebug>
 #include <QPushButton>
 

--- a/include/aomusicplayer.h
+++ b/include/aomusicplayer.h
@@ -27,7 +27,7 @@ public:
   // These have to be public for the stupid sync thing
   int loop_start[4] = {0, 0, 0, 0};
   int loop_end[4] = {0, 0, 0, 0};
-
+  bool is_playing = false;
 public slots:
   void play(QString p_song, int channel = 0, bool loop = false,
             int effect_flags = 0);

--- a/include/aooptionsdialog.h
+++ b/include/aooptionsdialog.h
@@ -131,6 +131,8 @@ private:
   QCheckBox *ui_casing_cm_cb;
   QLabel *ui_casing_cm_cases_lbl;
   QLineEdit *ui_casing_cm_cases_textbox;
+  QLabel *ui_casing_log_lbl;
+  QCheckBox *ui_casing_log_cb;
 
   bool needs_default_audiodev();
 

--- a/include/chatlogpiece.h
+++ b/include/chatlogpiece.h
@@ -10,9 +10,9 @@ class chatlogpiece {
 public:
   chatlogpiece();
   chatlogpiece(QString p_name, QString p_showname, QString p_message,
-               bool p_song);
+               bool p_song,int color);
   chatlogpiece(QString p_name, QString p_showname, QString p_message,
-               bool p_song, QDateTime p_datetime);
+               bool p_song, int color,QDateTime p_datetime);
 
   QString get_name();
   QString get_showname();
@@ -20,7 +20,7 @@ public:
   bool is_song();
   QDateTime get_datetime();
   QString get_datetime_as_string();
-
+  int get_chat_color();
   QString get_full();
 
 private:
@@ -28,6 +28,7 @@ private:
   QString showname;
   QString message;
   QDateTime datetime;
+  int color;
   bool p_is_song;
 };
 

--- a/include/courtroom.h
+++ b/include/courtroom.h
@@ -664,6 +664,8 @@ private slots:
 
   void on_ooc_return_pressed();
 
+  void on_music_search_return_pressed();
+
   void on_music_search_edited(QString p_text);
   void on_music_list_double_clicked(QTreeWidgetItem *p_item, int column);
   void on_music_list_context_menu_requested(const QPoint &pos);

--- a/include/courtroom.h
+++ b/include/courtroom.h
@@ -221,7 +221,7 @@ public:
   // this function keeps the chatlog scrolled to the top unless there's text
   // selected
   // or the user isn't already scrolled to the top
-  void append_ic_text(QString p_text, QString p_name = "", QString action = "");
+  void append_ic_text(QString p_text, QString p_name = "", QString action = "", int color = 0);
 
   // prints who played the song to IC chat and plays said song(if found on local
   // filesystem) takes in a list where the first element is the song name and the

--- a/src/aoemotebutton.cpp
+++ b/src/aoemotebutton.cpp
@@ -17,6 +17,7 @@ AOEmoteButton::AOEmoteButton(QWidget *p_parent, AOApplication *p_ao_app,
 
 void AOEmoteButton::set_image(QString p_image, QString p_emote_comment)
 {
+
   if (file_exists(p_image)) {
     this->setText("");
     this->setStyleSheet(
@@ -28,8 +29,15 @@ void AOEmoteButton::set_image(QString p_image, QString p_emote_comment)
     if(p_image.contains("_off") || p_image.contains("_on")){
         //Since we can't detect a button, lets just generate one!
         QString tmp_p_image = p_image;
-        if(!file_exists(tmp_p_image.replace("_off","_on")))
-           tmp_p_image.replace("_on","_off");
+        //if neither buttons exist then just throw some text
+        if(!file_exists(tmp_p_image.replace("_off","_on")) && !file_exists(tmp_p_image.replace("_on","_off")))
+        {
+            this->setText(p_emote_comment);
+            this->setStyleSheet("QPushButton { border-image: url(); }"
+                                "QToolTip { background-image: url(); color: #000000; "
+                                "background-color: #ffffff; border: 0px; }");
+            return;
+        }
 
         QImage *tmpImage = new QImage(tmp_p_image);
             QPoint p1, p2;
@@ -51,14 +59,14 @@ void AOEmoteButton::set_image(QString p_image, QString p_emote_comment)
        set_image(p_image,p_emote_comment);
 
     } else {
-    this->setText(p_emote_comment);
-    this->setStyleSheet("QPushButton { border-image: url(); }"
-                        "QToolTip { background-image: url(); color: #000000; "
-                        "background-color: #ffffff; border: 0px; }");
+        this->setText(p_emote_comment);
+        this->setStyleSheet("QPushButton { border-image: url(); }"
+                            "QToolTip { background-image: url(); color: #000000; "
+                            "background-color: #ffffff; border: 0px; }");
     }
   }
-
 }
+
 void AOEmoteButton::set_char_image(QString p_char, int p_emote, QString suffix)
 {
 

--- a/src/aoemotebutton.cpp
+++ b/src/aoemotebutton.cpp
@@ -50,13 +50,13 @@ void AOEmoteButton::set_image(QString p_image, QString p_emote_comment)
        tmpImage->save(p_image,"png");
        set_image(p_image,p_emote_comment);
 
-    }
+    } else {
     this->setText(p_emote_comment);
     this->setStyleSheet("QPushButton { border-image: url(); }"
                         "QToolTip { background-image: url(); color: #000000; "
                         "background-color: #ffffff; border: 0px; }");
+    }
   }
-}
 
 void AOEmoteButton::set_char_image(QString p_char, int p_emote, QString suffix)
 {

--- a/src/aoemotebutton.cpp
+++ b/src/aoemotebutton.cpp
@@ -58,6 +58,7 @@ void AOEmoteButton::set_image(QString p_image, QString p_emote_comment)
     }
   }
 
+}
 void AOEmoteButton::set_char_image(QString p_char, int p_emote, QString suffix)
 {
 

--- a/src/aoemotebutton.cpp
+++ b/src/aoemotebutton.cpp
@@ -25,6 +25,32 @@ void AOEmoteButton::set_image(QString p_image, QString p_emote_comment)
         "QToolTip { color: #000000; background-color: #ffffff; border: 0px; }");
   }
   else {
+    if(p_image.contains("_off") || p_image.contains("_on")){
+        //Since we can't detect a button, lets just generate one!
+        QString tmp_p_image = p_image;
+        if(!file_exists(tmp_p_image.replace("_off","_on")))
+           tmp_p_image.replace("_on","_off");
+
+        QImage *tmpImage = new QImage(tmp_p_image);
+            QPoint p1, p2;
+            p2.setY(tmpImage->height());
+
+            QLinearGradient gradient(p1, p2);
+            gradient.setColorAt(0, Qt::transparent);
+            gradient.setColorAt(1, QColor(0, 0, 0, 159));
+
+            QPainter p(tmpImage);
+            p.fillRect(0, 0, tmpImage->width(), tmpImage->height(), gradient);
+
+            gradient.setColorAt(0,QColor(0, 0, 0, 159));
+            gradient.setColorAt(1, Qt::transparent);
+            p.fillRect(0,0, tmpImage->width(), tmpImage->height(), gradient);
+
+            p.end();
+       tmpImage->save(p_image,"png");
+       set_image(p_image,p_emote_comment);
+
+    }
     this->setText(p_emote_comment);
     this->setStyleSheet("QPushButton { border-image: url(); }"
                         "QToolTip { background-image: url(); color: #000000; "
@@ -34,6 +60,7 @@ void AOEmoteButton::set_image(QString p_image, QString p_emote_comment)
 
 void AOEmoteButton::set_char_image(QString p_char, int p_emote, QString suffix)
 {
+
   QString emotion_number = QString::number(p_emote + 1);
   QString image_path =
       ao_app->get_static_image_suffix(ao_app->get_character_path(

--- a/src/aolineedit.cpp
+++ b/src/aolineedit.cpp
@@ -11,8 +11,11 @@ void AOLineEdit::mouseDoubleClickEvent(QMouseEvent *e)
 void AOLineEdit::focusOutEvent(QFocusEvent *ev)
 {
   int start = selectionStart();
-  int len = selectionEnd() - start; // We're not using selectionLength because
-                                    // Linux build doesn't run qt5.10
+  #if QT_VERSION >= QT_VERSION_CHECK(5, 10, 0)
+  int len = selectionLength();
+#else
+  int len = selectedText().length();
+#endif
   QLineEdit::focusOutEvent(ev);
   if (p_selection && start != -1 && len != -1)
     this->setSelection(start, len);

--- a/src/aomusicplayer.cpp
+++ b/src/aomusicplayer.cpp
@@ -23,7 +23,7 @@ void AOMusicPlayer::play(QString p_song, int channel, bool loop,
   if (channel < 0) // wtf?
     return;
   QString f_path = ao_app->get_music_path(p_song);
-
+  is_playing = true;
   unsigned int flags = BASS_STREAM_PRESCAN | BASS_STREAM_AUTOFREE |
                        BASS_UNICODE | BASS_ASYNCFILE;
   if (loop)
@@ -117,6 +117,7 @@ void AOMusicPlayer::play(QString p_song, int channel, bool loop,
 
 void AOMusicPlayer::stop(int channel)
 {
+    is_playing = false;
   BASS_ChannelStop(m_stream_list[channel]);
 }
 
@@ -213,9 +214,9 @@ void AOMusicPlayer::set_volume(int p_value, int channel)
 AOMusicPlayer::~AOMusicPlayer() {}
 
 void AOMusicPlayer::play(QString p_song, int channel, bool loop,
-                         int effect_flags) {}
+                         int effect_flags) {is_playing = true;}
 
-void AOMusicPlayer::stop(int channel) {}
+void AOMusicPlayer::stop(int channel) {is_playing = false;}
 
 void AOMusicPlayer::set_volume(int p_value, int channel) {}
 

--- a/src/aooptionsdialog.cpp
+++ b/src/aooptionsdialog.cpp
@@ -697,6 +697,20 @@ AOOptionsDialog::AOOptionsDialog(QWidget *parent, AOApplication *p_ao_app)
 
   ui_casing_layout->setWidget(row, QFormLayout::FieldRole,
                               ui_casing_cm_cases_textbox);
+  //Check whether mass logging is enabled
+  row += 1;
+  ui_casing_log_lbl = new QLabel(ui_casing_widget);
+  ui_casing_log_lbl->setText(tr("Automatic Logging:"));
+  ui_casing_log_lbl->setToolTip(
+      tr("If checked, all logs will be automatically written in the "
+         "/logs folder."));
+
+  ui_casing_layout->setWidget(row, QFormLayout::LabelRole, ui_casing_log_lbl);
+
+  ui_casing_log_cb = new QCheckBox(ui_casing_widget);
+  ui_casing_log_cb->setChecked(ao_app->get_casing_auto_logging_enabled());
+
+  ui_casing_layout->setWidget(row, QFormLayout::FieldRole, ui_casing_log_cb);
 
   // When we're done, we should continue the updates!
   setUpdatesEnabled(true);
@@ -723,7 +737,7 @@ void AOOptionsDialog::save_pressed()
   configini->setValue("stickyeffects", ui_stickyeffects_cb->isChecked());
   configini->setValue("stickypres", ui_stickypres_cb->isChecked());
   configini->setValue("customchat", ui_customchat_cb->isChecked());
-
+  configini->setValue("automatic_logging_enabled", ui_casing_log_cb->isChecked());
   QFile *callwordsini = new QFile(ao_app->get_base_path() + "callwords.ini");
 
   if (callwordsini->open(QIODevice::WriteOnly | QIODevice::Truncate |

--- a/src/chatlogpiece.cpp
+++ b/src/chatlogpiece.cpp
@@ -5,27 +5,31 @@ chatlogpiece::chatlogpiece()
   name = tr("UNKNOWN");
   showname = tr("UNKNOWN");
   message = tr("UNKNOWN");
+  color = 0;
   p_is_song = false;
   datetime = QDateTime::currentDateTime().toUTC();
 }
 
 chatlogpiece::chatlogpiece(QString p_name, QString p_showname,
-                           QString p_message, bool p_song)
+                           QString p_message, bool p_song, int p_color)
 {
   name = p_name;
   showname = p_showname;
   message = p_message;
   p_is_song = p_song;
+  color = p_color;
   datetime = QDateTime::currentDateTime().toUTC();
 }
 
 chatlogpiece::chatlogpiece(QString p_name, QString p_showname,
-                           QString p_message, bool p_song, QDateTime p_datetime)
+                           QString p_message, bool p_song, int p_color,
+                           QDateTime p_datetime)
 {
   name = p_name;
   showname = p_showname;
   message = p_message;
   p_is_song = p_song;
+  color = p_color;
   datetime = p_datetime.toUTC();
 }
 
@@ -40,6 +44,8 @@ QDateTime chatlogpiece::get_datetime() { return datetime; }
 bool chatlogpiece::is_song() { return p_is_song; }
 
 QString chatlogpiece::get_datetime_as_string() { return datetime.toString(); }
+
+int chatlogpiece::get_chat_color() { return color; }
 
 QString chatlogpiece::get_full()
 {

--- a/src/courtroom.cpp
+++ b/src/courtroom.cpp
@@ -4413,6 +4413,8 @@ void Courtroom::on_reload_theme_clicked()
 
   enter_courtroom();
   update_character(m_cid);
+  if (music_player->is_playing)
+    ui_music_display->play("music_display");
 
   anim_state = 4;
   text_state = 3;

--- a/src/courtroom.cpp
+++ b/src/courtroom.cpp
@@ -1786,7 +1786,7 @@ void Courtroom::handle_chatmessage(QStringList *p_contents)
     f_charname = ao_app->get_showname(char_list.at(f_char_id).name);
 
   chatlogpiece *temp =
-      new chatlogpiece(f_charname, f_showname, m_chatmessage[MESSAGE], false);
+      new chatlogpiece(f_charname, f_showname, m_chatmessage[MESSAGE], false,m_chatmessage[TEXT_COLOR].toInt());
   ic_chatlog_history.append(*temp);
   if (ao_app->get_casing_auto_logging_enabled())
     ao_app->append_to_file(temp->get_full(), ao_app->log_filename, true);
@@ -1796,7 +1796,7 @@ void Courtroom::handle_chatmessage(QStringList *p_contents)
     ic_chatlog_history.removeFirst();
   }
 
-  append_ic_text(m_chatmessage[MESSAGE], f_showname);
+  append_ic_text(m_chatmessage[MESSAGE], f_showname,"",m_chatmessage[TEXT_COLOR].toInt());
 
   int objection_mod = m_chatmessage[OBJECTION_MOD].toInt();
   QString f_char = m_chatmessage[CHAR_NAME];
@@ -2469,7 +2469,7 @@ QString Courtroom::filter_ic_text(QString p_text, bool html, int target_pos,
   return p_text_escaped;
 }
 
-void Courtroom::append_ic_text(QString p_text, QString p_name, QString p_action)
+void Courtroom::append_ic_text(QString p_text, QString p_name, QString p_action,int color)
 {
   QTextCharFormat bold;
   QTextCharFormat normal;
@@ -2482,7 +2482,7 @@ void Courtroom::append_ic_text(QString p_text, QString p_name, QString p_action)
 
   if (p_action == "")
     p_text = filter_ic_text(p_text, ao_app->is_colorlog_enabled(), -1,
-                            m_chatmessage[TEXT_COLOR].toInt());
+                            color);
 
   if (log_goes_downwards) {
     const bool is_scrolled_down =
@@ -3067,7 +3067,7 @@ void Courtroom::handle_song(QStringList *p_contents)
     }
 
     if (!mute_map.value(n_char)) {
-      chatlogpiece *temp = new chatlogpiece(str_char, str_show, f_song, true);
+      chatlogpiece *temp = new chatlogpiece(str_char, str_show, f_song, true, m_chatmessage[TEXT_COLOR].toInt());
       ic_chatlog_history.append(*temp);
       if (ao_app->get_casing_auto_logging_enabled())
         ao_app->append_to_file(temp->get_full(), ao_app->log_filename, true);
@@ -4502,14 +4502,14 @@ void Courtroom::on_showname_enable_clicked()
         append_ic_text(item.get_message(), item.get_showname(),
                        tr("has played a song"));
       else
-        append_ic_text(item.get_message(), item.get_showname());
+        append_ic_text(item.get_message(), item.get_showname(),"",item.get_chat_color());
     }
     else {
       if (item.is_song())
         append_ic_text(item.get_message(), item.get_name(),
                        tr("has played a song"));
       else
-        append_ic_text(item.get_message(), item.get_name());
+        append_ic_text(item.get_message(), item.get_name(),"",item.get_chat_color());
     }
   }
 

--- a/src/courtroom.cpp
+++ b/src/courtroom.cpp
@@ -1787,7 +1787,8 @@ void Courtroom::handle_chatmessage(QStringList *p_contents)
   chatlogpiece *temp =
       new chatlogpiece(f_charname, f_showname, m_chatmessage[MESSAGE], false);
   ic_chatlog_history.append(*temp);
-  ao_app->append_to_file(temp->get_full(), ao_app->log_filename, true);
+  if (ao_app->get_casing_auto_logging_enabled())
+    ao_app->append_to_file(temp->get_full(), ao_app->log_filename, true);
 
   while (ic_chatlog_history.size() > log_maximum_blocks &&
          log_maximum_blocks > 0) {
@@ -3067,7 +3068,8 @@ void Courtroom::handle_song(QStringList *p_contents)
     if (!mute_map.value(n_char)) {
       chatlogpiece *temp = new chatlogpiece(str_char, str_show, f_song, true);
       ic_chatlog_history.append(*temp);
-      ao_app->append_to_file(temp->get_full(), ao_app->log_filename, true);
+      if (ao_app->get_casing_auto_logging_enabled())
+        ao_app->append_to_file(temp->get_full(), ao_app->log_filename, true);
 
       while (ic_chatlog_history.size() > log_maximum_blocks &&
              log_maximum_blocks > 0) {

--- a/src/courtroom.cpp
+++ b/src/courtroom.cpp
@@ -1879,8 +1879,12 @@ void Courtroom::handle_chatmessage_2()
       ui_vp_chatbox->set_image("chatbox");
 
     QFontMetrics fm(ui_vp_showname->font());
+    //Gotta support the slow paced ubuntu 18 STUCK IN 5.9.5!!
+    #if QT_VERSION > QT_VERSION_CHECK(5, 11, 0)
     int fm_width = fm.horizontalAdvance(ui_vp_showname->text());
-
+    #else
+    int fm_width = fm.boundingRect((ui_vp_showname->text())).width();
+    #endif
     QString chatbox_path = ao_app->get_theme_path("chat");
     QString chatbox = ao_app->get_chat(m_chatmessage[CHAR_NAME]);
     QString customchar;
@@ -4290,7 +4294,12 @@ void Courtroom::on_text_color_changed(int p_color)
     if (markdown_end.isEmpty())
       markdown_end = markdown_start;
     int start = ui_ic_chat_message->selectionStart();
-    int end = ui_ic_chat_message->selectionEnd() + 1;
+#if QT_VERSION >= QT_VERSION_CHECK(5, 10, 0)
+     int end = ui_ic_chat_message->selectionEnd() + 1;
+    #else
+    int end = ui_ic_chat_message->selectedText().length() + 1;
+    #endif
+
     ui_ic_chat_message->setCursorPosition(start);
     ui_ic_chat_message->insert(markdown_start);
     ui_ic_chat_message->setCursorPosition(end);

--- a/src/courtroom.cpp
+++ b/src/courtroom.cpp
@@ -1349,10 +1349,11 @@ void Courtroom::list_music()
     ++n_listed_songs;
   }
 
-  ui_music_list->expandAll(); // Needs to somehow remember which categories were
-                              // expanded/collapsed if the music list didn't
-                              // change since last time
+  ui_music_list->collapseAll();
   if (ui_music_search->text() != "") {
+      ui_music_list->expandAll(); // Needs to somehow remember which categories were
+                                  // expanded/collapsed if the music list didn't
+                                  // change since last time
     on_music_search_edited(ui_music_search->text());
   }
 }

--- a/src/courtroom.cpp
+++ b/src/courtroom.cpp
@@ -322,6 +322,8 @@ Courtroom::Courtroom(AOApplication *p_ao_app) : QMainWindow()
   connect(ui_effects_dropdown, SIGNAL(customContextMenuRequested(QPoint)), this,
           SLOT(on_effects_context_menu_requested(QPoint)));
 
+  connect(ui_music_search, SIGNAL(returnPressed()), this,
+          SLOT(on_music_search_keypr()));
   connect(ui_mute_list, SIGNAL(clicked(QModelIndex)), this,
           SLOT(on_mute_list_clicked(QModelIndex)));
 
@@ -3539,6 +3541,13 @@ void Courtroom::on_music_search_edited(QString p_text)
         item->setHidden(false);
       }
     }
+  }
+}
+
+void Courtroom::on_music_search_keypr()
+{
+  if (ui_music_search->text() == "") {
+    ui_music_list->collapseAll();
   }
 }
 

--- a/src/courtroom.cpp
+++ b/src/courtroom.cpp
@@ -323,7 +323,7 @@ Courtroom::Courtroom(AOApplication *p_ao_app) : QMainWindow()
           SLOT(on_effects_context_menu_requested(QPoint)));
 
   connect(ui_music_search, SIGNAL(returnPressed()), this,
-          SLOT(on_music_search_keypr()));
+          SLOT(on_music_search_return_pressed()));
   connect(ui_mute_list, SIGNAL(clicked(QModelIndex)), this,
           SLOT(on_mute_list_clicked(QModelIndex)));
 
@@ -1351,7 +1351,7 @@ void Courtroom::list_music()
     ++n_listed_songs;
   }
 
-  ui_music_list->collapseAll();
+  ui_music_list->expandAll();
   if (ui_music_search->text() != "") {
       ui_music_list->expandAll(); // Needs to somehow remember which categories were
                                   // expanded/collapsed if the music list didn't
@@ -3502,6 +3502,7 @@ void Courtroom::on_ooc_toggle_clicked()
 // Todo: multithread this due to some servers having large as hell music list
 void Courtroom::on_music_search_edited(QString p_text)
 {
+    ui_music_list->expandAll();
   // Iterate through all QTreeWidgetItem items
   if (!ui_music_list->isHidden()) {
     QTreeWidgetItemIterator it(ui_music_list);
@@ -3544,7 +3545,7 @@ void Courtroom::on_music_search_edited(QString p_text)
   }
 }
 
-void Courtroom::on_music_search_keypr()
+void Courtroom::on_music_search_return_pressed()
 {
   if (ui_music_search->text() == "") {
     ui_music_list->collapseAll();

--- a/src/hardware_functions.cpp
+++ b/src/hardware_functions.cpp
@@ -3,7 +3,7 @@
 #include <QDebug>
 #include <QtGlobal>
 
-#if QT_VERSION < QT_VERSION_CHECK(5, 4, 0)
+#if QT_VERSION < QT_VERSION_CHECK(5, 11, 0)
 
 #if (defined(_WIN32) || defined(_WIN64))
 #include <windows.h>

--- a/src/lobby.cpp
+++ b/src/lobby.cpp
@@ -404,7 +404,7 @@ void Lobby::on_settings_clicked() { ao_app->call_settings_menu(); }
 void Lobby::on_server_list_clicked(QTreeWidgetItem *p_item, int column)
 {
   column = 0;
-  if (p_item->text(column).toInt() != last_index) {
+  if (p_item->text(column).toInt() != last_index || !public_servers_selected) {
     server_type f_server;
     int n_server = p_item->text(column).toInt();
     last_index = n_server;

--- a/src/packet_distribution.cpp
+++ b/src/packet_distribution.cpp
@@ -277,13 +277,16 @@ void AOApplication::server_packet_received(AOPacket *p_packet)
 
     // Remove any characters not accepted in folder names for the server_name
     // here
-    this->log_filename = QDateTime::currentDateTime().toUTC().toString(
-        "'logs/" + server_name.remove(QRegExp("[\\\\/:*?\"<>|\']")) +
-        "/'ddd MMMM yyyy hh.mm.ss t'.log'");
-    this->write_to_file("Joined server " + server_name + " on address " +
-                            server_address + " on " +
-                            QDateTime::currentDateTime().toUTC().toString(),
-                        log_filename, true);
+    if (AOApplication::get_casing_auto_logging_enabled()){
+        this->log_filename = QDateTime::currentDateTime().toUTC().toString(
+            "'logs/" + server_name.remove(QRegExp("[\\\\/:*?\"<>|\']")) +
+            "/'ddd MMMM yyyy hh.mm.ss t'.log'");
+        this->write_to_file("Joined server " + server_name + " on address " +
+                                server_address + " on " +
+                                QDateTime::currentDateTime().toUTC().toString(),
+                            log_filename, true);
+    }
+
     QCryptographicHash hash(QCryptographicHash::Algorithm::Sha256);
     hash.addData(server_address.toUtf8());
     if (is_discord_enabled())

--- a/src/scrolltext.cpp
+++ b/src/scrolltext.cpp
@@ -34,8 +34,12 @@ void ScrollText::setSeparator(QString separator)
 void ScrollText::updateText()
 {
   timer.stop();
-
+#if QT_VERSION > QT_VERSION_CHECK(5, 11, 0)
   singleTextWidth = fontMetrics().horizontalAdvance(_text);
+#else
+  singleTextWidth = fontMetrics().boundingRect(_text).width();
+#endif
+
   scrollEnabled = (singleTextWidth > width() - leftMargin * 2);
 
   if (scrollEnabled) {
@@ -47,8 +51,14 @@ void ScrollText::updateText()
     staticText.setText(_text);
 
   staticText.prepare(QTransform(), font());
+#if QT_VERSION > QT_VERSION_CHECK(5, 11, 0)
   wholeTextSize = QSize(fontMetrics().horizontalAdvance(staticText.text()),
                         fontMetrics().height());
+#else
+  wholeTextSize = QSize(fontMetrics().boundingRect(staticText.text()).width(),
+                        fontMetrics().height());
+#endif
+
 }
 
 void ScrollText::paintEvent(QPaintEvent *)

--- a/src/text_file_functions.cpp
+++ b/src/text_file_functions.cpp
@@ -1049,3 +1049,9 @@ QString AOApplication::get_casing_can_host_cases()
           .value<QString>();
   return result;
 }
+bool AOApplication::get_casing_auto_logging_enabled()
+{
+    QString result =
+        configini->value("automatic_logging_enabled", "false").value<QString>();
+    return result.startsWith("true");
+}

--- a/src/text_file_functions.cpp
+++ b/src/text_file_functions.cpp
@@ -641,7 +641,7 @@ QString AOApplication::get_char_shouts(QString p_char)
 {
   QString f_result = read_char_ini(p_char, "shouts", "Options");
   if (f_result == "")
-    return "default";
+    return current_theme; // The default option is the current theme.
   return f_result;
 }
 


### PR DESCRIPTION
### This PR includes:
**QoL**:
- **Added button darkening generator.** Missing emote buttons are automatically generated by darkening the existing emote button.  
e.g if emote1_off.png is missing, it will generate a darkened emote using "emote1_on" and vice versa.
- **Added a setting for the automatic chat logging**. It can be toggled on the casing tab.
- **If enter is hit with no search in the music search box it collapses the music list**

**Bug Fixes**    
- **Fixed Ubuntu 18 compatibility issues.** When building using qt 5.9.5 older functions are used.
- **Fixed #184** 
- **Fixed and issue with colors changing when show names are toggled**.