### PR TITLE
Improvements to the way the position dropdown is handled

### DIFF
--- a/include/courtroom.h
+++ b/include/courtroom.h
@@ -658,6 +658,7 @@ private:
 
   QComboBox *ui_emote_dropdown;
   QComboBox *ui_pos_dropdown;
+  AOButton *ui_pos_remove;
 
   QComboBox *ui_iniswap_dropdown;
   AOButton *ui_iniswap_remove;
@@ -835,6 +836,7 @@ private slots:
 
   void on_emote_dropdown_changed(int p_index);
   void on_pos_dropdown_changed(int p_index);
+  void on_pos_remove_clicked();
 
   void on_iniswap_dropdown_changed(int p_index);
   void set_iniswap_dropdown();

--- a/include/courtroom.h
+++ b/include/courtroom.h
@@ -165,7 +165,7 @@ public:
   void set_background(QString p_background, bool display = false);
 
   // sets the local character pos/side to use.
-  void set_side(QString p_side);
+  void set_side(QString p_side, bool block_signals=true);
 
   // sets the pos dropdown
   void set_pos_dropdown(QStringList pos_dropdowns);

--- a/src/courtroom.cpp
+++ b/src/courtroom.cpp
@@ -1307,6 +1307,27 @@ void Courtroom::set_side(QString p_side)
   else
     f_side = p_side;
 
+  if (f_side == "jud") {
+    ui_witness_testimony->show();
+    ui_cross_examination->show();
+    ui_not_guilty->show();
+    ui_guilty->show();
+    ui_defense_minus->show();
+    ui_defense_plus->show();
+    ui_prosecution_minus->show();
+    ui_prosecution_plus->show();
+  }
+  else {
+    ui_witness_testimony->hide();
+    ui_cross_examination->hide();
+    ui_guilty->hide();
+    ui_not_guilty->hide();
+    ui_defense_minus->hide();
+    ui_defense_plus->hide();
+    ui_prosecution_minus->hide();
+    ui_prosecution_plus->hide();
+  }
+
   for (int i = 0; i < ui_pos_dropdown->count(); ++i) {
     QString pos = ui_pos_dropdown->itemText(i);
     if (pos == f_side) {

--- a/src/courtroom.cpp
+++ b/src/courtroom.cpp
@@ -1299,7 +1299,7 @@ void Courtroom::set_background(QString p_background, bool display)
   }
 }
 
-void Courtroom::set_side(QString p_side)
+void Courtroom::set_side(QString p_side, bool block_signals)
 {
   QString f_side;
   if (p_side == "")
@@ -1333,14 +1333,16 @@ void Courtroom::set_side(QString p_side)
     if (pos == f_side) {
       // Block the signals to prevent setCurrentIndex from triggering a pos
       // change
-      ui_pos_dropdown->blockSignals(true);
+      if (block_signals)
+        ui_pos_dropdown->blockSignals(true);
 
       // Set the index on dropdown ui element to let you know what pos you're on
       // right now
       ui_pos_dropdown->setCurrentIndex(i);
 
       // Unblock the signals so the element can be used for setting pos again
-      ui_pos_dropdown->blockSignals(false);
+      if (block_signals)
+        ui_pos_dropdown->blockSignals(false);
 
       // alright we dun, jobs done here boyos
       break;

--- a/src/courtroom.cpp
+++ b/src/courtroom.cpp
@@ -4266,7 +4266,6 @@ void Courtroom::on_pos_dropdown_changed(int p_index)
 
 void Courtroom::on_pos_remove_clicked()
 {
-  current_side = "";
   QString default_side = ao_app->get_char_side(current_char);
 
   for (int i = 0; i < ui_pos_dropdown->count(); ++i) {
@@ -4281,6 +4280,7 @@ void Courtroom::on_pos_remove_clicked()
     ui_pos_dropdown->setCurrentIndex(wit_index); // fall back to "wit"
   else if (ui_pos_dropdown->currentText() != default_side) // we don't have "wit" either?
     ui_pos_dropdown->setCurrentIndex(0); // as a last resort, choose the first item in the dropdown
+  current_side = "";
   ui_pos_remove->hide();
 }
 

--- a/src/packet_distribution.cpp
+++ b/src/packet_distribution.cpp
@@ -470,7 +470,7 @@ void AOApplication::server_packet_received(AOPacket *p_packet)
 
     if (courtroom_constructed) // We were sent a "set position" packet
     {
-      w_courtroom->set_side(f_contents.at(0));
+      w_courtroom->set_side(f_contents.at(0), false);
       append_to_demofile(p_packet->to_string(true));
     }
   }


### PR DESCRIPTION
Implementation of my suggestion from #308:

> A possible way of doing this is by reusing the "X" button logic we use for iniswaps and sounds - when the user selects a position from the dropdown, we save that position in a different variable that has priority over the character's default position. An "X" button will appear next to the dropdown that, when clicked, clears that variable and resets the position to whatever the character's default is.