### PR TITLE
Add desk_mods 2 -5 for more flexibility in emotes

### DIFF
--- a/include/aoapplication.h
+++ b/include/aoapplication.h
@@ -76,6 +76,7 @@ public:
   bool looping_sfx_support_enabled = false;
   bool additive_enabled = false;
   bool effects_enabled = false;
+  bool expanded_desk_mods_enabled = false;
 
   ///////////////loading info///////////////////
 

--- a/include/courtroom.h
+++ b/include/courtroom.h
@@ -174,6 +174,9 @@ public:
   // sets desk and bg based on pos in chatmessage
   void set_scene(QString f_desk_mod, QString f_side);
 
+  // sets ui_vp_player_char according to SELF_OFFSET, only a function bc it's used with desk_mod 4 and 5
+  void set_self_offset(QString p_list);
+
   // takes in serverD-formatted IP list as prints a converted version to server
   // OOC admittedly poorly named
   void set_ip_list(QString p_list);

--- a/src/courtroom.cpp
+++ b/src/courtroom.cpp
@@ -2063,7 +2063,18 @@ void Courtroom::handle_chatmessage_2()
     f_pointsize = chatsize;
   set_font(ui_vp_message, "", "message", customchar, font_name, f_pointsize);
 
-  set_scene(m_chatmessage[DESK_MOD], m_chatmessage[SIDE]);
+  switch (m_chatmessage[DESK_MOD].toInt()){
+    case 2:
+      set_scene("0", m_chatmessage[SIDE]);
+      break;
+    case 3:
+      set_scene("1", m_chatmessage[SIDE]);
+      break;
+    default:
+      set_scene(m_chatmessage[DESK_MOD], m_chatmessage[SIDE]);
+      break;
+  }
+    
 
   int emote_mod = m_chatmessage[EMOTE_MOD].toInt();
   // Deal with invalid emote modifiers
@@ -2299,6 +2310,11 @@ void Courtroom::handle_chatmessage_3()
   int emote_mod = m_chatmessage[EMOTE_MOD].toInt();
 
   QString side = m_chatmessage[SIDE];
+
+  if (m_chatmessage[DESK_MOD] == "2")
+    set_scene("1", m_chatmessage[SIDE]);
+  else if (m_chatmessage[DESK_MOD] == "3")
+    set_scene("0", m_chatmessage[SIDE]);
 
   if (emote_mod == 5 || emote_mod == 6) {
     ui_vp_desk->hide();

--- a/src/courtroom.cpp
+++ b/src/courtroom.cpp
@@ -2063,19 +2063,6 @@ void Courtroom::handle_chatmessage_2()
     f_pointsize = chatsize;
   set_font(ui_vp_message, "", "message", customchar, font_name, f_pointsize);
 
-  switch (m_chatmessage[DESK_MOD].toInt()){
-    case 2:
-      set_scene("0", m_chatmessage[SIDE]);
-      break;
-    case 3:
-      set_scene("1", m_chatmessage[SIDE]);
-      break;
-    default:
-      set_scene(m_chatmessage[DESK_MOD], m_chatmessage[SIDE]);
-      break;
-  }
-    
-
   int emote_mod = m_chatmessage[EMOTE_MOD].toInt();
   // Deal with invalid emote modifiers
   if (emote_mod != 0 && emote_mod != 1 && emote_mod != 2 && emote_mod != 5 &&
@@ -2158,15 +2145,24 @@ void Courtroom::handle_chatmessage_2()
   }
   // Set ourselves according to SELF_OFFSET
 
-  QStringList self_offsets = m_chatmessage[SELF_OFFSET].split("&");
-  int self_offset = self_offsets[0].toInt();
-  int self_offset_v;
-  if (self_offsets.length() <= 1)
-    self_offset_v = 0;
-  else 
-    self_offset_v = self_offsets[1].toInt();
-  ui_vp_player_char->move(ui_viewport->width() * self_offset / 100, ui_viewport->height() * self_offset_v / 100);
+  set_self_offset(m_chatmessage[SELF_OFFSET]);
 
+  switch(m_chatmessage[DESK_MOD].toInt()) {
+    case 4:
+      ui_vp_sideplayer_char->hide();
+      ui_vp_player_char->move(0, 0);
+      [[fallthrough]];
+    case 2:
+      set_scene("0", m_chatmessage[SIDE]);
+      break;
+    case 5:
+    case 3:
+      set_scene("1", m_chatmessage[SIDE]);
+      break;
+    default:
+      set_scene(m_chatmessage[DESK_MOD], m_chatmessage[SIDE]);
+      break;
+  }
   switch (emote_mod) {
   case 1:
   case 2:
@@ -2311,11 +2307,24 @@ void Courtroom::handle_chatmessage_3()
 
   QString side = m_chatmessage[SIDE];
 
-  if (m_chatmessage[DESK_MOD] == "2")
-    set_scene("1", m_chatmessage[SIDE]);
-  else if (m_chatmessage[DESK_MOD] == "3")
-    set_scene("0", m_chatmessage[SIDE]);
-
+  switch(m_chatmessage[DESK_MOD].toInt()) {
+    case 4:
+      set_self_offset(m_chatmessage[SELF_OFFSET]);
+      [[fallthrough]];
+    case 2:
+      set_scene("1", m_chatmessage[SIDE]);
+      break;
+    case 5:
+      ui_vp_sideplayer_char->hide();
+      ui_vp_player_char->move(0, 0);
+      [[fallthrough]];
+    case 3:
+      set_scene("0", m_chatmessage[SIDE]);
+      break;
+    default:
+      set_scene(m_chatmessage[DESK_MOD], m_chatmessage[SIDE]);
+      break;
+  }
   if (emote_mod == 5 || emote_mod == 6) {
     ui_vp_desk->hide();
     ui_vp_legacy_desk->hide();
@@ -3149,6 +3158,17 @@ void Courtroom::set_scene(QString f_desk_mod, QString f_side)
     ui_vp_legacy_desk->hide();
     ui_vp_desk->show();
   }
+}
+
+void Courtroom::set_self_offset(QString p_list) {
+    QStringList self_offsets = p_list.split("&");
+    int self_offset = self_offsets[0].toInt();
+    int self_offset_v;
+    if (self_offsets.length() <= 1)
+      self_offset_v = 0;
+    else 
+      self_offset_v = self_offsets[1].toInt();
+    ui_vp_player_char->move(ui_viewport->width() * self_offset / 100, ui_viewport->height() * self_offset_v / 100);
 }
 
 void Courtroom::set_ip_list(QString p_list)

--- a/src/courtroom.cpp
+++ b/src/courtroom.cpp
@@ -1582,6 +1582,12 @@ void Courtroom::on_chat_return_pressed()
   if (ao_app->desk_mod_enabled) {
     f_desk_mod =
         QString::number(ao_app->get_desk_mod(current_char, current_emote));
+    if (!ao_app->expanded_desk_mods_enabled) {
+      if (f_desk_mod == "2" || f_desk_mod == "4")
+        f_desk_mod = "0";
+      else if (f_desk_mod == "3" || f_desk_mod == "5")
+        f_desk_mod = "1";
+    }
     if (f_desk_mod == "-1")
       f_desk_mod = "chat";
   }

--- a/src/packet_distribution.cpp
+++ b/src/packet_distribution.cpp
@@ -179,6 +179,7 @@ void AOApplication::server_packet_received(AOPacket *p_packet)
     looping_sfx_support_enabled = false;
     additive_enabled = false;
     effects_enabled = false;
+    expanded_desk_mods_enabled = false;
     if (f_packet.contains("yellowtext", Qt::CaseInsensitive))
       yellow_text_enabled = true;
     if (f_packet.contains("prezoom", Qt::CaseInsensitive))
@@ -205,6 +206,8 @@ void AOApplication::server_packet_received(AOPacket *p_packet)
       additive_enabled = true;
     if (f_packet.contains("effects", Qt::CaseInsensitive))
       effects_enabled = true;
+    if (f_packet.contains("expanded_desk_mods", Qt::CaseInsensitive))
+      expanded_desk_mods_enabled = true;
   }
   else if (header == "PN") {
     if (f_contents.size() < 2)


### PR DESCRIPTION
Yet another change that breaks tsuserver validation, so here's the PR for that: https://github.com/AttorneyOnline/tsuserver3/pull/133

`desk_mod 2`: Hides the overlay during preanimation, shows it again once the preanim is finished.

`desk_mod 3`: Shows the overlay *only* during the preanim, and hides it when it ends.

`desk_mod 4`: Same as `2`, except the preanim will ignore self_offset and the paired character will be hidden for its duration.

`desk_mod 5`: Same as `3`, except after the preanim the character will move to 0,0 and any paired characters will be hidden.

The most obvious use case (and the reason I wrote this) is this gavel slam:
![gavelzoom](https://user-images.githubusercontent.com/32779090/102520522-670b6880-4059-11eb-91c8-93970c8a1147.gif)

With emote_mod 4, the judge can be paired or offset without this zoom-in being offset as well. Additionally, the judge can appear under the desk when the zoom-in ends without having to make the zoom-in also appear under the desk.
