### PR TITLE
Fix not using custom chatbox's colors

### DIFF
--- a/src/courtroom.cpp
+++ b/src/courtroom.cpp
@@ -907,7 +907,6 @@ void Courtroom::set_widgets()
       tr("Change the text color of the spoken message.\n"
          "You can also select a part of your currently typed message and use "
          "the dropdown to change its color!"));
-  set_text_color_dropdown();
 
   set_size_and_pos(ui_music_slider, "music_slider");
   set_size_and_pos(ui_sfx_slider, "sfx_slider");
@@ -1236,6 +1235,8 @@ void Courtroom::update_character(int p_cid)
 
   current_char = f_char;
   current_side = ao_app->get_char_side(current_char);
+
+  set_text_color_dropdown();
 
   current_emote_page = 0;
   current_emote = 0;

--- a/src/courtroom.cpp
+++ b/src/courtroom.cpp
@@ -907,6 +907,7 @@ void Courtroom::set_widgets()
       tr("Change the text color of the spoken message.\n"
          "You can also select a part of your currently typed message and use "
          "the dropdown to change its color!"));
+  set_text_color_dropdown(); // Not calling this here crashes the client when entering a DRO server
 
   set_size_and_pos(ui_music_slider, "music_slider");
   set_size_and_pos(ui_sfx_slider, "sfx_slider");

--- a/src/courtroom.cpp
+++ b/src/courtroom.cpp
@@ -907,7 +907,9 @@ void Courtroom::set_widgets()
       tr("Change the text color of the spoken message.\n"
          "You can also select a part of your currently typed message and use "
          "the dropdown to change its color!"));
-  set_text_color_dropdown(); // Not calling this here crashes the client when entering a DRO server
+  // Not calling this here crashes the client at
+  // Courtroom::filter_ic_text if html is enabled
+  set_text_color_dropdown();
 
   set_size_and_pos(ui_music_slider, "music_slider");
   set_size_and_pos(ui_sfx_slider, "sfx_slider");

--- a/src/courtroom.cpp
+++ b/src/courtroom.cpp
@@ -1880,10 +1880,18 @@ void Courtroom::handle_chatmessage(QStringList *p_contents)
     ic_chatlog_history.removeFirst();
   }
 
-  append_ic_text(m_chatmessage[MESSAGE], f_showname, "", m_chatmessage[TEXT_COLOR].toInt());
-
   QString f_char = m_chatmessage[CHAR_NAME];
   QString f_custom_theme = ao_app->get_char_shouts(f_char);
+
+  // Load the colors in case it's using a custom chatbox with custom colors.
+  // Or reload the default ones in case it's not using custom colors
+  color_rgb_list.clear();
+  for (int c = 0; c < max_colors; ++c) {
+    QColor color = ao_app->get_chat_color("c" + QString::number(c), f_char);
+    color_rgb_list.append(color);
+  }
+
+  append_ic_text(m_chatmessage[MESSAGE], f_showname, "", m_chatmessage[TEXT_COLOR].toInt());
 
   // if an objection is used
   if (objection_mod <= 4 && objection_mod >= 1) {
@@ -1990,14 +1998,6 @@ void Courtroom::handle_chatmessage_2()
       chatbox_path = ao_app->get_base_path() + "misc/" + chatbox + "/chat";
       if (!ui_vp_chatbox->set_chatbox(chatbox_path))
         ui_vp_chatbox->set_chatbox(chatbox_path + "box");
-    }
-
-    // Load the colors in case it's using a custom chatbox with custom colors.
-    // Or reload the default ones in case it's not using custom colors
-    color_rgb_list.clear();
-    for (int c = 0; c < max_colors; ++c) {
-      QColor color = ao_app->get_chat_color("c" + QString::number(c), customchar);
-      color_rgb_list.append(color);
     }
 
     // This should probably be called only if any change from the last chat

--- a/src/courtroom.cpp
+++ b/src/courtroom.cpp
@@ -907,8 +907,6 @@ void Courtroom::set_widgets()
       tr("Change the text color of the spoken message.\n"
          "You can also select a part of your currently typed message and use "
          "the dropdown to change its color!"));
-  // Not calling this here crashes the client at
-  // Courtroom::filter_ic_text if html is enabled
   set_text_color_dropdown();
 
   set_size_and_pos(ui_music_slider, "music_slider");
@@ -1992,6 +1990,14 @@ void Courtroom::handle_chatmessage_2()
       chatbox_path = ao_app->get_base_path() + "misc/" + chatbox + "/chat";
       if (!ui_vp_chatbox->set_chatbox(chatbox_path))
         ui_vp_chatbox->set_chatbox(chatbox_path + "box");
+    }
+
+    // Load the colors in case it's using a custom chatbox with custom colors.
+    // Or reload the default ones in case it's not using custom colors
+    color_rgb_list.clear();
+    for (int c = 0; c < max_colors; ++c) {
+      QColor color = ao_app->get_chat_color("c" + QString::number(c), customchar);
+      color_rgb_list.append(color);
     }
 
     // This should probably be called only if any change from the last chat

--- a/src/text_file_functions.cpp
+++ b/src/text_file_functions.cpp
@@ -449,9 +449,9 @@ QColor AOApplication::get_chat_color(QString p_identifier, QString p_chat)
 {
   QColor return_color(255, 255, 255);
 
-  QString design_ini_path = get_base_path() + "misc/" + p_chat + "/config.ini";
+  QString design_ini_path = get_base_path() + "misc/" + get_chat(p_chat) + "/config.ini";
   QString default_path = get_base_path() + "misc/default/config.ini";
-  QString f_result = read_design_ini("c" + p_identifier, design_ini_path);
+  QString f_result = read_design_ini(p_identifier, design_ini_path);
 
   if (f_result == "") {
     f_result = read_design_ini(p_identifier, default_path);

--- a/src/text_file_functions.cpp
+++ b/src/text_file_functions.cpp
@@ -435,7 +435,7 @@ QString AOApplication::get_tagged_stylesheet(QString target_tag, QString p_file)
 
 QString AOApplication::get_chat_markdown(QString p_identifier, QString p_chat)
 {
-  QString design_ini_path = get_base_path() + "misc/" + p_chat + "/config.ini";
+  QString design_ini_path = get_base_path() + "misc/" + get_chat(p_chat) + "/config.ini";
   QString default_path = get_base_path() + "misc/default/config.ini";
   QString f_result = read_design_ini(p_identifier, design_ini_path);
 


### PR DESCRIPTION
Fix https://github.com/AttorneyOnline/AO2-Client/issues/194

```
Moved set_text_color_dropdown() to after current_char is actually updated
with the selected char. Otherwise set_text_color_dropdown will try to
update the colors with either nothing as character, or with the previously
selected character.


Use get_chat() so it actually gets the name of the custom chatbox
instead of using the same name as the character.
Remove the extra "c" since get_chat_color it's already called
with this "c" in place.
```