### PR TITLE
Do not update colors in log for each IC message

### DIFF
--- a/src/courtroom.cpp
+++ b/src/courtroom.cpp
@@ -1919,8 +1919,8 @@ void Courtroom::handle_chatmessage(QStringList *p_contents)
                               shout_stay_time);
         objection_player->play("custom", f_char, f_custom_theme);
       }
-      break;
       m_chatmessage[EMOTE_MOD] = 1;
+      break;
     }
     sfx_player->clear(); // Objection played! Cut all sfx.
   }

--- a/src/courtroom.cpp
+++ b/src/courtroom.cpp
@@ -1885,14 +1885,6 @@ void Courtroom::handle_chatmessage(QStringList *p_contents)
   QString f_char = m_chatmessage[CHAR_NAME];
   QString f_custom_theme = ao_app->get_char_shouts(f_char);
 
-  // Load the colors in case it's using a custom chatbox with custom colors.
-  // Or reload the default ones in case it's not using custom colors
-  color_rgb_list.clear();
-  for (int c = 0; c < max_colors; ++c) {
-    QColor color = ao_app->get_chat_color("c" + QString::number(c), f_char);
-    color_rgb_list.append(color);
-  }
-
   append_ic_text(m_chatmessage[MESSAGE], f_displayname, "",
                  m_chatmessage[TEXT_COLOR].toInt());
 


### PR DESCRIPTION
This is very slow (12 IO ops every IC message), and will cause undesired behavior. Changing color of messages in the IC logs can make it hard to read and inconsistent. Keep them to the defaults.