### PR TITLE
Allow non-png static image lookups

### DIFF
--- a/src/aocharmovie.cpp
+++ b/src/aocharmovie.cpp
@@ -35,8 +35,8 @@ void AOCharMovie::load_image(QString p_char, QString p_emote,
       ao_app->get_image_suffix(ao_app->get_character_path(
           p_char, emote_prefix + "/" +
                       p_emote)), // Path check if it's categorized into a folder
-      ao_app->get_character_path(
-          p_char, p_emote + ".png"), // Non-animated path if emote_prefix fails
+      ao_app->get_image_suffix(ao_app->get_character_path(
+          p_char, p_emote)), // Just use the non-prefixed image, animated or not
       ao_app->get_image_suffix(
           ao_app->get_theme_path("placeholder")), // Theme placeholder path
       ao_app->get_image_suffix(ao_app->get_default_theme_path(


### PR DESCRIPTION
Having to use .png exclusively when (a) and (b) lookup fails is stupid, especially with the absolutely 50% size reduction when using webp lossless for static sprites.
This ensures that if the (a) and (b) animation lookup fails for idle/talking, it will try to use anything that's named the same as emote. This should also allow character makers to hyper optimize their characters if separate (a) and (b) emotes don't need to exist.