### PR TITLE
Fix crash to desktop if the "emotes" element has a height or width of zero

### DIFF
--- a/src/emotes.cpp
+++ b/src/emotes.cpp
@@ -39,6 +39,11 @@ void Courtroom::refresh_emotes()
   QPoint p_point =
       ao_app->get_button_spacing("emote_button_size", "courtroom_design.ini");
 
+  if (ui_emotes->width() == 0 || ui_emotes->height() == 0) { // Workaround for a nasty crash
+    ui_emotes->hide();
+    return;
+  }
+
   const int button_width = p_point.x();
   int x_spacing = f_spacing.x();
   int x_mod_count = 0;


### PR DESCRIPTION
I think this is a divide-by-zero error? Whatever it is, this prevents it. Resolves #237.