### PR TITLE
Load fonts located in base/fonts

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -23,6 +23,12 @@ int main(int argc, char *argv[])
 
   AOApplication::addLibraryPath(AOApplication::applicationDirPath() + "/lib");
 
+  QFontDatabase fontDatabase;
+  QDirIterator it(main_app.get_base_path() + "fonts",
+                  QDirIterator::Subdirectories);
+  while (it.hasNext())
+    fontDatabase.addApplicationFont(it.next());
+
   QSettings *configini = main_app.configini;
 
   QPluginLoader apngPlugin("qapng");


### PR DESCRIPTION
This will register any font (OTF/TTF) located in the base/fonts folder recursively. They can be used for any purpose, without needing to install them on the system.