### PR TITLE
Replace "gender" with "blips" for better consistency and accuracy

### DIFF
--- a/include/aoapplication.h
+++ b/include/aoapplication.h
@@ -400,8 +400,8 @@ public:
   // Returns the desk modifier for p_char's p_emote
   int get_desk_mod(QString p_char, int p_emote);
 
-  // Returns p_char's gender
-  QString get_gender(QString p_char);
+  // Returns p_char's blips (previously called their "gender")
+  QString get_blips(QString p_char);
 
   // ======
   // These are all casing-related settings.

--- a/src/courtroom.cpp
+++ b/src/courtroom.cpp
@@ -2836,9 +2836,9 @@ void Courtroom::start_chat_ticking()
   current_display_speed = 3;
   chat_tick_timer->start(0); // Display the first char right away
 
-  QString f_gender = ao_app->get_gender(m_chatmessage[CHAR_NAME]);
+  QString f_blips = ao_app->get_blips(m_chatmessage[CHAR_NAME]);
 
-  blip_player->set_blips(f_gender);
+  blip_player->set_blips(f_blips);
 
   // means text is currently ticking
   text_state = 1;

--- a/src/text_file_functions.cpp
+++ b/src/text_file_functions.cpp
@@ -618,12 +618,15 @@ QString AOApplication::get_char_side(QString p_char)
   return f_result;
 }
 
-QString AOApplication::get_gender(QString p_char)
+QString AOApplication::get_blips(QString p_char)
 {
-  QString f_result = read_char_ini(p_char, "gender", "Options");
+  QString f_result = read_char_ini(p_char, "blips", "Options");
 
-  if (f_result == "")
-    f_result = "male";
+  if (f_result == "") {
+    f_result = read_char_ini(p_char, "gender", "Options"); // not very PC, FanatSors
+    if (f_result == "")
+      f_result = "male";
+  }
 
   if (!file_exists(get_sfx_suffix(get_sounds_path(f_result)))) {
     if (file_exists(get_sfx_suffix(get_sounds_path("../blips/" + f_result))))


### PR DESCRIPTION
The "gender" value can still be used, but "blips" takes precedence.