### PR TITLE
Rebase: Interjections should not force preanimation if 'Pre' is unchecked

### DIFF
--- a/src/courtroom.cpp
+++ b/src/courtroom.cpp
@@ -1533,9 +1533,8 @@ void Courtroom::on_chat_return_pressed()
     return;
 
   ui_ic_chat_message->blockSignals(true);
-  QTimer::singleShot(600, this, [=] {
-    ui_ic_chat_message->blockSignals(false);
-  });
+  QTimer::singleShot(600, this,
+                     [=] { ui_ic_chat_message->blockSignals(false); });
   // MS#
   // deskmod#
   // pre-emote#
@@ -1597,13 +1596,11 @@ void Courtroom::on_chat_return_pressed()
   int f_emote_mod = ao_app->get_emote_mod(current_char, current_emote);
 
   // needed or else legacy won't understand what we're saying
-  if (objection_state > 0) {
-    if (ui_pre->isChecked()) {
-      if (f_emote_mod == 4 || f_emote_mod == 5)
-        f_emote_mod = 6;
-      else
-        f_emote_mod = 2;
-    }
+  if (objection_state > 0 && ui_pre->isChecked()) {
+    if (f_emote_mod == 4 || f_emote_mod == 5)
+      f_emote_mod = 6;
+    else
+      f_emote_mod = 2;
   }
   else if (ui_pre->isChecked() && !ui_pre_non_interrupt->isChecked()) {
     if (f_emote_mod == 0)


### PR DESCRIPTION
Rebase of #133 to current master.