### PR TITLE
More accurate/consistent blip rate functionality + punctuation slowdown fixes

### DIFF
--- a/include/aoblipplayer.h
+++ b/include/aoblipplayer.h
@@ -22,12 +22,9 @@ public:
   int m_cycle = 0;
 
 private:
-  const int max_blip_ms = 60;
-
   QWidget *m_parent;
   AOApplication *ao_app;
   qreal m_volume;
-  QElapsedTimer delay;
 
   void set_volume_internal(qreal p_volume);
 

--- a/include/courtroom.h
+++ b/include/courtroom.h
@@ -275,7 +275,7 @@ private:
   bool message_is_centered = false;
 
   int current_display_speed = 3;
-  int message_display_speed[7] = {0, 10, 25, 40, 50, 70, 90};
+  int message_display_speed[7] = {5, 10, 25, 40, 50, 70, 90};
 
   // The character ID of the character this user wants to appear alongside with.
   int other_charid = -1;

--- a/include/courtroom.h
+++ b/include/courtroom.h
@@ -311,7 +311,7 @@ private:
   int real_tick_pos = 0;
   // used to determine how often blips sound
   int blip_ticker = 0;
-  int blip_rate = 1;
+  int blip_rate = 2;
   int rainbow_counter = 0;
   bool rainbow_appended = false;
   bool blank_blip = false;

--- a/src/aoblipplayer.cpp
+++ b/src/aoblipplayer.cpp
@@ -26,10 +26,6 @@ void AOBlipPlayer::set_blips(QString p_sfx)
 
 void AOBlipPlayer::blip_tick()
 {
-  if (delay.isValid() && delay.elapsed() < max_blip_ms)
-    return;
-
-  delay.start();
   int f_cycle = m_cycle++;
 
   if (m_cycle == 5)

--- a/src/courtroom.cpp
+++ b/src/courtroom.cpp
@@ -2943,7 +2943,17 @@ void Courtroom::chat_tick()
     // I am you
     // ! !  ! !
     // where ! is the blip sound
-    if (blip_ticker % blip_rate == 0) {
+    int b_rate = blip_rate;
+    // Earrape prevention without using timers, this method is more consistent.
+    if (msg_delay != 0 && msg_delay <= 25) {
+      // The default blip speed is 40ms, and if current msg_delay is 25ms,
+      // the formula will result in the blip rate of:
+      // 40/25 = 1.6 = 2
+      // And if it's faster than that:
+      // 40/10 = 4
+      b_rate = qMax(b_rate, qRound(static_cast<float>(message_display_speed[3])/msg_delay));
+    }
+    if (blip_ticker % b_rate == 0) {
       // ignoring white space unless blank_blip is enabled.
       if (!formatting_char && (f_character != ' ' || blank_blip)) {
         blip_player->blip_tick();
@@ -2958,9 +2968,10 @@ void Courtroom::chat_tick()
       ++blip_ticker;
     }
 
-    // Punctuation delayer
-    if (punctuation_chars.contains(f_character)) {
-      msg_delay *= punctuation_modifier;
+    // Punctuation delayer, only kicks in on speed ticks less than }}
+    if (current_display_speed > 1 && punctuation_chars.contains(f_character)) {
+      // Making the user have to wait any longer than 150ms per letter is downright unreasonable
+      msg_delay = qMin(150, msg_delay * punctuation_modifier);
     }
 
     // If this color is talking

--- a/src/courtroom.cpp
+++ b/src/courtroom.cpp
@@ -2938,11 +2938,23 @@ void Courtroom::chat_tick()
 
     ui_vp_message->ensureCursorVisible();
 
-    // Blip player and real tick pos ticker
-    if (!formatting_char && (f_character != ' ' || blank_blip)) {
-      if (blip_ticker % blip_rate == 0) {
+    // We blip every "blip rate" letters.
+    // Here's an example with blank_blip being false and blip_rate being 2:
+    // I am you
+    // ! !  ! !
+    // where ! is the blip sound
+    if (blip_ticker % blip_rate == 0) {
+      // ignoring white space unless blank_blip is enabled.
+      if (!formatting_char && (f_character != ' ' || blank_blip)) {
         blip_player->blip_tick();
+        ++blip_ticker;
       }
+    }
+    else
+    {
+      // Don't fully ignore whitespace still, keep ticking until
+      // we reached the need to play a blip sound - we also just
+      // need to wait for a letter to play it on.
       ++blip_ticker;
     }
 


### PR DESCRIPTION
Inspired by https://youtu.be/Min0hkwO43g
Here's what happens before this PR:
```
I am you
! ! ! !
```
The third blip sound was skipped entirely because it landed on a whitespace, leading to blip sounds feeling slower than they actually are.
This fixes it by delaying the blip until the whitespace has been passed, leading to this result:
```
I am you
! !  ! !
```
Meaning you hear 4 blips as intended, and removing the illusion of "slower text" caused by the difference.

Snapshots from the video used as reference:
![изображение](https://user-images.githubusercontent.com/3470436/92964540-f44c8900-f47c-11ea-863d-06f78c796b79.png)
![изображение](https://user-images.githubusercontent.com/3470436/92964522-ebf44e00-f47c-11ea-9ae0-922fe503ffa5.png)
![изображение](https://user-images.githubusercontent.com/3470436/92964548-f9113d00-f47c-11ea-879f-676067974403.png)

Labelled as bug due to unintended consequence of a shoddy implementation.