### PR TITLE
Checking for apng should be lower case

### DIFF
--- a/src/lobby.cpp
+++ b/src/lobby.cpp
@@ -356,7 +356,7 @@ void Lobby::on_connect_released()
 
 void Lobby::on_about_clicked()
 {
-  const bool hasApng = QImageReader::supportedImageFormats().contains("APNG");
+  const bool hasApng = QImageReader::supportedImageFormats().contains("apng");
 
   QString msg =
       tr("<h2>Attorney Online %1</h2>"


### PR DESCRIPTION
Fixes #375 

`QImageReader::supportedImageFormats()` return formats in lowercase