### PR TITLE
Search for libraries inside a dedicated "lib" folder (and notes on distributing future releases)

### DIFF
--- a/Attorney_Online.pro
+++ b/Attorney_Online.pro
@@ -14,6 +14,7 @@ SOURCES += $$files($$PWD/src/*.cpp)
 HEADERS += $$files($$PWD/include/*.h)
 
 LIBS += -L$$PWD/lib
+QMAKE_LFLAGS += -Wl,-rpath,"'\$$ORIGIN/lib'"
 
 # Uncomment for verbose network logging
 # DEFINES += DEBUG_NETWORK

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -21,6 +21,8 @@ int main(int argc, char *argv[])
 
   AOApplication main_app(argc, argv);
 
+  AOApplication::setLibraryPaths({AOApplication::applicationDirPath() + "/lib"});
+
   QSettings *configini = main_app.configini;
 
   QPluginLoader apngPlugin("qapng");

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -21,7 +21,7 @@ int main(int argc, char *argv[])
 
   AOApplication main_app(argc, argv);
 
-  AOApplication::setLibraryPaths({AOApplication::applicationDirPath() + "/lib"});
+  AOApplication::addLibraryPath(AOApplication::applicationDirPath() + "/lib");
 
   QSettings *configini = main_app.configini;
 


### PR DESCRIPTION
The current method of official releases - that is, static linking of Qt binaries - is an arduous process at best and potentially a license violation at worst (I'm not a lawyer, so I don't know if it is or isn't). Linux releases do not even do this much, instead relying on the user to already have installed Qt - which can be limiting, since many popular distributions' repositories have frustratingly old versions of Qt 5. This pull request is the first step in rectifying and simplifying the release process.

This pull request is largely pointless if official releases continue to be statically linked, which is why it doubles as a suggestion to switch to dynamic linking. On Windows the effect is negligible, but on Linux it would solve the very real problem of **differing Qt versions** across multiple distributions. Ubuntu 16.04's `qt5-default` uses Qt 5.5, for instance, which prohibits us the use of features introduced in the versions following - including WebP support, a headline feature of 2.8. Distributing the necessary object files along with our executable would allow Linux users to see the same WebP content that Windows users already can.

As an aside, multiple servers distributing their own forks of this client have used this approach. Using a "lib" directory is not strictly necessary on Windows, it's just to keep the main client directory clean - though it _is_ necessary on Linux.