### PR TITLE
Fix segfault in server list without a server selection 

### DIFF
--- a/Attorney_Online.pro
+++ b/Attorney_Online.pro
@@ -35,7 +35,7 @@ LIBS += -lbassopus
 
 macx:LIBS += -framework CoreFoundation -framework Foundation -framework CoreServices
 
-CONFIG += c++14
+CONFIG += c++17
 
 RESOURCES += resources.qrc
 

--- a/src/lobby.cpp
+++ b/src/lobby.cpp
@@ -337,7 +337,8 @@ void Lobby::on_add_to_fav_released()
 {
   ui_add_to_fav->set_image("addtofav");
   if (public_servers_selected) {
-    if (int selection = get_selected_server(); selection > -1) {
+    int selection = get_selected_server();
+    if (selection > -1) {
       ao_app->add_favorite_server(selection);
     }
   }

--- a/src/lobby.cpp
+++ b/src/lobby.cpp
@@ -504,6 +504,7 @@ void Lobby::list_servers()
   }
   ui_server_list->setSortingEnabled(true);
   ui_server_list->sortItems(0, Qt::SortOrder::AscendingOrder);
+  ui_server_list->setCurrentItem(ui_server_list->topLevelItem(0));
 }
 
 void Lobby::list_favorites()
@@ -520,6 +521,7 @@ void Lobby::list_favorites()
     i++;
   }
   ui_server_list->setSortingEnabled(true);
+  ui_server_list->setCurrentItem(ui_server_list->topLevelItem(0));
 }
 
 void Lobby::append_chatmessage(QString f_name, QString f_message)

--- a/src/lobby.cpp
+++ b/src/lobby.cpp
@@ -283,7 +283,10 @@ QString Lobby::get_chatlog()
 
 int Lobby::get_selected_server()
 {
-  return ui_server_list->currentItem()->text(0).toInt();
+  if (auto item = ui_server_list->currentItem()) {
+    return item->text(0).toInt();
+  }
+  return -1;
 }
 
 void Lobby::set_loading_value(int p_value)
@@ -333,12 +336,11 @@ void Lobby::on_add_to_fav_pressed()
 void Lobby::on_add_to_fav_released()
 {
   ui_add_to_fav->set_image("addtofav");
-
-  // you cant add favorites from favorites m8
-  if (!public_servers_selected)
-    return;
-
-  ao_app->add_favorite_server(get_selected_server());
+  if (public_servers_selected) {
+    if (int selection = get_selected_server(); selection > -1) {
+      ao_app->add_favorite_server(selection);
+    }
+  }
 }
 
 void Lobby::on_connect_pressed() { ui_connect->set_image("connect_pressed"); }

--- a/src/lobby.cpp
+++ b/src/lobby.cpp
@@ -504,7 +504,6 @@ void Lobby::list_servers()
   }
   ui_server_list->setSortingEnabled(true);
   ui_server_list->sortItems(0, Qt::SortOrder::AscendingOrder);
-  ui_server_list->setCurrentItem(ui_server_list->topLevelItem(0));
 }
 
 void Lobby::list_favorites()
@@ -521,7 +520,6 @@ void Lobby::list_favorites()
     i++;
   }
   ui_server_list->setSortingEnabled(true);
-  ui_server_list->setCurrentItem(ui_server_list->topLevelItem(0));
 }
 
 void Lobby::append_chatmessage(QString f_name, QString f_message)


### PR DESCRIPTION
Fixes #373 for most situations

Should take care of most situations, however it's still technically possible to segfault if the list isn't populated fast enough and it's still possible to segfault after unselecting the server with ctrl+click. These are specific situations though which are less likely to be encountered in the wild.