### PR TITLE
Demo Recording/Playback System

### DIFF
--- a/include/aoapplication.h
+++ b/include/aoapplication.h
@@ -27,6 +27,8 @@
 #include <QStringList>
 #include <QTextStream>
 
+#include <QElapsedTimer>
+
 class NetworkManager;
 class Lobby;
 class Courtroom;
@@ -445,6 +447,8 @@ public:
   static void CALLBACK BASSreset(HSTREAM handle, DWORD channel, DWORD data,
                                  void *user);
   static void doBASSreset();
+
+  QElapsedTimer demo_timer;
 
 private:
   const int RELEASE = 2;

--- a/src/packet_distribution.cpp
+++ b/src/packet_distribution.cpp
@@ -173,6 +173,15 @@ void AOApplication::server_packet_received(AOPacket *p_packet)
       else
         w_courtroom->append_server_chatmessage(f_contents.at(0),
                                                f_contents.at(1), "0");
+      if (get_auto_logging_enabled())
+      {
+        QString path = log_filename.left(log_filename.size()).replace(".log", ".demo");
+        append_to_file(p_packet->to_string(), path, true);
+        if (!demo_timer.isValid())
+          demo_timer.start();
+        else
+          append_to_file("wait#"+ QString::number(demo_timer.restart()) + "#%", path, true);
+      }
     }
   }
   else if (header == "FL") {
@@ -598,6 +607,15 @@ void AOApplication::server_packet_received(AOPacket *p_packet)
           2) // We have a pos included in the background packet!
         w_courtroom->set_side(f_contents.at(1));
       w_courtroom->set_background(f_contents.at(0), f_contents.size() >= 2);
+      if (get_auto_logging_enabled())
+      {
+        QString path = log_filename.left(log_filename.size()).replace(".log", ".demo");
+        append_to_file(p_packet->to_string(), path, true);
+        if (!demo_timer.isValid())
+          demo_timer.start();
+        else
+          append_to_file("wait#"+ QString::number(demo_timer.restart()) + "#%", path, true);
+      }
     }
   }
   else if (header == "SP") {
@@ -607,6 +625,15 @@ void AOApplication::server_packet_received(AOPacket *p_packet)
     if (courtroom_constructed) // We were sent a "set position" packet
     {
       w_courtroom->set_side(f_contents.at(0));
+      if (get_auto_logging_enabled())
+      {
+        QString path = log_filename.left(log_filename.size()).replace(".log", ".demo");
+        append_to_file(p_packet->to_string(), path, true);
+        if (!demo_timer.isValid())
+          demo_timer.start();
+        else
+          append_to_file("wait#"+ QString::number(demo_timer.restart()) + "#%", path, true);
+      }
     }
   }
   else if (header == "SD") // Send pos dropdown
@@ -626,27 +653,69 @@ void AOApplication::server_packet_received(AOPacket *p_packet)
   }
   else if (header == "MS") {
     if (courtroom_constructed && courtroom_loaded)
+    {
       w_courtroom->handle_chatmessage(&p_packet->get_contents());
+      if (get_auto_logging_enabled())
+      {
+        QString path = log_filename.left(log_filename.size()).replace(".log", ".demo");
+        append_to_file(p_packet->to_string(), path, true);
+        if (!demo_timer.isValid())
+          demo_timer.start();
+        else
+          append_to_file("wait#"+ QString::number(demo_timer.restart()) + "#%", path, true);
+      }
+    }
   }
   else if (header == "MC") {
     if (courtroom_constructed && courtroom_loaded)
+    {
       w_courtroom->handle_song(&p_packet->get_contents());
+      if (get_auto_logging_enabled())
+      {
+        QString path = log_filename.left(log_filename.size()).replace(".log", ".demo");
+        append_to_file(p_packet->to_string(), path, true);
+        if (!demo_timer.isValid())
+          demo_timer.start();
+        else
+          append_to_file("wait#"+ QString::number(demo_timer.restart()) + "#%", path, true);
+      }
+    }
   }
   else if (header == "RT") {
     if (f_contents.size() < 1)
       goto end;
     if (courtroom_constructed) {
-      if (f_contents.size() == 1)
-        w_courtroom->handle_wtce(f_contents.at(0), 0);
-      else if (f_contents.size() == 2) {
-        w_courtroom->handle_wtce(f_contents.at(0), f_contents.at(1).toInt());
+        if (f_contents.size() == 1)
+          w_courtroom->handle_wtce(f_contents.at(0), 0);
+        else if (f_contents.size() == 2) {
+          w_courtroom->handle_wtce(f_contents.at(0), f_contents.at(1).toInt());
+        if (get_auto_logging_enabled())
+        {
+          QString path = log_filename.left(log_filename.size()).replace(".log", ".demo");
+          append_to_file(p_packet->to_string(), path, true);
+          if (!demo_timer.isValid())
+            demo_timer.start();
+          else
+            append_to_file("wait#"+ QString::number(demo_timer.restart()) + "#%", path, true);
+        }
       }
     }
   }
   else if (header == "HP") {
     if (courtroom_constructed && f_contents.size() > 1)
+    {
       w_courtroom->set_hp_bar(f_contents.at(0).toInt(),
                               f_contents.at(1).toInt());
+      if (get_auto_logging_enabled())
+      {
+        QString path = log_filename.left(log_filename.size()).replace(".log", ".demo");
+        append_to_file(p_packet->to_string(), path, true);
+        if (!demo_timer.isValid())
+          demo_timer.start();
+        else
+          append_to_file("wait#"+ QString::number(demo_timer.restart()) + "#%", path, true);
+      }
+    }
   }
   else if (header == "LE") {
     if (courtroom_constructed) {


### PR DESCRIPTION
This implements support for a demo system by recording networking packets for anything that is relevant to this system.
Evidence might be recorded in the future, but it can potentially overload the filesize of .demo files due to how fucking cursed evidence packets are.

TODO:
- [ ] an option to enable/disable demo recordings in the settings

Demo playback system with:
- [ ] Playing the demo file as it would play out in-client
- [ ] Playing the demo file skipping dead air that goes over a certain ms threshold (like 10000 for wait time more than 10s to be skipped)
- [ ] Rewinding
- [ ] Skipping forward
- [ ] Reading the demo file frame-by-frame
- [ ] Timeline you can navigate with notches etc.
- [ ] Playback from lobby as an option instead of doing it when present on a server

implements https://github.com/AttorneyOnline/AO2-Client/issues/317