### PR TITLE
Deprecate hardcoded string-based authentication, add AUTH packet

### DIFF
--- a/include/aoapplication.h
+++ b/include/aoapplication.h
@@ -87,6 +87,7 @@ public:
   bool effects_enabled = false;
   bool y_offset_enabled = false;
   bool expanded_desk_mods_enabled = false;
+  bool auth_packet_enabled = false;
 
   ///////////////loading info///////////////////
 

--- a/include/courtroom.h
+++ b/include/courtroom.h
@@ -798,6 +798,7 @@ public slots:
   void case_called(QString msg, bool def, bool pro, bool jud, bool jur,
                    bool steno);
   void on_reload_theme_clicked();
+  void on_authentication_state_received(bool p_state);
 
 private slots:
   void start_chat_ticking();

--- a/include/courtroom.h
+++ b/include/courtroom.h
@@ -312,6 +312,8 @@ public:
   // Truncates text so it fits within theme-specified boundaries and sets the tooltip to the full string
   void truncate_label_text(QWidget* p_widget, QString p_identifier);
 
+  void on_authentication_state_received(int p_state);
+
   ~Courtroom();
 private:
   AOApplication *ao_app;
@@ -798,7 +800,6 @@ public slots:
   void case_called(QString msg, bool def, bool pro, bool jud, bool jur,
                    bool steno);
   void on_reload_theme_clicked();
-  void on_authentication_state_received(bool p_state);
 
 private slots:
   void start_chat_ticking();

--- a/src/courtroom.cpp
+++ b/src/courtroom.cpp
@@ -1634,7 +1634,7 @@ void Courtroom::append_server_chatmessage(QString p_name, QString p_message,
     color =
         ao_app->get_color("server_chatlog_sender_color", "courtroom_fonts.ini")
             .name();
-  if (!auth_packet_enabled && p_message == "Logged in as a moderator.") {
+  if (!ao_app->auth_packet_enabled && p_message == "Logged in as a moderator.") {
     ui_guard->show();
     append_server_chatmessage(
         tr("CLIENT"), tr("You were granted the Disable Modcalls button."), "1");
@@ -1655,7 +1655,7 @@ void Courtroom::on_authentication_state_received(int p_state)
   }
   else if (p_state < 0) {
     ui_guard->hide();
-    append_server_chatmessate(tr("CLIENT"), tr("You were logged out."), "1");
+    append_server_chatmessage(tr("CLIENT"), tr("You were logged out."), "1");
   }
 }
 

--- a/src/courtroom.cpp
+++ b/src/courtroom.cpp
@@ -1634,13 +1634,29 @@ void Courtroom::append_server_chatmessage(QString p_name, QString p_message,
     color =
         ao_app->get_color("server_chatlog_sender_color", "courtroom_fonts.ini")
             .name();
-  if (p_message == "Logged in as a moderator.") {
+  if (!auth_packet_enabled && p_message == "Logged in as a moderator.") {
     ui_guard->show();
     append_server_chatmessage(
         tr("CLIENT"), tr("You were granted the Disable Modcalls button."), "1");
   }
 
+
   ui_server_chatlog->append_chatmessage(p_name, p_message, color);
+}
+
+void Courtroom::on_authentication_state_received(int p_state)
+{
+  if (p_state >= 1) {
+    ui_guard->show();
+    append_server_chatmessage(tr("CLIENT"), tr("You were granted the Disable Modcalls button."), "1");
+  }
+  else if (p_state == 0) {
+    append_server_chatmessage(tr("CLIENT"), tr("Login unsuccessful."), "1");
+  }
+  else if (p_state < 0) {
+    ui_guard->hide();
+    append_server_chatmessate(tr("CLIENT"), tr("You were logged out."), "1");
+  }
 }
 
 void Courtroom::on_chat_return_pressed()

--- a/src/courtroom.cpp
+++ b/src/courtroom.cpp
@@ -1635,9 +1635,8 @@ void Courtroom::append_server_chatmessage(QString p_name, QString p_message,
         ao_app->get_color("server_chatlog_sender_color", "courtroom_fonts.ini")
             .name();
   if (!ao_app->auth_packet_enabled && p_message == "Logged in as a moderator.") {
-    ui_guard->show();
-    append_server_chatmessage(
-        tr("CLIENT"), tr("You were granted the Disable Modcalls button."), "1");
+    // Emulate successful authentication
+    on_authentication_state_received(1);
   }
 
 

--- a/src/packet_distribution.cpp
+++ b/src/packet_distribution.cpp
@@ -199,6 +199,7 @@ void AOApplication::server_packet_received(AOPacket *p_packet)
     additive_enabled = false;
     effects_enabled = false;
     expanded_desk_mods_enabled = false;
+    auth_packet_enabled = false;
     if (f_packet.contains("yellowtext", Qt::CaseInsensitive))
       yellow_text_enabled = true;
     if (f_packet.contains("prezoom", Qt::CaseInsensitive))
@@ -229,6 +230,8 @@ void AOApplication::server_packet_received(AOPacket *p_packet)
         y_offset_enabled = true;
     if (f_packet.contains("expanded_desk_mods", Qt::CaseInsensitive))
       expanded_desk_mods_enabled = true;
+    if (f_packet.contains("auth_packet", Qt::CaseInsensitive))
+      auth_packet_enabled = true;
   }
   else if (header == "PN") {
     if (f_contents.size() < 2)
@@ -682,6 +685,14 @@ void AOApplication::server_packet_received(AOPacket *p_packet)
     // Reload theme request
     if (f_contents.size() > 1 && f_contents.at(1) == "1")
       w_courtroom->on_reload_theme_clicked();
+  }
+  // Auth packet
+  else if (header == "AUTH") {
+    if (!courtroom_constructed || !auth_packet_enabled)
+      goto end;
+    int authenticated = f_contents.at(0).toInt();
+
+    w_courtroom->on_authentication_state_received(authenticated);
   }
 
 end:

--- a/src/packet_distribution.cpp
+++ b/src/packet_distribution.cpp
@@ -688,7 +688,7 @@ void AOApplication::server_packet_received(AOPacket *p_packet)
   }
   // Auth packet
   else if (header == "AUTH") {
-    if (!courtroom_constructed || !auth_packet_enabled)
+    if (!courtroom_constructed || !auth_packet_enabled || f_contents.size() < 1)
       goto end;
     int authenticated = f_contents.at(0).toInt();
 


### PR DESCRIPTION
Feature flagged so old servers will still work. The AUTH packet is used like this:

**Server:** `AUTH#{state}#%`

`state`:
`1` or higher: Successful log-in. Displays the guard button.
`0`: Unsuccessful log-in attempt.
`-1` or lower: Log-out. Hides the guard button.

A working implementation is available here: https://github.com/AttorneyOnline/akashi/pull/18