### PR TITLE
IC logic rewrite

### DIFF
--- a/include/courtroom.h
+++ b/include/courtroom.h
@@ -349,8 +349,10 @@ private:
   // amount by which we multiply the delay when we parse punctuation chars
   const int punctuation_modifier = 3;
 
-  static const int chatmessage_size = 30;
-  QString m_chatmessage[chatmessage_size];
+  // Minumum and maximum number of parameters in the MS packet
+  static const int MS_MINIMUM = 15;
+  static const int MS_MAXIMUM = 30;
+  QString m_chatmessage[MS_MAXIMUM];
   bool chatmessage_is_empty = false;
 
   QString previous_ic_message = "";

--- a/src/courtroom.cpp
+++ b/src/courtroom.cpp
@@ -1792,9 +1792,11 @@ void Courtroom::handle_chatmessage(QStringList *p_contents)
 
   QString f_displayname;
   if (!is_spectator && (m_chatmessage[SHOWNAME].isEmpty() || !ui_showname_enable->isChecked())) {
+    // If the users is not a spectator and showname is disabled, use the character's name
     f_displayname = ao_app->get_showname(char_list.at(f_char_id).name);
   }
   else {
+    // Otherwise, use the showname
     f_displayname = m_chatmessage[SHOWNAME];
   }
 
@@ -1803,20 +1805,7 @@ void Courtroom::handle_chatmessage(QStringList *p_contents)
     f_displayname = ao_app->get_showname(char_list.at(f_char_id).name);
 
   QString f_message = f_displayname + ": " + m_chatmessage[MESSAGE] + '\n';
-  // Remove undesired newline chars
-  m_chatmessage[MESSAGE].remove("\n");
-  chatmessage_is_empty =
-      m_chatmessage[MESSAGE] == " " || m_chatmessage[MESSAGE] == "";
 
-  if (f_char_id >= 0 && !chatmessage_is_empty &&
-      f_message == previous_ic_message) // Not a system message
-    return;
-
-  if (f_char_id <= -1)
-    previous_ic_message =
-        ""; // System messages don't care about repeating themselves
-  else
-    previous_ic_message = f_message;
   bool ok;
   int objection_mod = m_chatmessage[OBJECTION_MOD].toInt(
       &ok, 10); // checks if its a custom obj.


### PR DESCRIPTION
This is gonna take some time, but the entire function for handling the MS packet is a mess, and needs to be cleaned up.

Breaking changes:
This removes the logic to prevent spamming the same message. However, this should really be done serverside. No such check exists in tsu, and anyone could in theory show up with a modified client and just spam like this.

Fixes:
#247 