### PR TITLE
Check for custom realization sound when using effects list

### DIFF
--- a/src/text_file_functions.cpp
+++ b/src/text_file_functions.cpp
@@ -908,6 +908,11 @@ QString AOApplication::get_effect_sound(QString fx_name, QString p_char)
       f_result = read_design_ini(fx_name, default_path);
     }
   }
+
+  if(fx_name == "realization"){
+      f_result = get_custom_realization(p_char);
+  }
+
   return f_result;
 }
 


### PR DESCRIPTION
The logic for custom realizations was relying on the old realization flag in the MS packet, which is only used when an effects list is not present. Fixes #234 