### PR TITLE
Sort case evidence numerically before adding in

### DIFF
--- a/include/courtroom.h
+++ b/include/courtroom.h
@@ -58,6 +58,7 @@
 #include <QTextCharFormat>
 //#include <QRandomGenerator>
 
+#include <algorithm>
 #include <stack>
 
 class AOApplication;

--- a/src/courtroom.cpp
+++ b/src/courtroom.cpp
@@ -3588,7 +3588,15 @@ void Courtroom::on_ooc_return_pressed()
           new AOPacket("DE#" + QString::number(i) + "#%"));
     }
 
-    foreach (QString evi, casefile.childGroups()) {
+    // sort the case_evidence numerically
+    QStringList case_evidence = casefile.childGroups();
+    std::sort(case_evidence.begin(), case_evidence.end(),
+              [] (const QString &a, const QString &b) {
+                return a.toInt() < b.toInt();
+              });
+
+    // load evidence
+    foreach (QString evi, case_evidence) {
       if (evi == "General")
         continue;
 


### PR DESCRIPTION
Theoretically fixes #348 

Inventories get displayed lexicographical too but it is assumed to not matter

## Unit Test
https://github.com/skyedeving/AO2-Client/blob/add-tests/test/test_caseloading.cpp