### PR TITLE
fix doubleclick server being buggy

### DIFF
--- a/include/lobby.h
+++ b/include/lobby.h
@@ -46,6 +46,7 @@ public:
   void set_loading_value(int p_value);
 
   bool public_servers_selected = true;
+  bool doubleclicked = false;
 
   ~Lobby();
 

--- a/src/lobby.cpp
+++ b/src/lobby.cpp
@@ -441,8 +441,9 @@ void Lobby::on_server_list_clicked(QTreeWidgetItem *p_item, int column)
 // doubleclicked on an item in the serverlist so we'll connect right away
 void Lobby::on_server_list_doubleclicked(QTreeWidgetItem *p_item, int column)
 {
+  doubleclicked = true;
   on_server_list_clicked(p_item, column);
-  on_connect_released();
+  //on_connect_released();
 }
 
 void Lobby::on_server_search_edited(QString p_text)

--- a/src/packet_distribution.cpp
+++ b/src/packet_distribution.cpp
@@ -229,8 +229,10 @@ void AOApplication::server_packet_received(AOPacket *p_packet)
     w_lobby->set_player_count(f_contents.at(0).toInt(),
                               f_contents.at(1).toInt());
 
-    if (w_lobby->doubleclicked)
+    if (w_lobby->doubleclicked) {
         send_server_packet(new AOPacket("askchaa#%"));
+        w_lobby->doubleclicked = false;
+    }
   }
   else if (header == "SI") {
     if (f_contents.size() != 3)

--- a/src/packet_distribution.cpp
+++ b/src/packet_distribution.cpp
@@ -228,6 +228,9 @@ void AOApplication::server_packet_received(AOPacket *p_packet)
 
     w_lobby->set_player_count(f_contents.at(0).toInt(),
                               f_contents.at(1).toInt());
+
+    if (w_lobby->doubleclicked)
+        send_server_packet(new AOPacket("askchaa#%"));
   }
   else if (header == "SI") {
     if (f_contents.size() != 3)


### PR DESCRIPTION
this is a bit of a hack, but so is the rest of ao2 :^)

this won't work with ao1.x servers but honestly who cares

a more in-depth rewrite of connection handling is honestly needed. another limitation of this PR is that it doesn't fix the problem of pressing "connect" before the player count shows up will mess things up. a more sane solution would be to totally separate the connection for fetching player count from actually connecting to the server. basically, lobby.cpp initiates a connection, and if someone connects to a server, that QTcpSocket is killed off, and a new one is used to connect to the server. another thing i noticed while looking through the code is the bizarre way in which send_server_packet() works. It takes a pointer to an AOPacket, and is always invoked with the param of a new AOPacket(). I guess omni thought it was Java. The pointer is deleted at the end of send_server_packet which is just unnecessary if proper RAII guidelines are followed.

fixes #125 