### PR TITLE
Handle packet decoding separately for SC packet

### DIFF
--- a/include/aopacket.h
+++ b/include/aopacket.h
@@ -17,6 +17,8 @@ public:
   void net_encode();
   void net_decode();
 
+  static void escape(QStringList &contents);
+  static void unescape(QStringList &contents);
 private:
 
   QString m_header;

--- a/src/aopacket.cpp
+++ b/src/aopacket.cpp
@@ -12,25 +12,34 @@ QString AOPacket::to_string(bool encoded)
 {
   QStringList contents = m_contents;
   if (encoded)
-    contents.replaceInStrings("#", "<num>")
-      .replaceInStrings("%", "<percent>")
-      .replaceInStrings("$", "<dollar>")
-      .replaceInStrings("&", "<and>");
+    escape(contents);
   return m_header + "#" + contents.join("#") + "#%";
 }
 
 void AOPacket::net_encode()
 {
-  m_contents.replaceInStrings("#", "<num>")
-      .replaceInStrings("%", "<percent>")
-      .replaceInStrings("$", "<dollar>")
-      .replaceInStrings("&", "<and>");
+  escape(m_contents);
 }
 
 void AOPacket::net_decode()
 {
-  m_contents.replaceInStrings("<num>", "#")
+  unescape(m_contents);
+}
+
+void AOPacket::escape(QStringList &contents)
+{
+  contents.replaceInStrings("#", "<num>")
+    .replaceInStrings("%", "<percent>")
+    .replaceInStrings("$", "<dollar>")
+    .replaceInStrings("&", "<and>");
+
+}
+
+void AOPacket::unescape(QStringList &contents)
+{
+  contents.replaceInStrings("<num>", "#")
     .replaceInStrings("<percent>", "%")
     .replaceInStrings("<dollar>", "$")
     .replaceInStrings("<and>", "&");
+
 }

--- a/src/packet_distribution.cpp
+++ b/src/packet_distribution.cpp
@@ -336,10 +336,7 @@ void AOApplication::server_packet_received(AOPacket *p_packet)
     for (int n_element = 0; n_element < f_contents.size(); ++n_element) {
       QStringList sub_elements = f_contents.at(n_element).split("&");
 
-      sub_elements.replaceInStrings("#", "<num>")
-        .replaceInStrings("%", "<percent>")
-        .replaceInStrings("$", "<dollar>")
-        .replaceInStrings("&", "<and>");
+      AOPacket::unescape(sub_elements);
 
       char_type f_char;
       f_char.name = sub_elements.at(0);

--- a/src/packet_distribution.cpp
+++ b/src/packet_distribution.cpp
@@ -8,9 +8,12 @@
 
 void AOApplication::ms_packet_received(AOPacket *p_packet)
 {
-  p_packet->net_decode();
-
   QString header = p_packet->get_header();
+
+  // Some packets need to handle decode/encode separately
+  if (header != "SC") {
+    p_packet->net_decode();
+  }
   QStringList f_contents = p_packet->get_contents();
 
 #ifdef DEBUG_NETWORK
@@ -332,6 +335,11 @@ void AOApplication::server_packet_received(AOPacket *p_packet)
 
     for (int n_element = 0; n_element < f_contents.size(); ++n_element) {
       QStringList sub_elements = f_contents.at(n_element).split("&");
+
+      sub_elements.replaceInStrings("#", "<num>")
+        .replaceInStrings("%", "<percent>")
+        .replaceInStrings("$", "<dollar>")
+        .replaceInStrings("&", "<and>");
 
       char_type f_char;
       f_char.name = sub_elements.at(0);


### PR DESCRIPTION
Theoretically fixes #430 

The bad behaviour comes from these two lines:

https://github.com/AttorneyOnline/AO2-Client/blob/c13e6b7ab0fd36ebf784294b2788ae365109a24f/src/packet_distribution.cpp#L11

https://github.com/AttorneyOnline/AO2-Client/blob/c13e6b7ab0fd36ebf784294b2788ae365109a24f/src/packet_distribution.cpp#L334

At the start the received packets are decoded by converting escaped chars to the actual ones. The issue is that ampersand characters are also used as the split token for the received character list. Fix will have to be making an exception for the packet.