### PR TITLE
Fix: Qt failing to paint a darker button if source image is indexed

### DIFF
--- a/src/aoemotebutton.cpp
+++ b/src/aoemotebutton.cpp
@@ -27,6 +27,7 @@ void AOEmoteButton::set_image(QString p_image, QString p_emote_comment)
   }
   else if (p_image.contains("_on") && file_exists(tmp_p_image.replace("_on", "_off"))) {
     QImage tmpImage(tmp_p_image);
+    tmpImage = tmpImage.convertToFormat(QImage::Format_ARGB32);
     QPoint p1, p2;
     p2.setY(tmpImage.height());
 


### PR DESCRIPTION
Fix for https://github.com/AttorneyOnline/AO2-Client/issues/273
>By converting the image to an 8-bits per channel image with alpha channel we make sure the client won't fail painting a darker button, and keep the transparency if the source image had.

Also, using convertToFormat instead of convertTo because convertToFormat is available on Qt 5.12 (and maybe earlier even though the documentation doesn't say). While convertToFormat wasn't added until Qt 5.13, so using it could give issues even on somewhat updated distros like ubuntu 20.04 since it comes with Qt 5.12 and the client is compiled dynamically on Linux.