### PR TITLE
Add in support for streaming music with bass

### DIFF
--- a/src/aomusicplayer.cpp
+++ b/src/aomusicplayer.cpp
@@ -23,14 +23,26 @@ void AOMusicPlayer::play(QString p_song, int channel, bool loop,
 
   unsigned int flags = BASS_STREAM_PRESCAN | BASS_STREAM_AUTOFREE |
                        BASS_UNICODE | BASS_ASYNCFILE;
-  if (loop)
+  unsigned int streaming_flags = BASS_STREAM_AUTOFREE;
+  if (loop) {
     flags |= BASS_SAMPLE_LOOP;
+    streaming_flags |= BASS_SAMPLE_LOOP;
+  }
 
   DWORD newstream;
-  if (f_path.endsWith(".opus"))
-    newstream = BASS_OPUS_StreamCreateFile(FALSE, f_path.utf16(), 0, 0, flags);
-  else
-    newstream = BASS_StreamCreateFile(FALSE, f_path.utf16(), 0, 0, flags);
+  if (f_path.startsWith("http")) {
+    if (f_path.endsWith(".opus"))
+      newstream = BASS_OPUS_StreamCreateURL(f_path.toStdString().c_str(), 0, streaming_flags, nullptr, 0);
+    else
+      newstream = BASS_StreamCreateURL(f_path.toStdString().c_str(), 0, streaming_flags, nullptr, 0);
+
+  } else {
+    if (f_path.endsWith(".opus"))
+      newstream = BASS_OPUS_StreamCreateFile(FALSE, f_path.utf16(), 0, 0, flags);
+    else
+      newstream = BASS_StreamCreateFile(FALSE, f_path.utf16(), 0, 0, flags);
+  }
+
 
   if (ao_app->get_audio_output_device() != "default")
     BASS_ChannelSetDevice(m_stream_list[channel], BASS_GetDevice());

--- a/src/path_functions.cpp
+++ b/src/path_functions.cpp
@@ -73,6 +73,9 @@ QString AOApplication::get_sounds_path(QString p_file)
 
 QString AOApplication::get_music_path(QString p_song)
 {
+  if (p_song.startsWith("http")) {
+    return p_song; // url
+  }
   QString path = get_base_path() + "sounds/music/" + p_song;
   return get_case_sensitive_path(path);
 }


### PR DESCRIPTION
Theoretically fixes #336

The previous PR trying to address this looked like the flags were incorrect since the flags for file and url don't mix. The use of utf16 seems to be unnecessary too.
> URLs are written only with the graphic printable characters of the
   US-ASCII coded character set: The octets 80-FF hexadecimal are not
   used in US-ASCII, and the octets 00-1F and 7F hexadecimal represent
   control characters; these must be encoded.
-- https://tools.ietf.org/html/rfc1738

# Unit Test
https://github.com/skyedeving/AO2-Client/blob/add-tests/test/test_bass.cpp