### PR TITLE
Cache QMovie objects to reduce lag

### DIFF
--- a/src/aomovie.cpp
+++ b/src/aomovie.cpp
@@ -9,6 +9,7 @@ AOMovie::AOMovie(QWidget *p_parent, AOApplication *p_ao_app) : QLabel(p_parent)
   ao_app = p_ao_app;
 
   m_movie = new QMovie();
+  m_movie->setCacheMode(QMovie::CacheAll);
 
   this->setMovie(m_movie);
 

--- a/src/aoscene.cpp
+++ b/src/aoscene.cpp
@@ -7,6 +7,7 @@ AOScene::AOScene(QWidget *parent, AOApplication *p_ao_app) : QLabel(parent)
   m_parent = parent;
   ao_app = p_ao_app;
   m_movie = new QMovie(this);
+  m_movie->setCacheMode(QMovie::CacheAll);
   last_image = "";
 }
 


### PR DESCRIPTION
Performance tanks to a crawl with big-viewport zoomlines without this setting being on.