### PR TITLE
Add missing bassopus to the configure script

### DIFF
--- a/scripts/configure_ubuntu.sh
+++ b/scripts/configure_ubuntu.sh
@@ -20,10 +20,13 @@ cd tmp
 
 #get the bass prebuilt
 curl http://www.un4seen.com/files/bass24-linux.zip -o bass_linux.zip
+curl http://www.un4seen.com/files/bassopus24-linux.zip -o bassopus_linux.zip
 
 unzip bass_linux.zip
+unzip bassopus_linux.zip
 
 cp x64/libbass.so ../../lib
+cp x64/libbassopus.so ../../lib
 
 #get the discord-rpc prebuilt
 curl -L https://github.com/discordapp/discord-rpc/releases/download/v3.4.0/discord-rpc-linux.zip -o discord_rpc_linux.zip


### PR DESCRIPTION
I'm on another distro but the script was used as reference to make a dynamic build