### PR TITLE
Improved blankposting

### DIFF
--- a/include/courtroom.h
+++ b/include/courtroom.h
@@ -315,9 +315,6 @@ private:
   bool rainbow_appended = false;
   bool blank_blip = false;
 
-  // Whether or not is this message additive to the previous one
-  bool is_additive = false;
-
   // Used for getting the current maximum blocks allowed in the IC chatlog.
   int log_maximum_blocks = 0;
 

--- a/include/courtroom.h
+++ b/include/courtroom.h
@@ -355,7 +355,6 @@ private:
   static const int MS_MINIMUM = 15;
   static const int MS_MAXIMUM = 30;
   QString m_chatmessage[MS_MAXIMUM];
-  bool chatmessage_is_empty = false;
 
   QString previous_ic_message = "";
   QString additive_previous = "";

--- a/src/courtroom.cpp
+++ b/src/courtroom.cpp
@@ -1863,9 +1863,6 @@ void Courtroom::handle_chatmessage(QStringList *p_contents)
     reset_ui();
   }
 
-  // Let the server handle actually checking if they're allowed to do this.
-  is_additive = m_chatmessage[ADDITIVE].toInt() == 1;
-
   QString f_charname = "";
   if (f_char_id >= 0)
     f_charname = ao_app->get_showname(char_list.at(f_char_id).name);
@@ -2777,13 +2774,18 @@ void Courtroom::start_chat_ticking()
   if (m_chatmessage[MESSAGE].isEmpty()) {
     // since the message is empty, it's technically done ticking
     text_state = 2;
+    if (m_chatmessage[ADDITIVE] == "1") {
+      // Cool behavior
+      ui_vp_chatbox->show();
+      ui_vp_message->show();
+    }
     return;
   }
 
   ui_vp_chatbox->show();
   ui_vp_message->show();
 
-  if (!is_additive) {
+  if (m_chatmessage[ADDITIVE] != "1") {
     ui_vp_message->clear();
     real_tick_pos = 0;
     additive_previous = "";

--- a/src/courtroom.cpp
+++ b/src/courtroom.cpp
@@ -1538,7 +1538,11 @@ void Courtroom::append_server_chatmessage(QString p_name, QString p_message,
 
 void Courtroom::on_chat_return_pressed()
 {
-  if (ui_ic_chat_message->text() == "" || is_muted)
+  if (is_muted)
+    return;
+
+  // You can only blankpost w/o any input if the last character who spoke is yours
+  if (ui_ic_chat_message->text() == "" && m_chatmessage[CHAR_ID].toInt() != m_cid)
     return;
 
   if ((anim_state < 3 || text_state < 2) && objection_state == 0)
@@ -1590,7 +1594,10 @@ void Courtroom::on_chat_return_pressed()
 
   packet_contents.append(ao_app->get_emote(current_char, current_emote));
 
-  packet_contents.append(ui_ic_chat_message->text());
+  QString text = ui_ic_chat_message->text();
+  if (text == "")
+    text = " "; // blankpost time
+  packet_contents.append(text);
 
   packet_contents.append(current_side);
 


### PR DESCRIPTION
- Fix blankposting not hiding the chatbox (2.8.5 regression)
- Internally presume " " is the same as "" and use "" as the blankpost check (if the server sends us empty message string and not one with a single space bar for example)
- Fix screenshake not functioning with blankposting properly
- Allow user to send blankposts for the purpose of changing their emote by pressing enter without typing any message (not even spacebar), but only if the last char ID speaking matches our character ID
- Do not create spammy log entries for blankposting - we only need to know the user blankposted one time. Any subsequent blankposts are treated as simple "emote change requests" or w/e you wanna call em.