### PR TITLE
Fix bad OTF rendering on Windows; load fonts in base/fonts

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -78,7 +78,7 @@ jobs:
         cp ../../discord-rpc/win64-dynamic/bin/discord-rpc.dll .
         cp ../../x64/bass.dll .
         cp ../../x64/bassopus.dll .
-        cp $QT_PLUGIN_PATH/platforms/qdirect2d.dll ./plugins/
+        cp $QT_PLUGIN_PATH/platforms/qdirect2d.dll ./platforms/
 
     - name: Upload Artifact
       uses: actions/upload-artifact@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -73,11 +73,12 @@ jobs:
       working-directory: ${{github.workspace}}/build/Release
       shell: bash
       run: |
-        windeployqt .
+        windeployqt --no-opengl-sw .
         cp ../../msvc2017_64/plugins/imageformats/qapng.dll ./imageformats/
         cp ../../discord-rpc/win64-dynamic/bin/discord-rpc.dll .
         cp ../../x64/bass.dll .
         cp ../../x64/bassopus.dll .
+        cp $QT_PLUGIN_PATH/platforms/qdirect2d.dll ./plugins/
 
     - name: Upload Artifact
       uses: actions/upload-artifact@v2

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -20,7 +20,7 @@ int main(int argc, char *argv[])
 #endif
 
 #ifdef _WIN32
-  setenv("QT_QPA_PLATFORM", "direct2d", false);
+  qputenv("QT_QPA_PLATFORM", "direct2d");
 #endif
 
   AOApplication main_app(argc, argv);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -19,9 +19,19 @@ int main(int argc, char *argv[])
   AOApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
 #endif
 
+#ifdef WIN32
+  setenv("QT_QPA_PLATFORM", "direct2d", false);
+#endif
+
   AOApplication main_app(argc, argv);
 
   AOApplication::addLibraryPath(AOApplication::applicationDirPath() + "/lib");
+
+  QFontDatabase fontDatabase;
+  QDirIterator it(main_app.get_base_path() + "fonts",
+                  QDirIterator::Subdirectories);
+  while (it.hasNext())
+    fontDatabase.addApplicationFont(it.next());
 
   QSettings *configini = main_app.configini;
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -19,7 +19,7 @@ int main(int argc, char *argv[])
   AOApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
 #endif
 
-#ifdef WIN32
+#ifdef _WIN32
   setenv("QT_QPA_PLATFORM", "direct2d", false);
 #endif
 


### PR DESCRIPTION
Force the Direct2D QPA on Windows and additionally load fonts from `base/fonts` on startup.

Fixes #224.