### PR TITLE
Log objections IC, overhaul custom objections context menu, add more configuration options per-character

### DIFF
--- a/include/aoapplication.h
+++ b/include/aoapplication.h
@@ -219,6 +219,9 @@ public:
   // Returns whether the log should have a timestamp.
   bool get_log_timestamp();
 
+  // Returns whether to log IC actions.
+  bool get_log_ic_actions();
+
   // Returns the username the user may have set in config.ini.
   QString get_default_username();
 

--- a/include/aooptionsdialog.h
+++ b/include/aooptionsdialog.h
@@ -52,6 +52,8 @@ private:
   QSpinBox *ui_log_margin_spinbox;
   QLabel *ui_log_timestamp_lbl;
   QCheckBox *ui_log_timestamp_cb;
+  QLabel *ui_log_ic_actions_lbl;
+  QCheckBox *ui_log_ic_actions_cb;
   QFrame *ui_log_names_divider;
   QLineEdit *ui_username_textbox;
   QLabel *ui_username_lbl;

--- a/include/courtroom.h
+++ b/include/courtroom.h
@@ -331,6 +331,9 @@ private:
   // True, if the log should display the message like name<br>text instead of name: text
   bool log_newline = false;
 
+  // True, if the log should include RP actions like interjections, showing evidence, etc.
+  bool log_ic_actions = true;
+
   // Margin in pixels between log entries for the IC log.
   int log_margin = 0;
 
@@ -397,6 +400,11 @@ private:
 
   int objection_state = 0;
   QString objection_custom = "";
+  struct CustomObjection {
+    QString name;
+    QString filename;
+  };
+  QList<CustomObjection> custom_objections_list;
   int realization_state = 0;
   int screenshake_state = 0;
   int text_color = 0;

--- a/src/aooptionsdialog.cpp
+++ b/src/aooptionsdialog.cpp
@@ -169,7 +169,7 @@ AOOptionsDialog::AOOptionsDialog(QWidget *parent, AOApplication *p_ao_app)
   ui_log_ic_actions_lbl->setToolTip(
       tr("If ticked, log will show IC actions such as shouting and presenting evidence."));
 
-  ui_gameplay_form->setWidget(row, QFormLayout::LabelRole, ui_log_timestamp_lbl);
+  ui_gameplay_form->setWidget(row, QFormLayout::LabelRole, ui_log_ic_actions_lbl);
 
   ui_log_ic_actions_cb = new QCheckBox(ui_form_layout_widget);
   ui_log_ic_actions_cb->setChecked(p_ao_app->get_log_ic_actions());
@@ -778,6 +778,7 @@ void AOOptionsDialog::save_pressed()
   configini->setValue("log_newline", ui_log_newline_cb->isChecked());
   configini->setValue("log_margin", ui_log_margin_spinbox->value());
   configini->setValue("log_timestamp", ui_log_timestamp_cb->isChecked());
+  configini->setValue("log_ic_actions", ui_log_ic_actions_cb->isChecked());
   configini->setValue("default_username", ui_username_textbox->text());
   configini->setValue("show_custom_shownames", ui_showname_cb->isChecked());
   configini->setValue("master", ui_ms_textbox->text());

--- a/src/aooptionsdialog.cpp
+++ b/src/aooptionsdialog.cpp
@@ -164,6 +164,19 @@ AOOptionsDialog::AOOptionsDialog(QWidget *parent, AOApplication *p_ao_app)
   ui_gameplay_form->setWidget(row, QFormLayout::FieldRole, ui_log_timestamp_cb);
 
   row += 1;
+  ui_log_ic_actions_lbl = new QLabel(ui_form_layout_widget);
+  ui_log_ic_actions_lbl->setText(tr("Log IC actions:"));
+  ui_log_ic_actions_lbl->setToolTip(
+      tr("If ticked, log will show IC actions such as shouting and presenting evidence."));
+
+  ui_gameplay_form->setWidget(row, QFormLayout::LabelRole, ui_log_timestamp_lbl);
+
+  ui_log_ic_actions_cb = new QCheckBox(ui_form_layout_widget);
+  ui_log_ic_actions_cb->setChecked(p_ao_app->get_log_ic_actions());
+
+  ui_gameplay_form->setWidget(row, QFormLayout::FieldRole, ui_log_ic_actions_cb);
+  
+  row += 1;
   ui_log_names_divider = new QFrame(ui_form_layout_widget);
   ui_log_names_divider->setFrameShape(QFrame::HLine);
   ui_log_names_divider->setFrameShadow(QFrame::Sunken);

--- a/src/courtroom.cpp
+++ b/src/courtroom.cpp
@@ -1941,7 +1941,7 @@ void Courtroom::handle_chatmessage(QStringList *p_contents)
         objection_player->play("custom", f_char, f_custom_theme);
         shout_message = ao_app->read_char_ini(f_char, "custom_message", "Shouts");
         if (shout_message == "")
-          shout_message = tr("CUSTOM!");
+          shout_message = tr("CUSTOM OBJECTION!");
       }
       m_chatmessage[EMOTE_MOD] = 1;
       break;

--- a/src/text_file_functions.cpp
+++ b/src/text_file_functions.cpp
@@ -73,6 +73,13 @@ bool AOApplication::get_log_timestamp()
   return result.startsWith("true");
 }
 
+bool AOApplication::get_log_timestamp()
+{
+  QString result =
+      configini->value("log_ic_actions", "true").value<QString>();
+  return result.startsWith("true");
+}
+
 bool AOApplication::get_showname_enabled_by_default()
 {
   QString result =

--- a/src/text_file_functions.cpp
+++ b/src/text_file_functions.cpp
@@ -73,7 +73,7 @@ bool AOApplication::get_log_timestamp()
   return result.startsWith("true");
 }
 
-bool AOApplication::get_log_timestamp()
+bool AOApplication::get_log_ic_actions()
 {
   QString result =
       configini->value("log_ic_actions", "true").value<QString>();


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/32779090/102927884-6d388500-445d-11eb-991e-54ca0b1e1f2d.png)

No longer are interjections lost to the ether when they end, now they are logged in the IC log much like presenting evidence or playing a song. Speaking of presenting evidence, it and logging objections can now optionally be disabled in settings. Messages are determined by a new `[Shouts]` section in char.ini (though sane defaults are provided):
```ini
[Shouts]
holdit_message = This is a custom Hold it! message!
custom_name = My custom shout
custom_message = This is my custom shout!
custom2_name = My second custom shout
custom2_message = This is my second custom shout!
```
![image](https://user-images.githubusercontent.com/32779090/102928187-ea63fa00-445d-11eb-9b6b-4d16087bda8f.png)
The way the context menu displays options has been overhauled to support custom names, as well:
**Before:**
![image](https://user-images.githubusercontent.com/32779090/102928534-76762180-445e-11eb-8b51-5c303bec9e3b.png)
**After:**
![image](https://user-images.githubusercontent.com/32779090/102928470-5a728000-445e-11eb-865e-01bac25c5cdc.png)
**IC:**
![image](https://user-images.githubusercontent.com/32779090/102928585-93aaf000-445e-11eb-9e12-75c29f7146f8.png)

