### PR TITLE
Remove MS chat and character password box

### DIFF
--- a/include/courtroom.h
+++ b/include/courtroom.h
@@ -202,7 +202,6 @@ public:
   void list_areas();
 
   // these are for OOC chat
-  void append_ms_chatmessage(QString f_name, QString f_message);
   void append_server_chatmessage(QString p_name, QString p_message,
                                  QString p_color);
 
@@ -514,7 +513,6 @@ private:
 
   QTextEdit *ui_ic_chatlog;
 
-  AOTextArea *ui_ms_chatlog;
   AOTextArea *ui_server_chatlog;
 
   QListWidget *ui_mute_list;
@@ -566,8 +564,6 @@ private:
   AOButton *ui_hold_it;
   AOButton *ui_objection;
   AOButton *ui_take_that;
-
-  AOButton *ui_ooc_toggle;
 
   AOButton *ui_witness_testimony;
   AOButton *ui_cross_examination;
@@ -641,15 +637,12 @@ private:
 
   AOButton *ui_back_to_lobby;
 
-  QLineEdit *ui_char_password;
-
   AOButton *ui_char_select_left;
   AOButton *ui_char_select_right;
 
   AOButton *ui_spectator;
 
-  QLineEdit *ui_char_search;
-  QCheckBox *ui_char_passworded;
+  QLineEdit *ui_char_search;;
   QCheckBox *ui_char_taken;
 
   void construct_char_select();
@@ -785,8 +778,6 @@ private slots:
   void on_pair_offset_changed(int value);
   void on_pair_vert_offset_changed(int value);
 
-  void on_ooc_toggle_clicked();
-
   void on_witness_testimony_clicked();
   void on_cross_examination_clicked();
   void on_not_guilty_clicked();
@@ -829,7 +820,6 @@ private slots:
   void on_char_select_right_clicked();
   void on_char_search_changed();
   void on_char_taken_clicked();
-  void on_char_passworded_clicked();
 
   void on_spectator_clicked();
 

--- a/include/lobby.h
+++ b/include/lobby.h
@@ -75,9 +75,6 @@ private:
 
   AOTextArea *ui_chatbox;
 
-  QLineEdit *ui_chatname;
-  QLineEdit *ui_chatmessage;
-
   AOImage *ui_loading_background;
   QTextEdit *ui_loading_text;
   QProgressBar *ui_progress_bar;
@@ -102,7 +99,6 @@ private slots:
   void on_server_list_clicked(QTreeWidgetItem *p_item, int column);
   void on_server_list_doubleclicked(QTreeWidgetItem *p_item, int column);
   void on_server_search_edited(QString p_text);
-  void on_chatfield_return_pressed();
 };
 
 #endif // LOBBY_H

--- a/src/charselect.cpp
+++ b/src/charselect.cpp
@@ -19,9 +19,6 @@ void Courtroom::construct_char_select()
 
   ui_back_to_lobby = new AOButton(ui_char_select_background, ao_app);
 
-  ui_char_password = new QLineEdit(ui_char_select_background);
-  ui_char_password->setPlaceholderText(tr("Password"));
-
   ui_char_select_left = new AOButton(ui_char_select_background, ao_app);
   ui_char_select_right = new AOButton(ui_char_select_background, ao_app);
 
@@ -33,16 +30,11 @@ void Courtroom::construct_char_select()
   ui_char_search->setFocus();
   set_size_and_pos(ui_char_search, "char_search");
 
-  ui_char_passworded = new QCheckBox(ui_char_select_background);
-  ui_char_passworded->setText(tr("Passworded"));
-  set_size_and_pos(ui_char_passworded, "char_passworded");
-
   ui_char_taken = new QCheckBox(ui_char_select_background);
   ui_char_taken->setText(tr("Taken"));
   set_size_and_pos(ui_char_taken, "char_taken");
 
   ui_char_taken->setChecked(true);
-  ui_char_passworded->setChecked(true);
 
   set_size_and_pos(ui_char_buttons, "char_buttons");
 
@@ -58,8 +50,6 @@ void Courtroom::construct_char_select()
 
   connect(ui_char_search, SIGNAL(textEdited(const QString &)), this,
           SLOT(on_char_search_changed()));
-  connect(ui_char_passworded, SIGNAL(stateChanged(int)), this,
-          SLOT(on_char_passworded_clicked()));
   connect(ui_char_taken, SIGNAL(stateChanged(int)), this,
           SLOT(on_char_taken_clicked()));
 }
@@ -139,8 +129,6 @@ void Courtroom::char_clicked(int n_char)
   }
 
   if (n_char != m_cid) {
-    ao_app->send_server_packet(
-        new AOPacket("PW#" + ui_char_password->text() + "#%"));
     ao_app->send_server_packet(
         new AOPacket("CC#" + QString::number(ao_app->s_pv) + "#" +
                      QString::number(n_char) + "#" + get_hdid() + "#%"));
@@ -248,11 +236,6 @@ void Courtroom::filter_character_list()
   for (int i = 0; i < char_list.size(); i++) {
     AOCharButton *current_char = ui_char_button_list.at(i);
 
-    // It seems passwording characters is unimplemented yet?
-    // Until then, this will stay here, I suppose.
-    // if (ui_char_passworded->isChecked() && character_is_passworded??)
-    //    continue;
-
     if (!ui_char_taken->isChecked() && char_list.at(i).taken)
       continue;
 
@@ -274,7 +257,5 @@ void Courtroom::filter_character_list()
 }
 
 void Courtroom::on_char_search_changed() { filter_character_list(); }
-
-void Courtroom::on_char_passworded_clicked() { filter_character_list(); }
 
 void Courtroom::on_char_taken_clicked() { filter_character_list(); }

--- a/src/courtroom.cpp
+++ b/src/courtroom.cpp
@@ -82,11 +82,6 @@ Courtroom::Courtroom(AOApplication *p_ao_app) : QMainWindow()
   log_margin = ao_app->get_log_margin();
   log_timestamp = ao_app->get_log_timestamp();
 
-  ui_ms_chatlog = new AOTextArea(this);
-  ui_ms_chatlog->setReadOnly(true);
-  ui_ms_chatlog->setOpenExternalLinks(true);
-  ui_ms_chatlog->hide();
-
   ui_server_chatlog = new AOTextArea(this);
   ui_server_chatlog->setReadOnly(true);
   ui_server_chatlog->setOpenExternalLinks(true);
@@ -172,7 +167,6 @@ Courtroom::Courtroom(AOApplication *p_ao_app) : QMainWindow()
   ui_objection = new AOButton(this, ao_app);
   ui_take_that = new AOButton(this, ao_app);
 
-  ui_ooc_toggle = new AOButton(this, ao_app);
   ui_witness_testimony = new AOButton(this, ao_app);
   ui_cross_examination = new AOButton(this, ao_app);
   ui_guilty = new AOButton(this, ao_app);
@@ -352,9 +346,6 @@ Courtroom::Courtroom(AOApplication *p_ao_app) : QMainWindow()
           SLOT(on_sfx_slider_moved(int)));
   connect(ui_blip_slider, SIGNAL(valueChanged(int)), this,
           SLOT(on_blip_slider_moved(int)));
-
-  connect(ui_ooc_toggle, SIGNAL(clicked()), this,
-          SLOT(on_ooc_toggle_clicked()));
 
   connect(ui_music_search, SIGNAL(textChanged(QString)), this,
           SLOT(on_music_search_edited(QString)));
@@ -578,9 +569,6 @@ void Courtroom::set_widgets()
   ui_ic_chatlog->setPlaceholderText(log_goes_downwards ? "▼ Log goes down ▼"
                                                        : "▲ Log goes up ▲");
 
-  set_size_and_pos(ui_ms_chatlog, "ms_chatlog");
-  ui_ms_chatlog->setFrameShape(QFrame::NoFrame);
-
   set_size_and_pos(ui_server_chatlog, "server_chatlog");
   ui_server_chatlog->setFrameShape(QFrame::NoFrame);
 
@@ -772,11 +760,6 @@ void Courtroom::set_widgets()
                               "message will be a shout!"));
   ui_take_that->set_image("takethat");
 
-  set_size_and_pos(ui_ooc_toggle, "ooc_toggle");
-  ui_ooc_toggle->setText(tr("Server"));
-  ui_ooc_toggle->setToolTip(
-      tr("Toggle between server chat and global AO2 chat."));
-
   set_size_and_pos(ui_witness_testimony, "witness_testimony");
   ui_witness_testimony->set_image("witnesstestimony");
   ui_witness_testimony->setToolTip(tr("This will display the animation in the "
@@ -922,8 +905,6 @@ void Courtroom::set_widgets()
   ui_back_to_lobby->setText(tr("Back to Lobby"));
   ui_back_to_lobby->setToolTip(tr("Return back to the server list."));
 
-  set_size_and_pos(ui_char_password, "char_password");
-
   set_size_and_pos(ui_char_buttons, "char_buttons");
 
   set_size_and_pos(ui_char_select_left, "char_select_left");
@@ -958,7 +939,6 @@ void Courtroom::set_fonts(QString p_char)
   set_font(ui_vp_showname, "", "showname", p_char);
   set_font(ui_vp_message, "", "message", p_char);
   set_font(ui_ic_chatlog, "", "ic_chatlog", p_char);
-  set_font(ui_ms_chatlog, "", "ms_chatlog", p_char);
   set_font(ui_server_chatlog, "", "server_chatlog", p_char);
   set_font(ui_music_list, "", "music_list", p_char);
   set_font(ui_area_list, "", "area_list", p_char);
@@ -1508,22 +1488,11 @@ void Courtroom::list_areas()
   }
 }
 
-void Courtroom::append_ms_chatmessage(QString f_name, QString f_message)
-{
-  ui_ms_chatlog->append_chatmessage(
-      f_name, f_message,
-      ao_app->get_color("ms_chatlog_sender_color", "courtroom_fonts.ini")
-          .name());
-}
-
 void Courtroom::append_server_chatmessage(QString p_name, QString p_message,
                                           QString p_color)
 {
   QString color = "#000000";
-
-  if (p_color == "0")
-    color = ao_app->get_color("ms_chatlog_sender_color", "courtroom_fonts.ini")
-                .name();
+  
   if (p_color == "1")
     color =
         ao_app->get_color("server_chatlog_sender_color", "courtroom_fonts.ini")
@@ -3682,24 +3651,6 @@ void Courtroom::on_ooc_return_pressed()
   ui_ooc_chat_message->clear();
 
   ui_ooc_chat_message->setFocus();
-}
-
-void Courtroom::on_ooc_toggle_clicked()
-{
-  if (server_ooc) {
-    ui_ms_chatlog->show();
-    ui_server_chatlog->hide();
-    ui_ooc_toggle->setText(tr("Master"));
-
-    server_ooc = false;
-  }
-  else {
-    ui_ms_chatlog->hide();
-    ui_server_chatlog->show();
-    ui_ooc_toggle->setText(tr("Server"));
-
-    server_ooc = true;
-  }
 }
 
 // Todo: multithread this due to some servers having large as hell music list

--- a/src/lobby.cpp
+++ b/src/lobby.cpp
@@ -38,10 +38,6 @@ Lobby::Lobby(AOApplication *p_ao_app) : QMainWindow()
   ui_description->setOpenExternalLinks(true);
   ui_chatbox = new AOTextArea(this);
   ui_chatbox->setOpenExternalLinks(true);
-  ui_chatname = new QLineEdit(this);
-  ui_chatname->setPlaceholderText(tr("Name"));
-  ui_chatname->setText(ao_app->get_ooc_name());
-  ui_chatmessage = new QLineEdit(this);
   ui_loading_background = new AOImage(this, ao_app);
   ui_loading_text = new QTextEdit(ui_loading_background);
   ui_progress_bar = new QProgressBar(ui_loading_background);
@@ -69,8 +65,6 @@ Lobby::Lobby(AOApplication *p_ao_app) : QMainWindow()
           this, SLOT(on_server_list_doubleclicked(QTreeWidgetItem *, int)));
   connect(ui_server_search, SIGNAL(textChanged(QString)), this,
           SLOT(on_server_search_edited(QString)));
-  connect(ui_chatmessage, SIGNAL(returnPressed()), this,
-          SLOT(on_chatfield_return_pressed()));
   connect(ui_cancel, SIGNAL(clicked()), ao_app, SLOT(loading_cancelled()));
 
   ui_connect->setEnabled(false);
@@ -157,15 +151,6 @@ void Lobby::set_widgets()
   ui_chatbox->setStyleSheet(
       "QTextBrowser{background-color: rgba(0, 0, 0, 0);}");
 
-  set_size_and_pos(ui_chatname, "chatname");
-  ui_chatname->setStyleSheet("background-color: rgba(0, 0, 0, 0);"
-                             "selection-background-color: rgba(0, 0, 0, 0);");
-
-  set_size_and_pos(ui_chatmessage, "chatmessage");
-  ui_chatmessage->setStyleSheet(
-      "background-color: rgba(0, 0, 0, 0);"
-      "selection-background-color: rgba(0, 0, 0, 0);");
-
   ui_loading_background->resize(this->width(), this->height());
   ui_loading_background->set_image("loadingbackground");
 
@@ -210,8 +195,6 @@ void Lobby::set_fonts()
   set_font(ui_player_count, "player_count");
   set_font(ui_description, "description");
   set_font(ui_chatbox, "chatbox");
-  set_font(ui_chatname, "chatname");
-  set_font(ui_chatmessage, "chatmessage");
   set_font(ui_loading_text, "loading_text");
   set_font(ui_server_list, "server_list");
 }
@@ -230,8 +213,6 @@ void Lobby::set_stylesheets()
   set_stylesheet(ui_player_count, "[PLAYER COUNT]");
   set_stylesheet(ui_description, "[DESCRIPTION]");
   set_stylesheet(ui_chatbox, "[CHAT BOX]");
-  set_stylesheet(ui_chatname, "[CHAT NAME]");
-  set_stylesheet(ui_chatmessage, "[CHAT MESSAGE]");
   set_stylesheet(ui_loading_text, "[LOADING TEXT]");
   set_stylesheet(ui_server_list, "[SERVER LIST]");
 }
@@ -466,22 +447,6 @@ void Lobby::on_server_search_edited(QString p_text)
       item->setHidden(false);
     }
   }
-}
-
-void Lobby::on_chatfield_return_pressed()
-{
-  // no you can't send empty messages
-  if (ui_chatname->text() == "" || ui_chatmessage->text() == "")
-    return;
-
-  QString f_header = "CT";
-  QStringList f_contents{ui_chatname->text(), ui_chatmessage->text()};
-
-  AOPacket *f_packet = new AOPacket(f_header, f_contents);
-
-  ao_app->send_ms_packet(f_packet);
-
-  ui_chatmessage->clear();
 }
 
 void Lobby::list_servers()

--- a/src/packet_distribution.cpp
+++ b/src/packet_distribution.cpp
@@ -59,9 +59,6 @@ void AOApplication::ms_packet_received(AOPacket *p_packet)
     if (lobby_constructed) {
       w_lobby->append_chatmessage(f_name, f_message);
     }
-    if (courtroom_constructed && courtroom_loaded) {
-      w_courtroom->append_ms_chatmessage(f_name, f_message);
-    }
   }
   else if (header == "AO2CHECK") {
     send_ms_packet(new AOPacket("ID#AO2#" + get_version_string() + "#%"));
@@ -419,8 +416,6 @@ void AOApplication::server_packet_received(AOPacket *p_packet)
       goto end;
 
     if (lobby_constructed)
-      w_courtroom->append_ms_chatmessage("", w_lobby->get_chatlog());
-
     w_courtroom->character_loading_finished();
     w_courtroom->done_received();
 


### PR DESCRIPTION
Removed Master Chat text functions from the server list but kept the lobby chat window. (Chat in MS is disabled anyway.)
Removed the Character password functions. (Redundant as never been used.)
Removed the master chat and ooc toggle buttons. (They aren't necessary and waste space.)

