### PR TITLE
forgot to return after destroying the connection

### DIFF
--- a/src/demoserver.cpp
+++ b/src/demoserver.cpp
@@ -37,11 +37,17 @@ void DemoServer::accept_connection()
 {
     QString path = QFileDialog::getOpenFileName(nullptr, tr("Load Demo"), "logs/", tr("Demo Files (*.demo)"));
     if (path.isEmpty())
+    {
         destroy_connection();
+        return;
+    }
     load_demo(path);
 
     if (demo_data.isEmpty())
+    {
         destroy_connection();
+        return;
+    }
 
     if (demo_data.head().startsWith("SC#"))
     {


### PR DESCRIPTION
bugfix

the alternative to the extra return would be to an inline function but i find those confusing