### PR TITLE
Fix blankposts never appearing in the IC log

### DIFF
--- a/src/courtroom.cpp
+++ b/src/courtroom.cpp
@@ -2152,16 +2152,21 @@ void Courtroom::log_chatmessage(QString f_message, int f_char_id, QString f_show
       }
     }
   }
-  switch (f_log_mode) {
-    case IO_ONLY:
-      log_ic_text(f_showname, f_displayname, f_message, "",f_color);
-      break;
-    case DISPLAY_AND_IO:
-      log_ic_text(f_showname, f_displayname, f_message, "",f_color);
-      [[fallthrough]];
-    case DISPLAY_ONLY:
-      append_ic_text(f_message, f_displayname, "",f_color);
-      break;
+
+  // If the chat message isn't a blankpost, or the chatlog history is empty, or its last message isn't a blankpost
+  if (!f_message.isEmpty() ||
+      ic_chatlog_history.isEmpty() || ic_chatlog_history.last().get_message() != "") {
+    switch (f_log_mode) {
+      case IO_ONLY:
+        log_ic_text(f_showname, f_displayname, f_message, "",f_color);
+        break;
+      case DISPLAY_AND_IO:
+        log_ic_text(f_showname, f_displayname, f_message, "",f_color);
+        [[fallthrough]];
+      case DISPLAY_ONLY:
+        append_ic_text(f_message, f_displayname, "",f_color);
+        break;
+    }
   }
 }
 

--- a/src/courtroom.cpp
+++ b/src/courtroom.cpp
@@ -2152,21 +2152,16 @@ void Courtroom::log_chatmessage(QString f_message, int f_char_id, QString f_show
       }
     }
   }
-
-  // If the chat message isn't a blankpost, or the chatlog history is empty, or its last message isn't a blankpost
-  if (!f_message.isEmpty() ||
-      ic_chatlog_history.isEmpty() || ic_chatlog_history.last().get_message() != "") {
-    switch (f_log_mode) {
-      case IO_ONLY:
-        log_ic_text(f_showname, f_displayname, f_message, "",f_color);
-        break;
-      case DISPLAY_AND_IO:
-        log_ic_text(f_showname, f_displayname, f_message, "",f_color);
-        [[fallthrough]];
-      case DISPLAY_ONLY:
-        append_ic_text(f_message, f_displayname, "",f_color);
-        break;
-    }
+  switch (f_log_mode) {
+    case IO_ONLY:
+      log_ic_text(f_showname, f_displayname, f_message, "",f_color);
+      break;
+    case DISPLAY_AND_IO:
+      log_ic_text(f_showname, f_displayname, f_message, "",f_color);
+      [[fallthrough]];
+    case DISPLAY_ONLY:
+      append_ic_text(f_message, f_displayname, "",f_color);
+      break;
   }
 }
 

--- a/src/courtroom.cpp
+++ b/src/courtroom.cpp
@@ -2153,20 +2153,22 @@ void Courtroom::log_chatmessage(QString f_message, int f_char_id, QString f_show
     }
   }
 
-  // If the chat message isn't a blankpost, or the chatlog history is empty, or its last message isn't a blankpost
-  if (!f_message.isEmpty() ||
-      ic_chatlog_history.isEmpty() || ic_chatlog_history.last().get_message() != "") {
-    switch (f_log_mode) {
-      case IO_ONLY:
-        log_ic_text(f_showname, f_displayname, f_message, "",f_color);
-        break;
-      case DISPLAY_AND_IO:
-        log_ic_text(f_showname, f_displayname, f_message, "",f_color);
-        [[fallthrough]];
-      case DISPLAY_ONLY:
-        append_ic_text(f_message, f_displayname, "",f_color);
-        break;
-    }
+  if ((f_log_mode != IO_ONLY) && // if we're not in I/O only mode,
+      f_message.isEmpty() &&  // our current message is a blankpost,
+      !ic_chatlog_history.isEmpty() && // the chat log isn't empty,
+      last_ic_message == f_displayname + ":" && // the chat log's last message is a blank post, and 
+      last_ic_message.mid(0, last_ic_message.lastIndexOf(":")) == f_displayname) // the blankpost's showname is the same as ours
+    return; // Skip adding message
+  switch (f_log_mode) {
+    case IO_ONLY:
+      log_ic_text(f_showname, f_displayname, f_message, "",f_color);
+      break;
+    case DISPLAY_AND_IO:
+      log_ic_text(f_showname, f_displayname, f_message, "",f_color);
+      [[fallthrough]];
+    case DISPLAY_ONLY:
+      append_ic_text(f_message, f_displayname, "",f_color);
+      break;
   }
 }
 
@@ -3019,6 +3021,7 @@ void Courtroom::log_ic_text(QString p_name, QString p_showname,
 void Courtroom::append_ic_text(QString p_text, QString p_name, QString p_action,
                                int color, QDateTime timestamp)
 {
+  last_ic_message = p_name + ":" + p_text;
   QTextCharFormat bold;
   QTextCharFormat normal;
   QTextCharFormat italics;
@@ -5331,7 +5334,6 @@ void Courtroom::regenerate_ic_chatlog()
                    name,
                    item.get_action(), item.get_chat_color(),
                    item.get_datetime().toLocalTime());
-    last_ic_message = name + ":" + message;
   }
 }
 


### PR DESCRIPTION
This ~~removes~~ fixes the functionality that prevented multiple sequential blankposts from showing up in the IC log, which was necessary because calling `log_ic_text` and `append_ic_text` at separate times causes the "last IC message" to *always* be blank when a blankpost is entered.