### PR TITLE
Optimize ARUP

### DIFF
--- a/include/courtroom.h
+++ b/include/courtroom.h
@@ -457,6 +457,14 @@ private:
   QString current_background = "default";
   QString current_side = "";
 
+  QBrush free_brush;
+  QBrush lfp_brush;
+  QBrush casing_brush;
+  QBrush recess_brush;
+  QBrush rp_brush;
+  QBrush gaming_brush;
+  QBrush locked_brush;
+
   AOMusicPlayer *music_player;
   AOSfxPlayer *sfx_player;
   AOSfxPlayer *objection_player;

--- a/include/courtroom.h
+++ b/include/courtroom.h
@@ -109,7 +109,6 @@ public:
       if (arup_locks.size() > place)
         arup_locks[place] = value;
     }
-    list_areas();
   }
 
   void character_loading_finished();

--- a/src/courtroom.cpp
+++ b/src/courtroom.cpp
@@ -70,6 +70,14 @@ Courtroom::Courtroom(AOApplication *p_ao_app) : QMainWindow()
 
   ui_background = new AOImage(this, ao_app);
 
+  free_brush = *new QBrush(ao_app->get_color("area_free_color", "courtroom_design.ini"));
+  lfp_brush = *new QBrush(ao_app->get_color("area_lfp_color", "courtroom_design.ini"));
+  casing_brush = *new QBrush(ao_app->get_color("area_casing_color", "courtroom_design.ini"));
+  recess_brush = *new QBrush(ao_app->get_color("area_recess_color", "courtroom_design.ini"));
+  rp_brush = *new QBrush(ao_app->get_color("area_rp_color", "courtroom_design.ini"));
+  gaming_brush = *new QBrush(ao_app->get_color("area_gaming_color", "courtroom_design.ini"));
+  locked_brush = *new QBrush(ao_app->get_color("area_locked_color", "courtroom_design.ini"));
+
   ui_viewport = new QWidget(this);
   ui_vp_background = new AOScene(ui_viewport, ao_app);
   ui_vp_speedlines = new AOMovie(ui_viewport, ao_app);
@@ -1433,15 +1441,6 @@ void Courtroom::list_areas()
   ui_area_list->clear();
   //  ui_music_search->setText("");
 
-  QString f_file = "courtroom_design.ini";
-
-  QBrush free_brush(ao_app->get_color("area_free_color", f_file));
-  QBrush lfp_brush(ao_app->get_color("area_lfp_color", f_file));
-  QBrush casing_brush(ao_app->get_color("area_casing_color", f_file));
-  QBrush recess_brush(ao_app->get_color("area_recess_color", f_file));
-  QBrush rp_brush(ao_app->get_color("area_rp_color", f_file));
-  QBrush gaming_brush(ao_app->get_color("area_gaming_color", f_file));
-  QBrush locked_brush(ao_app->get_color("area_locked_color", f_file));
 
   int n_listed_areas = 0;
 

--- a/src/courtroom.cpp
+++ b/src/courtroom.cpp
@@ -70,14 +70,6 @@ Courtroom::Courtroom(AOApplication *p_ao_app) : QMainWindow()
 
   ui_background = new AOImage(this, ao_app);
 
-  free_brush = *new QBrush(ao_app->get_color("area_free_color", "courtroom_design.ini"));
-  lfp_brush = *new QBrush(ao_app->get_color("area_lfp_color", "courtroom_design.ini"));
-  casing_brush = *new QBrush(ao_app->get_color("area_casing_color", "courtroom_design.ini"));
-  recess_brush = *new QBrush(ao_app->get_color("area_recess_color", "courtroom_design.ini"));
-  rp_brush = *new QBrush(ao_app->get_color("area_rp_color", "courtroom_design.ini"));
-  gaming_brush = *new QBrush(ao_app->get_color("area_gaming_color", "courtroom_design.ini"));
-  locked_brush = *new QBrush(ao_app->get_color("area_locked_color", "courtroom_design.ini"));
-
   ui_viewport = new QWidget(this);
   ui_vp_background = new AOScene(ui_viewport, ao_app);
   ui_vp_speedlines = new AOMovie(ui_viewport, ao_app);
@@ -941,6 +933,14 @@ void Courtroom::set_widgets()
   set_size_and_pos(ui_spectator, "spectator");
   ui_spectator->setToolTip(tr("Become a spectator. You won't be able to "
                               "interact with the in-character screen."));
+
+  free_brush = *new QBrush(ao_app->get_color("area_free_color", "courtroom_design.ini"));
+  lfp_brush = *new QBrush(ao_app->get_color("area_lfp_color", "courtroom_design.ini"));
+  casing_brush = *new QBrush(ao_app->get_color("area_casing_color", "courtroom_design.ini"));
+  recess_brush = *new QBrush(ao_app->get_color("area_recess_color", "courtroom_design.ini"));
+  rp_brush = *new QBrush(ao_app->get_color("area_rp_color", "courtroom_design.ini"));
+  gaming_brush = *new QBrush(ao_app->get_color("area_gaming_color", "courtroom_design.ini"));
+  locked_brush = *new QBrush(ao_app->get_color("area_locked_color", "courtroom_design.ini"));
 
   refresh_evidence();
 }

--- a/src/packet_distribution.cpp
+++ b/src/packet_distribution.cpp
@@ -676,6 +676,7 @@ void AOApplication::server_packet_received(AOPacket *p_packet)
         w_courtroom->arup_modify(arup_type, n_element - 1,
                                  f_contents.at(n_element));
       }
+      w_courtroom->list_areas();
     }
   }
   else if (header == "IL") {


### PR DESCRIPTION
Do the expensive IO operations only once, and only regen the area list once per ARUP packet.
Fixes #241 