### PR TITLE
Encode doc contents with hash sign

### DIFF
--- a/src/courtroom.cpp
+++ b/src/courtroom.cpp
@@ -3573,9 +3573,10 @@ void Courtroom::on_ooc_return_pressed()
     if (!caseauth.isEmpty())
       append_server_chatmessage(tr("CLIENT"),
                                 tr("Case made by %1.").arg(caseauth), "1");
-    if (!casedoc.isEmpty())
-      ao_app->send_server_packet(new AOPacket("CT#" + ui_ooc_chat_name->text() +
-                                              "#/doc " + casedoc + "#%"));
+    if (!casedoc.isEmpty()) {
+      QStringList f_contents = {ui_ooc_chat_name->text(), "/doc " + casedoc};
+      ao_app->send_server_packet(new AOPacket("CT", f_contents));
+    }
     if (!casestatus.isEmpty())
       ao_app->send_server_packet(new AOPacket("CT#" + ui_ooc_chat_name->text() +
                                               "#/status " + casestatus + "#%"));


### PR DESCRIPTION
Theoretically fixes #347 

The problem is when constructing a new AOPacket as a packet string, the '#' at the end of the `doc` url is considered a token to split on. The fix in theory is to use the other constructor to directly initialize the contents of the AOPacket.

## Unit Test
https://github.com/skyedeving/AO2-Client/blob/add-tests/README_TEST.md
https://github.com/skyedeving/AO2-Client/blob/add-tests/test/test_aopacket.cpp