### PR TITLE
Fix timestamps when toggling showname

### DIFF
--- a/include/courtroom.h
+++ b/include/courtroom.h
@@ -225,7 +225,7 @@ public:
   // selected
   // or the user isn't already scrolled to the top
   void append_ic_text(QString p_text, QString p_name = "", QString action = "",
-                      int color = 0, QDateTime timestamp = {});
+                      int color = 0, QDateTime timestamp = QDateTime::currentDateTime());
 
   // prints who played the song to IC chat and plays said song(if found on local
   // filesystem) takes in a list where the first element is the song name and

--- a/include/courtroom.h
+++ b/include/courtroom.h
@@ -225,7 +225,7 @@ public:
   // selected
   // or the user isn't already scrolled to the top
   void append_ic_text(QString p_text, QString p_name = "", QString action = "",
-                      int color = 0);
+                      int color = 0, QDateTime timestamp = {});
 
   // prints who played the song to IC chat and plays said song(if found on local
   // filesystem) takes in a list where the first element is the song name and

--- a/src/courtroom.cpp
+++ b/src/courtroom.cpp
@@ -2619,7 +2619,7 @@ void Courtroom::log_ic_text(QString p_name, QString p_showname,
 }
 
 void Courtroom::append_ic_text(QString p_text, QString p_name, QString p_action,
-                               int color)
+                               int color, QDateTime timestamp)
 {
   QTextCharFormat bold;
   QTextCharFormat normal;
@@ -2645,10 +2645,15 @@ void Courtroom::append_ic_text(QString p_text, QString p_name, QString p_action,
   }
 
   // Timestamp if we're doing that meme
-  if (log_timestamp)
-    ui_ic_chatlog->textCursor().insertText(
-        "[" + QDateTime::currentDateTime().toString("h:mm:ss AP") + "] ",
-        normal);
+  if (log_timestamp) {
+    if (timestamp.isValid()) {
+      ui_ic_chatlog->textCursor().insertText(
+        "[" + timestamp.toString("h:mm:ss AP") + "] ", normal);
+    } else {
+      ui_ic_chatlog->textCursor().insertText(
+        "[" + QDateTime::currentDateTime().toString("h:mm:ss AP") + "] ", normal);
+    }
+  }
 
   // Format the name of the actor
   ui_ic_chatlog->textCursor().insertText(p_name, bold);
@@ -4780,7 +4785,8 @@ void Courtroom::regenerate_ic_chatlog()
     append_ic_text(item.get_message(),
                    ui_showname_enable->isChecked() ? item.get_showname()
                                                    : item.get_name(),
-                   item.get_action(), item.get_chat_color());
+                   item.get_action(), item.get_chat_color(),
+                   item.get_datetime().toLocalTime());
   }
 }
 

--- a/src/courtroom.cpp
+++ b/src/courtroom.cpp
@@ -2650,8 +2650,7 @@ void Courtroom::append_ic_text(QString p_text, QString p_name, QString p_action,
       ui_ic_chatlog->textCursor().insertText(
         "[" + timestamp.toString("h:mm:ss AP") + "] ", normal);
     } else {
-      ui_ic_chatlog->textCursor().insertText(
-        "[" + QDateTime::currentDateTime().toString("h:mm:ss AP") + "] ", normal);
+      qDebug() << "could not insert invalid timestamp";
     }
   }
 


### PR DESCRIPTION
Fixes #328 

On toggling shownames, regenerate_ic_chatlog() gets called to reprint
the entire chatlog with append_ic_text().  The issue is that
append_ic_text() uses QDateTime::currentDateTime() for the timestamp
when it's called.  Therefore the fix is adding a new timestamp
parameter to the append_ic_text() which we supply from the datetime
provided by each chatlogpiece