### PR TITLE
Fix #193

### DIFF
--- a/src/courtroom.cpp
+++ b/src/courtroom.cpp
@@ -2154,7 +2154,6 @@ void Courtroom::play_char_sfx(QString sfx_name)
 
 void Courtroom::handle_chatmessage_3()
 {
-
   int f_evi_id = m_chatmessage[EVIDENCE_ID].toInt();
   QString f_side = m_chatmessage[SIDE];
 
@@ -2223,8 +2222,6 @@ void Courtroom::handle_chatmessage_3()
     anim_state = 3;
   }
 
-  start_chat_ticking();
-
   QString f_message = m_chatmessage[MESSAGE];
   QStringList call_words = ao_app->get_call_words();
 
@@ -2236,6 +2233,8 @@ void Courtroom::handle_chatmessage_3()
       break;
     }
   }
+
+  start_chat_ticking();
 }
 
 QString Courtroom::filter_ic_text(QString p_text, bool html, int target_pos,

--- a/src/courtroom.cpp
+++ b/src/courtroom.cpp
@@ -2154,7 +2154,6 @@ void Courtroom::play_char_sfx(QString sfx_name)
 
 void Courtroom::handle_chatmessage_3()
 {
-  start_chat_ticking();
 
   int f_evi_id = m_chatmessage[EVIDENCE_ID].toInt();
   QString f_side = m_chatmessage[SIDE];
@@ -2223,6 +2222,8 @@ void Courtroom::handle_chatmessage_3()
                                  m_chatmessage[EMOTE]);
     anim_state = 3;
   }
+
+  start_chat_ticking();
 
   QString f_message = m_chatmessage[MESSAGE];
   QStringList call_words = ao_app->get_call_words();


### PR DESCRIPTION
Fix for https://github.com/AttorneyOnline/AO2-Client/issues/193
This bug is caused by calling do_screenshake before play_idle like it would normally happen when using the screenshake button with a preanimation or with \s
This could be fixed by calling play_idle inside start_chat_ticking just before do_screenshake. Or also as done in this commit, move the call to start_chat_ticking inside handle_chatmessage_3 to after play_idle is used.