### PR TITLE
Fix continuous playback being nonfunctional on non-CharLayer elements, and allow users to toggle it off.

### DIFF
--- a/include/aoapplication.h
+++ b/include/aoapplication.h
@@ -222,6 +222,10 @@ public:
   // for settings.
   bool is_customchat_enabled();
 
+  // Returns the value of whether continuous playback should be used
+  // from the config.ini.
+  bool is_continuous_enabled();
+
   // Returns the value of the maximum amount of lines the IC chatlog
   // may contain, from config.ini.
   int get_max_log_size();

--- a/include/aooptionsdialog.h
+++ b/include/aooptionsdialog.h
@@ -97,6 +97,9 @@ private:
   QLabel *ui_customchat_lbl;
   QCheckBox *ui_customchat_cb;
 
+  QLabel *ui_continuous_lbl;
+  QCheckBox *ui_continuous_cb;
+
   QWidget *ui_callwords_tab;
   QWidget *ui_callwords_widget;
   QVBoxLayout *ui_callwords_layout;

--- a/src/aolayer.cpp
+++ b/src/aolayer.cpp
@@ -325,6 +325,11 @@ void AOLayer::start_playback(QString p_image)
   if (!file_exists(p_image))
     return;
 
+  if (!ao_app->is_continuous_enabled()) {
+    continuous = false;
+    force_continuous = true;
+  }
+
   QString scaling_override =
       ao_app->read_design_ini("scaling", p_image + ".ini");
   if (scaling_override != "")
@@ -351,12 +356,13 @@ void AOLayer::start_playback(QString p_image)
     frame = 0;
     continuous = false;
   }
-  // CANTFIX: this causes a slight hitch
+  // CANTFIX: this causes a hitch
   // The correct way of doing this would be to use QImageReader::jumpToImage()
   // and populate missing data in the movie ticker when it's needed. This is
-  // unforunately completely impossible, because QImageReader::jumpToImage() is
+  // unfortunately completely impossible, because QImageReader::jumpToImage() is
   // not implemented in any image format AO2 is equipped to use. Instead, the
   // default behavior is used - that is, absolutely nothing.
+  // This is why continuous playback can be toggled off.
   if (continuous) {
     for (int i = frame; i--;) {
       if (i <= -1)
@@ -368,6 +374,7 @@ void AOLayer::start_playback(QString p_image)
       // qDebug() << "appending delay of " << l_delay;
     }
   }
+  last_path = p_image;
   // qDebug() << "CONT: " << continuous << " MAX: " << max_frames
   //         << " LAST MAX: " << last_max_frames << " FRAME: " << frame;
   QPixmap f_pixmap = this->get_pixmap(m_reader.read());

--- a/src/aooptionsdialog.cpp
+++ b/src/aooptionsdialog.cpp
@@ -440,6 +440,19 @@ AOOptionsDialog::AOOptionsDialog(QWidget *parent, AOApplication *p_ao_app)
 
   ui_gameplay_form->setWidget(row, QFormLayout::FieldRole, ui_customchat_cb);
 
+  row += 1;
+  ui_continuous_lbl = new QLabel(ui_form_layout_widget);
+  ui_continuous_lbl->setText(tr("Continuous Playback:"));
+  ui_continuous_lbl->setToolTip(
+      tr("Whether or not to resume playing animations from where they left off. Turning off might reduce lag."));
+
+  ui_gameplay_form->setWidget(row, QFormLayout::LabelRole, ui_continuous_lbl);
+
+  ui_continuous_cb = new QCheckBox(ui_form_layout_widget);
+  ui_continuous_cb->setChecked(ao_app->is_continuous_enabled());
+
+  ui_gameplay_form->setWidget(row, QFormLayout::FieldRole, ui_continuous_cb);
+
   QScrollArea *scroll = new QScrollArea(this);
   scroll->setWidget(ui_form_layout_widget);
   ui_gameplay_tab->setLayout(new QVBoxLayout);
@@ -852,6 +865,7 @@ void AOOptionsDialog::save_pressed()
   configini->setValue("stickypres", ui_stickypres_cb->isChecked());
   configini->setValue("customchat", ui_customchat_cb->isChecked());
   configini->setValue("automatic_logging_enabled", ui_log_cb->isChecked());
+  configini->setValue("continuous_playback", ui_continuous_cb->isChecked());
   QFile *callwordsini = new QFile(ao_app->get_base_path() + "callwords.ini");
 
   if (callwordsini->open(QIODevice::WriteOnly | QIODevice::Truncate |

--- a/src/text_file_functions.cpp
+++ b/src/text_file_functions.cpp
@@ -1089,6 +1089,12 @@ bool AOApplication::is_customchat_enabled()
   return result.startsWith("true");
 }
 
+bool AOApplication::is_continuous_enabled()
+{
+  QString result = configini->value("continuous_playback", "true").value<QString>();
+  return result.startsWith("true");
+}
+
 bool AOApplication::get_casing_enabled()
 {
   QString result = configini->value("casing_enabled", "false").value<QString>();


### PR DESCRIPTION
Yeah, uh, that "slight" hitch becomes around one and a half seconds of lag when you're using continuous playback on both the background and the character layers. Woof.