### PR TITLE
Keep users from seeing white space when they try to maximize the window

### DIFF
--- a/src/charselect.cpp
+++ b/src/charselect.cpp
@@ -7,6 +7,8 @@
 
 void Courtroom::construct_char_select()
 {
+  this->setWindowFlags( (this->windowFlags() | Qt::CustomizeWindowHint) & ~Qt::WindowMaximizeButtonHint);
+
   ui_char_select_background = new AOImage(this, ao_app);
 
   ui_char_buttons = new QWidget(ui_char_select_background);

--- a/src/charselect.cpp
+++ b/src/charselect.cpp
@@ -74,10 +74,10 @@ void Courtroom::set_char_select()
   if (f_charselect.width < 0 || f_charselect.height < 0) {
     qDebug() << "W: did not find char_select width or height in "
                 "courtroom_design.ini!";
-    this->resize(714, 668);
+    this->setFixedSize(714, 668);
   }
   else
-    this->resize(f_charselect.width, f_charselect.height);
+    this->setFixedSize(f_charselect.width, f_charselect.height);
 
   ui_char_select_background->resize(f_charselect.width, f_charselect.height);
   ui_char_select_background->set_image("charselect_background");

--- a/src/courtroom.cpp
+++ b/src/courtroom.cpp
@@ -3,6 +3,9 @@
 Courtroom::Courtroom(AOApplication *p_ao_app) : QMainWindow()
 {
   ao_app = p_ao_app;
+
+  this->setWindowFlags( (this->windowFlags() | Qt::CustomizeWindowHint) & ~Qt::WindowMaximizeButtonHint);
+
   ao_app->initBASS();
 
   qsrand(static_cast<uint>(QDateTime::currentMSecsSinceEpoch() / 1000));

--- a/src/courtroom.cpp
+++ b/src/courtroom.cpp
@@ -449,13 +449,13 @@ void Courtroom::set_widgets()
   if (f_courtroom.width < 0 || f_courtroom.height < 0) {
     qDebug() << "W: did not find courtroom width or height in " << filename;
 
-    this->resize(714, 668);
+    this->setFixedSize(714, 668);
   }
   else {
     m_courtroom_width = f_courtroom.width;
     m_courtroom_height = f_courtroom.height;
 
-    this->resize(f_courtroom.width, f_courtroom.height);
+    this->setFixedSize(f_courtroom.width, f_courtroom.height);
   }
 
   set_fonts();

--- a/src/lobby.cpp
+++ b/src/lobby.cpp
@@ -13,6 +13,7 @@ Lobby::Lobby(AOApplication *p_ao_app) : QMainWindow()
 
   this->setWindowTitle(tr("Attorney Online 2"));
   this->setWindowIcon(QIcon(":/logo.png"));
+  this->setWindowFlags( (this->windowFlags() | Qt::CustomizeWindowHint) & ~Qt::WindowMaximizeButtonHint);
 
   ui_background = new AOImage(this, ao_app);
   ui_public_servers = new AOButton(this, ao_app);

--- a/src/lobby.cpp
+++ b/src/lobby.cpp
@@ -98,10 +98,10 @@ void Lobby::set_widgets()
            "Did you download all resources correctly from tiny.cc/getao, "
            "including the large 'base' folder?"));
 
-    this->resize(517, 666);
+    this->setFixedSize(517, 666);
   }
   else {
-    this->resize(f_lobby.width, f_lobby.height);
+    this->setFixedSize(f_lobby.width, f_lobby.height);
   }
 
   set_size_and_pos(ui_background, "lobby");


### PR DESCRIPTION
this sets a flag for each of the 3 main windows we have so the maximize button is grayed out as clicking it will only reveal a ton of white space