### PR TITLE
fix bugs and set default .css behavior to match established convention

### DIFF
--- a/src/aoapplication.cpp
+++ b/src/aoapplication.cpp
@@ -18,6 +18,7 @@ AOApplication::AOApplication(int &argc, char **argv) : QApplication(argc, argv)
   discord = new AttorneyOnline::Discord();
   QObject::connect(net_manager, SIGNAL(ms_connect_finished(bool, bool)),
                    SLOT(ms_connect_finished(bool, bool)));
+  qApp->setStyleSheet("QFrame {background-color:transparent;} QAbstractItemView {background-color: transparent; color: black;}; QLineEdit {background-color:transparent;}");
 }
 
 AOApplication::~AOApplication()

--- a/src/aooptionsdialog.cpp
+++ b/src/aooptionsdialog.cpp
@@ -981,6 +981,7 @@ void AOOptionsDialog::save_pressed()
   configini->setValue("stickyeffects", ui_stickyeffects_cb->isChecked());
   configini->setValue("stickypres", ui_stickypres_cb->isChecked());
   configini->setValue("customchat", ui_customchat_cb->isChecked());
+  configini->setValue("sticker", ui_sticker_cb->isChecked());
   configini->setValue("automatic_logging_enabled", ui_log_cb->isChecked());
   configini->setValue("continuous_playback", ui_continuous_cb->isChecked());
   configini->setValue("category_stop", ui_category_stop_cb->isChecked());

--- a/src/courtroom.cpp
+++ b/src/courtroom.cpp
@@ -1256,9 +1256,12 @@ void Courtroom::set_background(QString p_background, bool display)
     ui_vp_evidence_display->reset();
     ui_vp_background->kill();
     ui_vp_desk->kill();
+    QString f_side = current_side;
+    if (current_side == "")
+      f_side = ao_app->get_char_side(current_char);
     set_scene(
         QString::number(ao_app->get_desk_mod(current_char, current_emote)),
-        current_side);
+        f_side);
   }
 }
 
@@ -1318,7 +1321,6 @@ void Courtroom::set_pos_dropdown(QStringList pos_dropdowns)
 
   // Unblock the signals so the element can be used for setting pos again
   ui_pos_dropdown->blockSignals(false);
-  // Don't block the signals when setting side
   set_side(current_side);
 }
 

--- a/src/evidence.cpp
+++ b/src/evidence.cpp
@@ -256,7 +256,7 @@ void Courtroom::set_evidence_list(QVector<evi_type> &p_evi_list)
     else if (compare_evidence_changed(
                  old_list.at(current_evidence),
                  local_evidence_list.at(current_evidence))) {
-      QMessageBox *msgBox = new QMessageBox(this);
+      QMessageBox *msgBox = new QMessageBox;
 
       msgBox->setAttribute(Qt::WA_DeleteOnClose);
       msgBox->setText(tr("The piece of evidence you've been editing has changed."));
@@ -551,7 +551,7 @@ void Courtroom::on_evidence_x_clicked()
     evidence_close();
     return;
   }
-  QMessageBox *msgBox = new QMessageBox(this);
+  QMessageBox *msgBox = new QMessageBox;
   msgBox->setAttribute(Qt::WA_DeleteOnClose);
   msgBox->setText(tr("Evidence has been modified."));
   msgBox->setInformativeText(tr("Do you want to save your changes?"));
@@ -655,7 +655,7 @@ void Courtroom::on_evidence_transfer_clicked()
     private_evidence_list.append(f_evi);
   }
 
-  QMessageBox *msgBox = new QMessageBox(this);
+  QMessageBox *msgBox = new QMessageBox;
   msgBox->setAttribute(Qt::WA_DeleteOnClose);
   msgBox->setText(tr("\"%1\" has been transferred.").arg(name));
   msgBox->setStandardButtons(QMessageBox::Ok);


### PR DESCRIPTION
before:
![image](https://user-images.githubusercontent.com/3470436/109352570-18195500-788c-11eb-95b6-13b7b1021b76.png)

after:
![image](https://user-images.githubusercontent.com/3470436/109352525-0932a280-788c-11eb-9ad9-393693ee44e4.png)

note that the theme in question (KFO 2x) already had a .css file, it's just worse than the current default .css. This means we unfortunately have to copy-paste the default .css into all the AO2-Themes as well because nobody will use a .bat file to remove the .css for inheritance, and nobody will do it manually.