### PR TITLE
Countdown Timer

### DIFF
--- a/include/aoapplication.h
+++ b/include/aoapplication.h
@@ -61,6 +61,9 @@ public:
   void call_settings_menu();
   void call_announce_menu(Courtroom *court);
 
+  qint64 last_ping;
+  QString window_title;
+
   /////////////////server metadata//////////////////
 
   unsigned int s_decryptor = 5;

--- a/include/aoclocklabel.h
+++ b/include/aoclocklabel.h
@@ -5,6 +5,7 @@
 #include <QBasicTimer>
 #include <QTimerEvent>
 #include <QTime>
+#include <QDebug>
 
 class AOClockLabel : public QLabel {
   Q_OBJECT
@@ -12,7 +13,7 @@ class AOClockLabel : public QLabel {
 public:
   AOClockLabel(QWidget *parent);
   void start();
-  void start(QTime p_time);
+  void start(int msecs);
   void pause();
   void resume();
   void stop();
@@ -22,7 +23,6 @@ protected:
 
 private:
     QBasicTimer timer;
-    QTime starting_time;
     QTime target_time;
 };
 

--- a/include/aoclocklabel.h
+++ b/include/aoclocklabel.h
@@ -14,8 +14,8 @@ public:
   AOClockLabel(QWidget *parent);
   void start();
   void start(int msecs);
+  void set(int msecs, bool update_text=false);
   void pause();
-  void resume();
   void stop();
 
 protected:

--- a/include/aoclocklabel.h
+++ b/include/aoclocklabel.h
@@ -1,0 +1,29 @@
+#ifndef AOCLOCKLABEL_H
+#define AOCLOCKLABEL_H
+
+#include <QLabel>
+#include <QBasicTimer>
+#include <QTimerEvent>
+#include <QTime>
+
+class AOClockLabel : public QLabel {
+  Q_OBJECT
+
+public:
+  AOClockLabel(QWidget *parent);
+  void start();
+  void start(QTime p_time);
+  void pause();
+  void resume();
+  void stop();
+
+protected:
+  void timerEvent(QTimerEvent *event) override;
+
+private:
+    QBasicTimer timer;
+    QTime starting_time;
+    QTime target_time;
+};
+
+#endif // AOCLOCKLABEL_H

--- a/include/courtroom.h
+++ b/include/courtroom.h
@@ -251,6 +251,10 @@ public:
 
   void check_connection_received();
 
+  void start_clock(qint64 msecs);
+
+  void stop_clock();
+
   qint64 get_ping() { return ping_timer.elapsed(); }
 
   ~Courtroom();

--- a/include/courtroom.h
+++ b/include/courtroom.h
@@ -6,6 +6,7 @@
 #include "aobutton.h"
 #include "aocharbutton.h"
 #include "aocharmovie.h"
+#include "aoclocklabel.h"
 #include "aoemotebutton.h"
 #include "aoevidencebutton.h"
 #include "aoevidencedisplay.h"
@@ -516,6 +517,8 @@ private:
 
   ScrollText *ui_music_name;
   AOMovie *ui_music_display;
+
+  AOClockLabel *ui_clock;
 
   AOButton *ui_pair_button;
   QListWidget *ui_pair_list;

--- a/include/courtroom.h
+++ b/include/courtroom.h
@@ -253,9 +253,8 @@ public:
 
   void start_clock();
   void start_clock(qint64 msecs);
-
   void set_clock(qint64 msecs);
-
+  void pause_clock();
   void stop_clock();
 
   qint64 get_ping() { return ping_timer.elapsed(); }

--- a/include/courtroom.h
+++ b/include/courtroom.h
@@ -57,7 +57,7 @@
 #include <QScrollBar>
 #include <QTextBoundaryFinder>
 #include <QTextCharFormat>
-//#include <QRandomGenerator>
+#include <QElapsedTimer>
 
 #include <stack>
 
@@ -251,6 +251,8 @@ public:
 
   void check_connection_received();
 
+  qint64 get_ping() { return ping_timer.elapsed(); }
+
   ~Courtroom();
 
 private:
@@ -299,11 +301,15 @@ private:
 
   QVector<chatlogpiece> ic_chatlog_history;
 
-  // triggers ping_server() every 60 seconds
+  // triggers ping_server() every 1 second
   QTimer *keepalive_timer;
 
   // determines how fast messages tick onto screen
   QTimer *chat_tick_timer;
+
+  // count up timer to check how long it took for us to get a response from ping_server()
+  QElapsedTimer ping_timer;
+
   // int chat_tick_interval = 60;
   // which tick position(character in chat message) we are at
   int tick_pos = 0;

--- a/include/courtroom.h
+++ b/include/courtroom.h
@@ -251,7 +251,10 @@ public:
 
   void check_connection_received();
 
+  void start_clock();
   void start_clock(qint64 msecs);
+
+  void set_clock(qint64 msecs);
 
   void stop_clock();
 

--- a/src/aoclocklabel.cpp
+++ b/src/aoclocklabel.cpp
@@ -7,28 +7,43 @@ void AOClockLabel::start()
   this->resume();
 }
 
-void AOClockLabel::start(QTime p_time)
+void AOClockLabel::start(int msecs)
 {
   QTime time = QTime::currentTime();
-  if (p_time > time)
+  if (msecs > time.msec())
   {
-    target_time = p_time;
-    starting_time = time;
+    target_time = time.addMSecs(msecs);
     timer.start(100, this);
   }
 }
 
-void AOClockLabel::pause() {}
+void AOClockLabel::pause()
+{
+  timer.stop();
+}
 
-void AOClockLabel::resume() {}
+void AOClockLabel::resume()
+{
+  timer.start(100, this);
+}
 
-void AOClockLabel::stop() {}
+void AOClockLabel::stop()
+{
+  this->setText("00:00:00.000");
+  timer.stop();
+}
 
 void AOClockLabel::timerEvent(QTimerEvent *event)
 {
     if (event->timerId() == timer.timerId()) {
-        QTime elapsed = QTime(0,0).addSecs(starting_time.secsTo(starting_time));
-        this->setText(elapsed.toString("hh:mm:ss.zzz"));
+        if (QTime::currentTime() >= target_time)
+        {
+          this->stop();
+          return;
+        }
+        QTime timeleft = QTime(0,0).addMSecs(QTime::currentTime().msecsTo(target_time));
+        QString timestring = timeleft.toString("hh:mm:ss.zzz");
+        this->setText(timestring);
     } else {
         QWidget::timerEvent(event);
     }

--- a/src/aoclocklabel.cpp
+++ b/src/aoclocklabel.cpp
@@ -1,0 +1,35 @@
+#include "aoclocklabel.h"
+
+AOClockLabel::AOClockLabel(QWidget *parent) : QLabel(parent) {}
+
+void AOClockLabel::start()
+{
+  this->resume();
+}
+
+void AOClockLabel::start(QTime p_time)
+{
+  QTime time = QTime::currentTime();
+  if (p_time > time)
+  {
+    target_time = p_time;
+    starting_time = time;
+    timer.start(100, this);
+  }
+}
+
+void AOClockLabel::pause() {}
+
+void AOClockLabel::resume() {}
+
+void AOClockLabel::stop() {}
+
+void AOClockLabel::timerEvent(QTimerEvent *event)
+{
+    if (event->timerId() == timer.timerId()) {
+        QTime elapsed = QTime(0,0).addSecs(starting_time.secsTo(starting_time));
+        this->setText(elapsed.toString("hh:mm:ss.zzz"));
+    } else {
+        QWidget::timerEvent(event);
+    }
+}

--- a/src/aoclocklabel.cpp
+++ b/src/aoclocklabel.cpp
@@ -35,6 +35,11 @@ void AOClockLabel::set(int msecs, bool update_text)
   }
 }
 
+void AOClockLabel::pause()
+{
+  timer.stop();
+}
+
 void AOClockLabel::stop()
 {
   this->setText("00:00:00.000");

--- a/src/aoclocklabel.cpp
+++ b/src/aoclocklabel.cpp
@@ -4,27 +4,35 @@ AOClockLabel::AOClockLabel(QWidget *parent) : QLabel(parent) {}
 
 void AOClockLabel::start()
 {
-  this->resume();
+  timer.start(100, this);
 }
 
 void AOClockLabel::start(int msecs)
+{
+  this->set(msecs);
+  this->start();
+}
+
+void AOClockLabel::set(int msecs, bool update_text)
 {
   QTime time = QTime::currentTime();
   if (msecs > time.msec())
   {
     target_time = time.addMSecs(msecs);
-    timer.start(100, this);
   }
-}
-
-void AOClockLabel::pause()
-{
-  timer.stop();
-}
-
-void AOClockLabel::resume()
-{
-  timer.start(100, this);
+  if (update_text)
+  {
+    if (QTime::currentTime() >= target_time)
+    {
+      this->setText("00:00:00.000");
+    }
+    else
+    {
+      QTime timeleft = QTime(0,0).addMSecs(QTime::currentTime().msecsTo(target_time));
+      QString timestring = timeleft.toString("hh:mm:ss.zzz");
+      this->setText(timestring);
+    }
+  }
 }
 
 void AOClockLabel::stop()
@@ -35,16 +43,16 @@ void AOClockLabel::stop()
 
 void AOClockLabel::timerEvent(QTimerEvent *event)
 {
-    if (event->timerId() == timer.timerId()) {
-        if (QTime::currentTime() >= target_time)
-        {
-          this->stop();
-          return;
-        }
-        QTime timeleft = QTime(0,0).addMSecs(QTime::currentTime().msecsTo(target_time));
-        QString timestring = timeleft.toString("hh:mm:ss.zzz");
-        this->setText(timestring);
-    } else {
-        QWidget::timerEvent(event);
+  if (event->timerId() == timer.timerId()) {
+    if (QTime::currentTime() >= target_time)
+    {
+      this->stop();
+      return;
     }
+    QTime timeleft = QTime(0,0).addMSecs(QTime::currentTime().msecsTo(target_time));
+    QString timestring = timeleft.toString("hh:mm:ss.zzz");
+    this->setText(timestring);
+  } else {
+    QWidget::timerEvent(event);
+  }
 }

--- a/src/aomusicplayer.cpp
+++ b/src/aomusicplayer.cpp
@@ -145,7 +145,6 @@ void CALLBACK loopProc(HSYNC handle, DWORD channel, DWORD data, void *user)
 
 void AOMusicPlayer::set_looping(bool toggle, int channel)
 {
-  qDebug() << "Setting looping for channel" << channel << "to" << toggle;
   m_looping = toggle;
   if (!m_looping) {
     if (BASS_ChannelFlags(m_stream_list[channel], 0, 0) & BASS_SAMPLE_LOOP)

--- a/src/courtroom.cpp
+++ b/src/courtroom.cpp
@@ -4715,9 +4715,24 @@ void Courtroom::announce_case(QString title, bool def, bool pro, bool jud,
   }
 }
 
+void Courtroom::start_clock()
+{
+  ui_clock->start();
+}
+
 void Courtroom::start_clock(qint64 msecs)
 {
   ui_clock->start(static_cast<int>(msecs));
+}
+
+void Courtroom::set_clock(qint64 msecs)
+{
+  ui_clock->set(static_cast<int>(msecs), true);
+}
+
+void Courtroom::pause_clock()
+{
+  ui_clock->pause();
 }
 
 void Courtroom::stop_clock()

--- a/src/courtroom.cpp
+++ b/src/courtroom.cpp
@@ -112,6 +112,9 @@ Courtroom::Courtroom(AOApplication *p_ao_app) : QMainWindow()
   ui_music_name->setText(tr("None"));
   ui_music_name->setAttribute(Qt::WA_TransparentForMouseEvents);
 
+  ui_clock = new AOClockLabel(this);
+  ui_clock->setAttribute(Qt::WA_TransparentForMouseEvents);
+
   ui_ic_chat_name = new QLineEdit(this);
   ui_ic_chat_name->setFrame(false);
   ui_ic_chat_name->setPlaceholderText(tr("Showname"));
@@ -619,6 +622,9 @@ void Courtroom::set_widgets()
   ui_music_display->play("music_display");
   ui_music_display->set_play_once(false);
 
+  set_size_and_pos(ui_clock, "clock");
+  ui_clock->start(30000);
+
   if (is_ao2_bg) {
     set_size_and_pos(ui_ic_chat_message, "ao2_ic_chat_message");
     set_size_and_pos(ui_vp_chatbox, "ao2_chatbox");
@@ -943,6 +949,7 @@ void Courtroom::set_fonts(QString p_char)
   set_font(ui_music_list, "", "music_list", p_char);
   set_font(ui_area_list, "", "area_list", p_char);
   set_font(ui_music_name, "", "music_name", p_char);
+  set_font(ui_clock, "", "clock", p_char);
 
   set_dropdowns();
 }

--- a/src/courtroom.cpp
+++ b/src/courtroom.cpp
@@ -4715,6 +4715,16 @@ void Courtroom::announce_case(QString title, bool def, bool pro, bool jud,
   }
 }
 
+void Courtroom::start_clock(qint64 msecs)
+{
+  ui_clock->start(static_cast<int>(msecs));
+}
+
+void Courtroom::stop_clock()
+{
+  ui_clock->stop();
+}
+
 Courtroom::~Courtroom()
 {
   delete music_player;

--- a/src/courtroom.cpp
+++ b/src/courtroom.cpp
@@ -8,7 +8,7 @@ Courtroom::Courtroom(AOApplication *p_ao_app) : QMainWindow()
   qsrand(static_cast<uint>(QDateTime::currentMSecsSinceEpoch() / 1000));
 
   keepalive_timer = new QTimer(this);
-  keepalive_timer->start(60000);
+  keepalive_timer->start(1000);
 
   chat_tick_timer = new QTimer(this);
 
@@ -623,7 +623,6 @@ void Courtroom::set_widgets()
   ui_music_display->set_play_once(false);
 
   set_size_and_pos(ui_clock, "clock");
-  ui_clock->start(30000);
 
   if (is_ao2_bg) {
     set_size_and_pos(ui_ic_chat_message, "ao2_ic_chat_message");
@@ -4672,6 +4671,7 @@ void Courtroom::on_switch_area_music_clicked()
 
 void Courtroom::ping_server()
 {
+  ping_timer.start();
   ao_app->send_server_packet(
       new AOPacket("CH#" + QString::number(m_cid) + "#%"));
 }

--- a/src/packet_distribution.cpp
+++ b/src/packet_distribution.cpp
@@ -116,13 +116,7 @@ void AOApplication::server_packet_received(AOPacket *p_packet)
     qDebug() << "R:" << f_packet;
 #endif
 
-  if (header == "CHECK") {
-    if (courtroom_constructed) {
-      last_ping = w_courtroom->get_ping();
-      w_courtroom->set_window_title(window_title + " [ping:" + QString::number(last_ping) + "]");
-    }
-  }
-  else if (header == "decryptor") {
+  if (header == "decryptor") {
     if (f_contents.size() == 0)
       goto end;
 
@@ -750,6 +744,12 @@ void AOApplication::server_packet_received(AOPacket *p_packet)
       }
       else
         w_courtroom->stop_clock();
+    }
+  }
+  else if (header == "CHECK") {
+    if (courtroom_constructed) {
+      last_ping = w_courtroom->get_ping();
+      w_courtroom->set_window_title(window_title + " [ping:" + QString::number(last_ping) + "]");
     }
   }
 

--- a/src/packet_distribution.cpp
+++ b/src/packet_distribution.cpp
@@ -116,7 +116,13 @@ void AOApplication::server_packet_received(AOPacket *p_packet)
     qDebug() << "R:" << f_packet;
 #endif
 
-  if (header == "decryptor") {
+  if (header == "CHECK") {
+    if (courtroom_constructed) {
+      last_ping = w_courtroom->get_ping();
+      w_courtroom->set_window_title(window_title + " [ping:" + QString::number(last_ping) + "]");
+    }
+  }
+  else if (header == "decryptor") {
     if (f_contents.size() == 0)
       goto end;
 
@@ -250,7 +256,7 @@ void AOApplication::server_packet_received(AOPacket *p_packet)
 
     courtroom_loaded = false;
 
-    QString window_title = tr("Attorney Online 2");
+    window_title = tr("Attorney Online 2");
     int selected_server = w_lobby->get_selected_server();
 
     QString server_address = "", server_name = "";

--- a/src/packet_distribution.cpp
+++ b/src/packet_distribution.cpp
@@ -729,12 +729,25 @@ void AOApplication::server_packet_received(AOPacket *p_packet)
                                f_contents.at(5) == "1");
   }
   else if (header == "TI") { // Timer packet
-    if (courtroom_constructed && f_contents.size() >= 1) {
+    if (courtroom_constructed && f_contents.size() > 0) {
       qint64 resolution = f_contents.at(0).toInt();
+      //Type 0 = start/stop timer
+      //Type 1 = pause timer
+      int type = 0;
+      if (f_contents.size() > 1)
+        type = f_contents.at(1).toInt();
       qDebug() << "timer" << resolution << last_ping << resolution - last_ping;
       resolution = resolution - last_ping;
       if (resolution > 0)
-        w_courtroom->start_clock(resolution);
+      {
+        if (type == 1)
+        {
+          w_courtroom->pause_clock();
+          w_courtroom->set_clock(resolution);
+        }
+        else
+          w_courtroom->start_clock(resolution);
+      }
       else
         w_courtroom->stop_clock();
     }

--- a/src/packet_distribution.cpp
+++ b/src/packet_distribution.cpp
@@ -728,6 +728,17 @@ void AOApplication::server_packet_received(AOPacket *p_packet)
                                f_contents.at(4) == "1",
                                f_contents.at(5) == "1");
   }
+  else if (header == "TI") { // Timer packet
+    if (courtroom_constructed && f_contents.size() >= 1) {
+      qint64 resolution = f_contents.at(0).toInt();
+      qDebug() << "timer" << resolution << last_ping << resolution - last_ping;
+      resolution = resolution - last_ping;
+      if (resolution > 0)
+        w_courtroom->start_clock(resolution);
+      else
+        w_courtroom->stop_clock();
+    }
+  }
 
 end:
 


### PR DESCRIPTION
An incredibly powerful asset in any GM's hands, this is useful for a huge number of role-plays: Danganronpa Class Trials, Nonary Game countdown, Ambidex Game phases, Main Game phases, etc. etc. etc.
Literally anything that needs a countdown timer will benefit from this feature.

**Absolutely Important**:
 - [x] Countdown Timer label class
 - [x] Configurable from courtroom_config.ini and courtroom_fonts.ini
 - [x] Can be started from the server using a unique packet
 - [x] Can be stopped and resumed from the server using a unique packet
 - [x] Accounts for the packet travel time and ensures that everyone is in sync when the timer starts/stops (ROLLBACK NETCODE 2.8.6)
 - [ ] Can be hidden and unhidden by the server using a unique packet
 - [ ] Ability to define more than 1 timer (at least 2)

**TBD in separate PR's**:
 - [ ] Ability to tell the timer to count *up* towards something
 - [ ] Ability to turn the timer into GTA-Style AM/PM day cycle timer