### PR TITLE
[ULTRA TOP PRIORITY] Fix backwards compatibility with the stopmusic [!!!!!!!!!!!!!!!]

### DIFF
--- a/include/aoapplication.h
+++ b/include/aoapplication.h
@@ -226,6 +226,10 @@ public:
   // from the config.ini.
   bool is_continuous_enabled();
 
+  // Returns the value of whether stopping music by double clicking category should be used
+  // from the config.ini.
+  bool is_category_stop_enabled();
+
   // Returns the value of the maximum amount of lines the IC chatlog
   // may contain, from config.ini.
   int get_max_log_size();

--- a/include/aooptionsdialog.h
+++ b/include/aooptionsdialog.h
@@ -102,6 +102,9 @@ private:
   QLabel *ui_continuous_lbl;
   QCheckBox *ui_continuous_cb;
 
+  QLabel *ui_category_stop_lbl;
+  QCheckBox *ui_category_stop_cb;
+
   QWidget *ui_callwords_tab;
   QWidget *ui_callwords_widget;
   QVBoxLayout *ui_callwords_layout;

--- a/src/aooptionsdialog.cpp
+++ b/src/aooptionsdialog.cpp
@@ -472,6 +472,19 @@ AOOptionsDialog::AOOptionsDialog(QWidget *parent, AOApplication *p_ao_app)
 
   ui_gameplay_form->setWidget(row, QFormLayout::FieldRole, ui_continuous_cb);
 
+  row += 1;
+  ui_category_stop_lbl = new QLabel(ui_form_layout_widget);
+  ui_category_stop_lbl->setText(tr("Stop Music w/ Category:"));
+  ui_category_stop_lbl->setToolTip(
+      tr("Stop music when double-clicking a category. If this is disabled, use the right-click context menu to stop music."));
+
+  ui_gameplay_form->setWidget(row, QFormLayout::LabelRole, ui_category_stop_lbl);
+
+  ui_category_stop_cb = new QCheckBox(ui_form_layout_widget);
+  ui_category_stop_cb->setChecked(ao_app->is_category_stop_enabled());
+
+  ui_gameplay_form->setWidget(row, QFormLayout::FieldRole, ui_category_stop_cb);
+
   QScrollArea *scroll = new QScrollArea(this);
   scroll->setWidget(ui_form_layout_widget);
   ui_gameplay_tab->setLayout(new QVBoxLayout);
@@ -886,6 +899,7 @@ void AOOptionsDialog::save_pressed()
   configini->setValue("customchat", ui_customchat_cb->isChecked());
   configini->setValue("automatic_logging_enabled", ui_log_cb->isChecked());
   configini->setValue("continuous_playback", ui_continuous_cb->isChecked());
+  configini->setValue("category_stop", ui_category_stop_cb->isChecked());
   QFile *callwordsini = new QFile(ao_app->get_base_path() + "callwords.ini");
 
   if (callwordsini->open(QIODevice::WriteOnly | QIODevice::Truncate |

--- a/src/text_file_functions.cpp
+++ b/src/text_file_functions.cpp
@@ -1101,6 +1101,12 @@ bool AOApplication::is_continuous_enabled()
   return result.startsWith("true");
 }
 
+bool AOApplication::is_category_stop_enabled()
+{
+  QString result = configini->value("category_stop", "true").value<QString>();
+  return result.startsWith("true");
+}
+
 bool AOApplication::get_casing_enabled()
 {
   QString result = configini->value("casing_enabled", "false").value<QString>();


### PR DESCRIPTION
Hide ~stop.mp3 and the stop category
Add an option to make it so when you double-click a category, it expands/collapses it without sending the stop-music command (INSTEAD OF BREAKING ORIGINAL BEHAVIOR EVERYONE'S ALREADY USED TO)
Make right click stop music backwards compatible