### PR TITLE
Set emote format to apng if png supports animation

### DIFF
--- a/src/aocharmovie.cpp
+++ b/src/aocharmovie.cpp
@@ -64,9 +64,9 @@ void AOCharMovie::load_image(QString p_char, QString p_emote,
 
   // set format to apng if png supports animation
   if (emote_path.endsWith("png")) {
-    m_reader.setFormat("apng");
-    if (!m_reader.supportsAnimation()) {
-      m_reader.setFormat("png");
+    m_reader->setFormat("apng");
+    if (!m_reader->supportsAnimation()) {
+      m_reader->setFormat("png");
     }
   }
 

--- a/src/aocharmovie.cpp
+++ b/src/aocharmovie.cpp
@@ -61,6 +61,15 @@ void AOCharMovie::load_image(QString p_char, QString p_emote,
     return;
 
   m_reader->setFileName(emote_path);
+
+  // set format to apng if png supports animation
+  if (emote_path.endsWith("png")) {
+    m_reader.setFormat("apng");
+    if (!m_reader.supportsAnimation()) {
+      m_reader.setFormat("png");
+    }
+  }
+
   QPixmap f_pixmap = this->get_pixmap(m_reader->read());
   int f_delay = m_reader->nextImageDelay();
 


### PR DESCRIPTION
Theoretically fixes #332 

The methods provided by qt to autodetect or decide from contents fail to detect apng from png files. This PR works around that by performing the check for animation manually.

# Test
https://github.com/skyedeving/AO2-Client/blob/add-tests/test/test_apng.cpp