### PR TITLE
Use QList::mid when constructing QStringList

### DIFF
--- a/src/aopacket.cpp
+++ b/src/aopacket.cpp
@@ -5,9 +5,7 @@ AOPacket::AOPacket(QString p_packet_string)
   QStringList packet_contents = p_packet_string.split("#");
 
   m_header = packet_contents.first();
-  for (auto it = packet_contents.begin()+1; it != packet_contents.end()-1; it++) {
-    m_contents += *it;
-  }
+  m_contents = packet_contents.mid(1, packet_contents.size()-2); // trims %
 }
 
 QString AOPacket::to_string()

--- a/src/aopacket.cpp
+++ b/src/aopacket.cpp
@@ -5,7 +5,9 @@ AOPacket::AOPacket(QString p_packet_string)
   QStringList packet_contents = p_packet_string.split("#");
 
   m_header = packet_contents.first();
-  m_contents = QStringList(packet_contents.begin()+1, packet_contents.end()-1); // trims %
+  for (auto it = packet_contents.begin()+1; it != packet_contents.end()-1; it++) {
+    m_contents += *it;
+  }
 }
 
 QString AOPacket::to_string()


### PR DESCRIPTION
A follow up on #363 

The QStringList constructor introduced in 5.14 seems to be too cutting edge right now