### PR TITLE
Add proper alpha masking to AOImage elements

### DIFF
--- a/src/aoimage.cpp
+++ b/src/aoimage.cpp
@@ -29,9 +29,9 @@ bool AOImage::set_image(QString p_image)
   }
 
   QPixmap f_pixmap(final_image_path);
-
-  this->setPixmap(
-      f_pixmap.scaled(this->width(), this->height(), Qt::IgnoreAspectRatio));
+  f_pixmap = f_pixmap.scaled(this->width(), this->height(), Qt::IgnoreAspectRatio);
+  this->setPixmap(f_pixmap);
+  this->setMask(f_pixmap.mask());
   return true;
 }
 
@@ -45,7 +45,8 @@ bool AOImage::set_chatbox(QString p_path)
 
   QPixmap f_pixmap(p_path);
 
-  this->setPixmap(
-      f_pixmap.scaled(this->width(), this->height(), Qt::IgnoreAspectRatio));
+  f_pixmap = f_pixmap.scaled(this->width(), this->height(), Qt::IgnoreAspectRatio);
+  this->setPixmap(f_pixmap);
+  this->setMask(f_pixmap.mask());
   return true;
 }

--- a/src/aoimage.cpp
+++ b/src/aoimage.cpp
@@ -2,6 +2,8 @@
 
 #include "aoimage.h"
 
+#include <QBitmap>
+
 AOImage::AOImage(QWidget *parent, AOApplication *p_ao_app) : QLabel(parent)
 {
   m_parent = parent;
@@ -29,7 +31,8 @@ bool AOImage::set_image(QString p_image)
   }
 
   QPixmap f_pixmap(final_image_path);
-  f_pixmap = f_pixmap.scaled(this->width(), this->height(), Qt::IgnoreAspectRatio);
+  f_pixmap =
+      f_pixmap.scaled(this->width(), this->height(), Qt::IgnoreAspectRatio);
   this->setPixmap(f_pixmap);
   this->setMask(f_pixmap.mask());
   return true;
@@ -45,7 +48,8 @@ bool AOImage::set_chatbox(QString p_path)
 
   QPixmap f_pixmap(p_path);
 
-  f_pixmap = f_pixmap.scaled(this->width(), this->height(), Qt::IgnoreAspectRatio);
+  f_pixmap =
+      f_pixmap.scaled(this->width(), this->height(), Qt::IgnoreAspectRatio);
   this->setPixmap(f_pixmap);
   this->setMask(f_pixmap.mask());
   return true;


### PR DESCRIPTION
This allows for more flexibility when theming since masked elements ignore mouse events from transparent areas. See the two below cases where this proves useful:

**Irregular button shapes:**
![example](https://user-images.githubusercontent.com/32779090/95914166-ee431400-0d6a-11eb-9201-ea884c055cc4.png)
**Evidence menu:**
![example2](https://user-images.githubusercontent.com/32779090/95914382-3feb9e80-0d6b-11eb-9e69-a4619ce9f952.png)
