### PR TITLE
Fix timer overflow

### DIFF
--- a/include/aoclocklabel.h
+++ b/include/aoclocklabel.h
@@ -4,7 +4,7 @@
 #include <QLabel>
 #include <QBasicTimer>
 #include <QTimerEvent>
-#include <QTime>
+#include <QDateTime>
 #include <QDebug>
 
 class AOClockLabel : public QLabel {
@@ -13,8 +13,8 @@ class AOClockLabel : public QLabel {
 public:
   AOClockLabel(QWidget *parent);
   void start();
-  void start(int msecs);
-  void set(int msecs, bool update_text = false);
+  void start(qint64 msecs);
+  void set(qint64 msecs, bool update_text = false);
   void pause();
   void stop();
 
@@ -23,7 +23,7 @@ protected:
 
 private:
     QBasicTimer timer;
-    QTime target_time;
+    QDateTime target_time;
 };
 
 #endif // AOCLOCKLABEL_H

--- a/src/aoclocklabel.cpp
+++ b/src/aoclocklabel.cpp
@@ -7,24 +7,25 @@ void AOClockLabel::start()
   timer.start(1000 / 60, this);
 }
 
-void AOClockLabel::start(int msecs)
+void AOClockLabel::start(qint64 msecs)
 {
   this->set(msecs);
   this->start();
 }
 
-void AOClockLabel::set(int msecs, bool update_text)
+void AOClockLabel::set(qint64 msecs, bool update_text)
 {
-  target_time = QTime::currentTime().addMSecs(msecs);
+  target_time = QDateTime::currentDateTime().addMSecs(msecs);
   if (update_text)
   {
-    if (QTime::currentTime() >= target_time)
+    if (QDateTime::currentDateTime() >= target_time)
     {
       this->setText("00:00:00.000");
     }
     else
     {
-      QTime timeleft = QTime(0,0).addMSecs(QTime::currentTime().msecsTo(target_time));
+      qint64 ms_left = QDateTime::currentDateTime().msecsTo(target_time);
+      QTime timeleft = QTime(0, 0).addMSecs(ms_left % (1000 * 3600 * 24));
       QString timestring = timeleft.toString("hh:mm:ss.zzz");
       this->setText(timestring);
     }
@@ -45,12 +46,13 @@ void AOClockLabel::stop()
 void AOClockLabel::timerEvent(QTimerEvent *event)
 {
   if (event->timerId() == timer.timerId()) {
-    if (QTime::currentTime() >= target_time)
+    if (QDateTime::currentDateTime() >= target_time)
     {
       this->stop();
       return;
     }
-    QTime timeleft = QTime(0,0).addMSecs(QTime::currentTime().msecsTo(target_time));
+    qint64 ms_left = QDateTime::currentDateTime().msecsTo(target_time);
+    QTime timeleft = QTime(0, 0).addMSecs(ms_left % (1000 * 3600 * 24));
     QString timestring = timeleft.toString("hh:mm:ss.zzz");
     this->setText(timestring);
   } else {


### PR DESCRIPTION
Fixes a bug where timers cannot be set past approximately 2 hours because of the use of 32-bit integers instead of 64-bit integers.