### PR TITLE
Define IC Log colors independent of character, define message colors according to character

### DIFF
--- a/include/courtroom.h
+++ b/include/courtroom.h
@@ -411,6 +411,10 @@ private:
   // Same as above but populated from misc/default's config
   QVector<QColor> default_color_rgb_list;
 
+  // Get a color index from an arbitrary misc config
+  void gen_char_rgb_list(QString p_char);
+  QVector<QColor> char_color_rgb_list;
+
   // List of markdown start characters, their index is tied to the color index
   QStringList color_markdown_start_list;
 

--- a/include/courtroom.h
+++ b/include/courtroom.h
@@ -415,6 +415,10 @@ private:
   void gen_char_rgb_list(QString p_char);
   QVector<QColor> char_color_rgb_list;
 
+  // Misc we used for the last message, and the one we're using now. Used to avoid loading assets when it's not needed
+  QString current_misc;
+  QString last_misc;
+
   // List of markdown start characters, their index is tied to the color index
   QStringList color_markdown_start_list;
 

--- a/include/courtroom.h
+++ b/include/courtroom.h
@@ -408,6 +408,9 @@ private:
   // List of associated RGB colors for this color index
   QVector<QColor> color_rgb_list;
 
+  // Same as above but populated from misc/default's config
+  QVector<QColor> default_color_rgb_list;
+
   // List of markdown start characters, their index is tied to the color index
   QStringList color_markdown_start_list;
 

--- a/src/courtroom.cpp
+++ b/src/courtroom.cpp
@@ -2799,6 +2799,8 @@ void Courtroom::start_chat_ticking()
 
   QString f_gender = ao_app->get_gender(m_chatmessage[CHAR_NAME]);
 
+  gen_char_rgb_list(m_chatmessage[CHAR_NAME]);
+
   blip_player->set_blips(f_gender);
 
   // means text is currently ticking
@@ -2833,7 +2835,7 @@ void Courtroom::chat_tick()
         f_custom_theme); // Chat stopped being processed, indicate that.
     QString f_message_filtered = filter_ic_text(f_message, true, -1, m_chatmessage[TEXT_COLOR].toInt());
     for (int c = 0; c < max_colors; ++c) {
-      f_message_filtered = f_message_filtered.replace("$c" + QString::number(c), color_rgb_list.at(c).name(QColor::HexRgb));
+      f_message_filtered = f_message_filtered.replace("$c" + QString::number(c), char_color_rgb_list.at(c).name(QColor::HexRgb));
     }
     ui_vp_message->setHtml(additive_previous + f_message_filtered);
     real_tick_pos = ui_vp_message->toPlainText().size();
@@ -2950,7 +2952,7 @@ void Courtroom::chat_tick()
     // Do the colors, gradual showing, etc. in here
     QString f_message_filtered = filter_ic_text(f_message, true, tick_pos, m_chatmessage[TEXT_COLOR].toInt());
     for (int c = 0; c < max_colors; ++c) {
-      f_message_filtered = f_message_filtered.replace("$c" + QString::number(c), color_rgb_list.at(c).name(QColor::HexRgb));
+      f_message_filtered = f_message_filtered.replace("$c" + QString::number(c), char_color_rgb_list.at(c).name(QColor::HexRgb));
     }
     ui_vp_message->setHtml(additive_previous + f_message_filtered);
 
@@ -4444,6 +4446,14 @@ void Courtroom::set_text_color_dropdown()
   for (int c = 0; c < max_colors; ++c) {
     QColor color = ao_app->get_chat_color("c" + QString::number(c), "default");
     default_color_rgb_list.append(color);
+  }
+}
+
+void Courtroom::gen_char_rgb_list(QString p_char) {
+  char_color_rgb_list.clear();
+  for (int c = 0; c < max_colors; ++c) {
+    QColor color = ao_app->get_chat_color("c" + QString::number(c), p_char);
+    char_color_rgb_list.append(color);
   }
 }
 

--- a/src/courtroom.cpp
+++ b/src/courtroom.cpp
@@ -2798,8 +2798,11 @@ void Courtroom::start_chat_ticking()
   chat_tick_timer->start(0); // Display the first char right away
 
   QString f_gender = ao_app->get_gender(m_chatmessage[CHAR_NAME]);
-
-  gen_char_rgb_list(m_chatmessage[CHAR_NAME]);
+  
+  last_misc = current_misc;
+  current_misc = ao_app->get_char_shouts(m_chatmessage[CHAR_NAME]);
+  if (last_misc != current_misc)
+    gen_char_rgb_list(m_chatmessage[CHAR_NAME]);
 
   blip_player->set_blips(f_gender);
 

--- a/src/courtroom.cpp
+++ b/src/courtroom.cpp
@@ -2363,9 +2363,7 @@ QString Courtroom::filter_ic_text(QString p_text, bool html, int target_pos,
   // If html is enabled, prepare this text to be all ready for it.
   if (html) {
     ic_color_stack.push(default_color);
-    QString appendage = "<font color=\"" +
-                        color_rgb_list.at(default_color).name(QColor::HexRgb) +
-                        "\">";
+    QString appendage = "<font color=\"$c" + QString::number(default_color) + "\">";
 
     if (!align.isEmpty())
       appendage.prepend("<div align=" + align + ">");
@@ -2484,8 +2482,7 @@ QString Courtroom::filter_ic_text(QString p_text, bool html, int target_pos,
 
             if (!ic_color_stack.empty())
               appendage +=
-                  "<font color=\"" +
-                  color_rgb_list.at(ic_color_stack.top()).name(QColor::HexRgb) +
+                  "<font color=\"$c" + QString::number(ic_color_stack.top()) +
                   "\">";
 
             if (is_end && !skip) {
@@ -2643,12 +2640,16 @@ void Courtroom::append_ic_text(QString p_text, QString p_name, QString p_action,
     else
       ui_ic_chatlog->textCursor().insertText(": ", normal);
     // Format the result according to html
-    if (log_colors)
-      ui_ic_chatlog->textCursor().insertHtml(
-          filter_ic_text(p_text, true, -1, color));
+    if (log_colors) {
+      QString p_text_filtered = filter_ic_text(p_text, true, -1, color);
+      p_text_filtered = p_text_filtered.replace("$c0", ao_app->get_color("ic_chatlog_color", "courtroom_fonts.ini").name(QColor::HexRgb));
+      for (int c = 1; c < max_colors; ++c) {
+        p_text_filtered = p_text_filtered.replace("$c" + QString::number(c), default_color_rgb_list.at(c).name(QColor::HexRgb));
+      }
+      ui_ic_chatlog->textCursor().insertHtml(p_text_filtered);
+    }
     else
-      ui_ic_chatlog->textCursor().insertText(filter_ic_text(p_text, false),
-                                             normal);
+      ui_ic_chatlog->textCursor().insertText(filter_ic_text(p_text, false), normal);
   }
 
   // Only append with newline if log goes upwards
@@ -2830,9 +2831,11 @@ void Courtroom::chat_tick()
     ui_vp_chat_arrow->play(
         "chat_arrow", f_char,
         f_custom_theme); // Chat stopped being processed, indicate that.
-    additive_previous =
-        additive_previous +
-        filter_ic_text(f_message, true, -1, m_chatmessage[TEXT_COLOR].toInt());
+    QString f_message_filtered = filter_ic_text(f_message, true, -1, m_chatmessage[TEXT_COLOR].toInt());
+    for (int c = 0; c < max_colors; ++c) {
+      f_message_filtered = f_message_filtered.replace("$c" + QString::number(c), color_rgb_list.at(c).name(QColor::HexRgb));
+    }
+    ui_vp_message->setHtml(additive_previous + f_message_filtered);
     real_tick_pos = ui_vp_message->toPlainText().size();
     return;
   }
@@ -2945,9 +2948,11 @@ void Courtroom::chat_tick()
   else {
     int msg_delay = message_display_speed[current_display_speed];
     // Do the colors, gradual showing, etc. in here
-    ui_vp_message->setHtml(additive_previous +
-                           filter_ic_text(f_message, true, tick_pos,
-                                          m_chatmessage[TEXT_COLOR].toInt()));
+    QString f_message_filtered = filter_ic_text(f_message, true, tick_pos, m_chatmessage[TEXT_COLOR].toInt());
+    for (int c = 0; c < max_colors; ++c) {
+      f_message_filtered = f_message_filtered.replace("$c" + QString::number(c), color_rgb_list.at(c).name(QColor::HexRgb));
+    }
+    ui_vp_message->setHtml(additive_previous + f_message_filtered);
 
     // This should always be done AFTER setHtml. Scroll the chat window with the
     // text.
@@ -4399,6 +4404,7 @@ void Courtroom::set_text_color_dropdown()
 
   // Clear the stored optimization information
   color_rgb_list.clear();
+  default_color_rgb_list.clear();
   color_markdown_start_list.clear();
   color_markdown_end_list.clear();
   color_markdown_remove_list.clear();
@@ -4434,6 +4440,10 @@ void Courtroom::set_text_color_dropdown()
     pixmap.fill(color);
     ui_text_color->setItemIcon(ui_text_color->count() - 1, QIcon(pixmap));
     color_row_to_number.append(c);
+  }
+  for (int c = 0; c < max_colors; ++c) {
+    QColor color = ao_app->get_chat_color("c" + QString::number(c), "default");
+    default_color_rgb_list.append(color);
   }
 }
 

--- a/src/courtroom.cpp
+++ b/src/courtroom.cpp
@@ -2837,7 +2837,7 @@ void Courtroom::chat_tick()
     for (int c = 0; c < max_colors; ++c) {
       f_message_filtered = f_message_filtered.replace("$c" + QString::number(c), char_color_rgb_list.at(c).name(QColor::HexRgb));
     }
-    ui_vp_message->setHtml(additive_previous + f_message_filtered);
+    additive_previous = additive_previous + f_message_filtered;
     real_tick_pos = ui_vp_message->toPlainText().size();
     return;
   }

--- a/src/text_file_functions.cpp
+++ b/src/text_file_functions.cpp
@@ -636,6 +636,8 @@ QString AOApplication::get_gender(QString p_char)
 
 QString AOApplication::get_chat(QString p_char)
 {
+  if (p_char == "default")
+    return "default";
   QString f_result = read_char_ini(p_char, "chat", "Options");
 
   // handling the correct order of chat is a bit complicated, we let the caller


### PR DESCRIPTION
### Defining IC Log colors

This is done by altering the `filter_ic_text` function to use placeholder values (`$c[x]` where `[x]` is the color index) instead of inserting hex values directly. The caller must then populate those placeholder values with hex values derived in whatever way it chooses - the IC log uses a list of colors generated from the `config.ini` located at `misc/default/` while the message box pulls colors from the current character's color list - more on that below.

Additional complexity has been added - `$c0` is overridden by the color as defined by `courtroom_fonts.ini` in the user's theme, as it was previously ignored when colored IC logs were switched on.

**Before:**
![image](https://user-images.githubusercontent.com/32779090/96329545-c1655a00-1013-11eb-977c-9ad4d53f2411.png)
**After:**
![image](https://user-images.githubusercontent.com/32779090/96329552-ca562b80-1013-11eb-9c44-6a4be2f958ea.png)

### Defining message colors
This fixes a regression from 2.6, which had this feature until it was inadvertently removed in 2.8. It's implemented differently here.

Done by keeping a temporary color index populated from the current onscreen character's config and drawing color values from it. This index is generated whenever `start_chat_ticking` is called.

**Before:** (The character selected has a c0 of 0,0,0 while the character talking has a c0 of 255,255,255)
![image](https://user-images.githubusercontent.com/32779090/96329921-ed360f00-1016-11eb-823f-8914b2137349.png)
**After:**
![image](https://user-images.githubusercontent.com/32779090/96329977-62a1df80-1017-11eb-8533-799004b29f63.png)