### PR TITLE
Fix files not being written as UTF-8

### DIFF
--- a/src/aooptionsdialog.cpp
+++ b/src/aooptionsdialog.cpp
@@ -990,6 +990,7 @@ void AOOptionsDialog::save_pressed()
   if (callwordsini->open(QIODevice::WriteOnly | QIODevice::Truncate |
                          QIODevice::Text)) {
     QTextStream out(callwordsini);
+    out.setCodec("UTF-8");
     out << ui_callwords_textbox->toPlainText();
     callwordsini->close();
   }

--- a/src/courtroom.cpp
+++ b/src/courtroom.cpp
@@ -4011,6 +4011,7 @@ void Courtroom::on_ooc_return_pressed()
     }
 
     QTextStream out(&file);
+    out.setCodec("UTF-8");
 
     foreach (chatlogpiece item, ic_chatlog_history) {
       out << item.get_full() << '\n';

--- a/src/text_file_functions.cpp
+++ b/src/text_file_functions.cpp
@@ -176,6 +176,7 @@ bool AOApplication::write_to_file(QString p_text, QString p_file, bool make_dir)
                  QIODevice::Truncate)) {
     QTextStream out(&f_log);
 
+    out.setCodec("UTF-8");
     out << p_text;
 
     f_log.flush();
@@ -205,6 +206,7 @@ bool AOApplication::append_to_file(QString p_text, QString p_file,
   if (f_log.open(QIODevice::WriteOnly | QIODevice::Append)) {
     QTextStream out(&f_log);
 
+    out.setCodec("UTF-8");
     out << "\r\n" << p_text;
 
     f_log.flush();
@@ -226,7 +228,7 @@ void AOApplication::write_to_serverlist_txt(QString p_line)
   }
 
   QTextStream out(&serverlist_txt);
-
+  out.setCodec("UTF-8");
   out << "\r\n" << p_line;
 
   serverlist_txt.close();


### PR DESCRIPTION
Fixes a bug on Windows where logs written to file do not encode non-Latin characters correctly because `QTextStream` uses the system locale's encoding by default.