### PR TITLE
Make music 'fade out previous' an effect enabled by default

### DIFF
--- a/include/courtroom.h
+++ b/include/courtroom.h
@@ -415,7 +415,7 @@ private:
   QString effect = "";
 
   // Music effect flags we want to send to server when we play music
-  int music_flags = 0;
+  int music_flags = FADE_OUT;
 
   int defense_bar_state = 0;
   int prosecution_bar_state = 0;

--- a/src/lobby.cpp
+++ b/src/lobby.cpp
@@ -378,7 +378,7 @@ void Lobby::on_about_clicked()
          "Robotic Overlord, Shadowlions (aka Shali), Sierra, SomeGuy, "
          "Veritas, Wiso"
          "<p><b>Special thanks:</b><br>"
-         "CrazyJC and MaximumVolty (2.8 release); "
+         "CrazyJC (2.8 release director) and MaximumVolty (2.8 release promotion); "
          "Remy, Hibiki, court-records.net (sprites); Qubrick (webAO); "
          "Rue (website); Draxirch (UI design); "
          "Lewdton and Argoneus (tsuserver); "


### PR DESCRIPTION
Will let users experience the SMOOTH FADE OUT EXPERIENCE of AO2.8 supported servers, plus will teach people what it actually does.