### PR TITLE
Fix emoji displaying extraneous characters

### DIFF
--- a/src/courtroom.cpp
+++ b/src/courtroom.cpp
@@ -2541,7 +2541,7 @@ QString Courtroom::filter_ic_text(QString p_text, bool html, int target_pos,
       p_text_escaped.insert(check_pos_escaped, f_character);
       check_pos_escaped += f_char_length;
     }
-    check_pos += 1;
+    check_pos += f_char_length;
   }
 
   if (!ic_color_stack.empty() && html) {


### PR DESCRIPTION
Fixes #192.

Screenshot:

![Proof of fix🐻](https://user-images.githubusercontent.com/5247009/88972849-cbc95080-d27b-11ea-8481-ff96e1f8e096.png)
