### PR TITLE
Add arup_clear() and clear arup when fetching new areas

### DIFF
--- a/include/courtroom.h
+++ b/include/courtroom.h
@@ -92,6 +92,13 @@ public:
     arup_locks.append(locked);
   }
 
+  void arup_clear() {
+    arup_players.clear();
+    arup_statuses.clear();
+    arup_cms.clear();
+    arup_locks.clear();
+  }
+
   void arup_modify(int type, int place, QString value)
   {
     if (type == 0) {

--- a/src/packet_distribution.cpp
+++ b/src/packet_distribution.cpp
@@ -413,9 +413,11 @@ void AOApplication::server_packet_received(AOPacket *p_packet)
       goto end;
 
     w_courtroom->clear_areas();
+    w_courtroom->arup_clear();
 
     for (int n_element = 0; n_element < f_contents.size(); ++n_element) {
       w_courtroom->append_area(f_contents.at(n_element));
+      w_courtroom->arup_append(0, "Unknown", "Unknown", "Unknown");
     }
 
     w_courtroom->list_areas();


### PR DESCRIPTION
Theoretically fixes #313

The "FA" packet from the server invalidates the client's previous area
list so it makes sense for the arup information tied to that list to
be invalidated as well (especially seeing that the area and arup share
the same index).  As we repopulate the client's area list, we do the
same for the arup list.

The "SM" packet also initializes arup this way:
https://github.com/AttorneyOnline/AO2-Client/blob/e65072f8f1e885f7bbade9e9d84fbeea2ef8a097/src/packet_distribution.cpp#L383

The server is expected to send "ARUP" packets to update the arup for
the client in both cases.