### PR TITLE
Add timer packets to demo playback

### DIFF
--- a/include/aoapplication.h
+++ b/include/aoapplication.h
@@ -518,6 +518,7 @@ private:
 
 private slots:
   void ms_connect_finished(bool connected, bool will_retry);
+  void skip_timers(qint64 msecs);
 
 public slots:
   void server_disconnected();

--- a/include/aoapplication.h
+++ b/include/aoapplication.h
@@ -518,7 +518,6 @@ private:
 
 private slots:
   void ms_connect_finished(bool connected, bool will_retry);
-  void skip_timers(qint64 msecs);
 
 public slots:
   void server_disconnected();

--- a/include/aoclocklabel.h
+++ b/include/aoclocklabel.h
@@ -17,6 +17,8 @@ public:
   void set(qint64 msecs, bool update_text = false);
   void pause();
   void stop();
+  void skip(qint64 msecs);
+  bool active();
 
 protected:
   void timerEvent(QTimerEvent *event) override;

--- a/include/courtroom.h
+++ b/include/courtroom.h
@@ -307,6 +307,7 @@ public:
   void pause_clock(int id);
   void stop_clock(int id);
   void set_clock_visibility(int id, bool visible);
+  void skip_clocks(qint64 msecs);
 
   qint64 pong();
   // Truncates text so it fits within theme-specified boundaries and sets the tooltip to the full string

--- a/include/demoserver.h
+++ b/include/demoserver.h
@@ -20,6 +20,7 @@ public:
     bool server_started = false;
     int port = 27088;
     int max_wait = -1;
+    int min_wait = -1;
 
 private:
     void handle_packet(AOPacket packet);

--- a/include/demoserver.h
+++ b/include/demoserver.h
@@ -20,7 +20,6 @@ public:
     bool server_started = false;
     int port = 27088;
     int max_wait = -1;
-    int min_wait = -1;
 
 private:
     void handle_packet(AOPacket packet);
@@ -44,6 +43,7 @@ private slots:
     void recv_data();
     void client_disconnect();
     void playback();
+    void skip_timers(qint64 msecs);
 
 public slots:
     void start_server();

--- a/include/demoserver.h
+++ b/include/demoserver.h
@@ -43,13 +43,12 @@ private slots:
     void recv_data();
     void client_disconnect();
     void playback();
-    void skip_timers(qint64 msecs);
 
 public slots:
     void start_server();
 
 signals:
-
+    void skip_timers(qint64 msecs);
 };
 
 #endif // DEMOSERVER_H

--- a/src/aoapplication.cpp
+++ b/src/aoapplication.cpp
@@ -49,6 +49,8 @@ void AOApplication::construct_lobby()
   if (demo_server)
       demo_server->deleteLater();
   demo_server = new DemoServer();
+  QObject::connect(demo_server, SIGNAL(skip_timers(qint64)),
+                   SLOT(skip_timers(qint64)));
 
   w_lobby->show();
 }
@@ -169,6 +171,12 @@ void AOApplication::ms_connect_finished(bool connected, bool will_retry)
                     "please try again."));
     }
   }
+}
+
+void AOApplication::skip_timers(qint64 msecs)
+{
+  if (courtroom_constructed)
+    w_courtroom->skip_clocks(msecs);
 }
 
 void AOApplication::call_settings_menu()

--- a/src/aoapplication.cpp
+++ b/src/aoapplication.cpp
@@ -48,9 +48,7 @@ void AOApplication::construct_lobby()
 
   if (demo_server)
       demo_server->deleteLater();
-  demo_server = new DemoServer();
-  QObject::connect(demo_server, SIGNAL(skip_timers(qint64)),
-                   SLOT(skip_timers(qint64)));
+  demo_server = new DemoServer(this);
 
   w_lobby->show();
 }
@@ -81,6 +79,14 @@ void AOApplication::construct_courtroom()
   int x = (geometry.width() - w_courtroom->width()) / 2;
   int y = (geometry.height() - w_courtroom->height()) / 2;
   w_courtroom->move(x, y);
+
+  if (demo_server != nullptr) {
+    QObject::connect(demo_server, &DemoServer::skip_timers,
+                     w_courtroom, &Courtroom::skip_clocks);
+  }
+  else {
+    qDebug() << "W: demo server did not exist during courtroom construction";
+  }
 }
 
 void AOApplication::destruct_courtroom()
@@ -171,12 +177,6 @@ void AOApplication::ms_connect_finished(bool connected, bool will_retry)
                     "please try again."));
     }
   }
-}
-
-void AOApplication::skip_timers(qint64 msecs)
-{
-  if (courtroom_constructed)
-    w_courtroom->skip_clocks(msecs);
 }
 
 void AOApplication::call_settings_menu()

--- a/src/aoclocklabel.cpp
+++ b/src/aoclocklabel.cpp
@@ -43,6 +43,17 @@ void AOClockLabel::stop()
   timer.stop();
 }
 
+void AOClockLabel::skip(qint64 msecs)
+{
+  qint64 ms_left = QDateTime::currentDateTime().msecsTo(target_time);
+  this->set(ms_left - msecs, true);
+}
+
+bool AOClockLabel::active()
+{
+  return timer.isActive();
+}
+
 void AOClockLabel::timerEvent(QTimerEvent *event)
 {
   if (event->timerId() == timer.timerId()) {

--- a/src/courtroom.cpp
+++ b/src/courtroom.cpp
@@ -5458,7 +5458,7 @@ void Courtroom::set_clock(int id, qint64 msecs)
   }
 }
 
-// Used by demo playback to adjust for max_wait skpis
+// Used by demo playback to adjust for max_wait skips
 void Courtroom::skip_clocks(qint64 msecs)
 {
   // Loop through all the timers

--- a/src/courtroom.cpp
+++ b/src/courtroom.cpp
@@ -5446,7 +5446,7 @@ void Courtroom::start_clock(int id, qint64 msecs)
 {
   if (id >= 0 && id < max_clocks && ui_clock[id] != nullptr)
   {
-    ui_clock[id]->start(static_cast<int>(msecs));
+    ui_clock[id]->start(msecs);
   }
 }
 
@@ -5454,7 +5454,18 @@ void Courtroom::set_clock(int id, qint64 msecs)
 {
   if (id >= 0 && id < max_clocks && ui_clock[id] != nullptr)
   {
-    ui_clock[id]->set(static_cast<int>(msecs), true);
+    ui_clock[id]->set(msecs, true);
+  }
+}
+
+// Used by demo playback to adjust for max_wait skpis
+void Courtroom::skip_clocks(qint64 msecs)
+{
+  // Loop through all the timers
+  for (int i = 0; i < max_clocks; i++) {
+    // Only skip time on active clocks
+    if (ui_clock[i]->active())
+      ui_clock[i]->skip(msecs);
   }
 }
 

--- a/src/demoserver.cpp
+++ b/src/demoserver.cpp
@@ -254,6 +254,7 @@ void DemoServer::load_demo(QString filename)
     demo_data.clear();
     p_path = filename;
     QTextStream demo_stream(&demo_file);
+    demo_stream.setCodec("UTF-8");
     QString line = demo_stream.readLine();
     while (!line.isNull()) {
         if (!line.endsWith("%")) {

--- a/src/demoserver.cpp
+++ b/src/demoserver.cpp
@@ -230,7 +230,6 @@ void DemoServer::load_demo(QString filename)
     demo_data.clear();
     p_path = filename;
     QTextStream demo_stream(&demo_file);
-    demo_stream.setCodec("UTF-8");
     QString line = demo_stream.readLine();
     while (!line.isNull()) {
         if (!line.endsWith("%")) {

--- a/src/demoserver.cpp
+++ b/src/demoserver.cpp
@@ -212,11 +212,35 @@ void DemoServer::handle_packet(AOPacket packet)
         }
         else if (contents[1].startsWith("/min_wait"))
         {
-            client_sock->write("CT#DEMO#min_wait is deprecated. Use the client Settings for minimum wait instead!");
+          QStringList args = contents[1].split(" ");
+          if (args.size() > 1)
+          {
+            bool ok;
+            int p_min_wait = args.at(1).toInt(&ok);
+            if (ok)
+            {
+              if (p_min_wait < 0)
+                p_min_wait = -1;
+              min_wait = p_min_wait;
+              client_sock->write("CT#DEMO#Setting min_wait to ");
+              client_sock->write(QString::number(min_wait).toUtf8());
+              client_sock->write(" milliseconds.#1#%");
+            }
+            else
+            {
+              client_sock->write("CT#DEMO#Not a valid integer!#1#%");
+            }
+          }
+          else
+          {
+            client_sock->write("CT#DEMO#Current min_wait is ");
+            client_sock->write(QString::number(min_wait).toUtf8());
+            client_sock->write(" milliseconds.#1#%");
+          }
         }
         else if (contents[1].startsWith("/help"))
         {
-            client_sock->write("CT#DEMO#Available commands:\nload, play, pause, max_wait, help#1#%");
+            client_sock->write("CT#DEMO#Available commands:\nload, play, pause, max_wait, min_wait, help#1#%");
         }
     }
 }

--- a/src/demoserver.cpp
+++ b/src/demoserver.cpp
@@ -212,35 +212,11 @@ void DemoServer::handle_packet(AOPacket packet)
         }
         else if (contents[1].startsWith("/min_wait"))
         {
-          QStringList args = contents[1].split(" ");
-          if (args.size() > 1)
-          {
-            bool ok;
-            int p_min_wait = args.at(1).toInt(&ok);
-            if (ok)
-            {
-              if (p_min_wait < 0)
-                p_min_wait = -1;
-              min_wait = p_min_wait;
-              client_sock->write("CT#DEMO#Setting min_wait to ");
-              client_sock->write(QString::number(min_wait).toUtf8());
-              client_sock->write(" milliseconds.#1#%");
-            }
-            else
-            {
-              client_sock->write("CT#DEMO#Not a valid integer!#1#%");
-            }
-          }
-          else
-          {
-            client_sock->write("CT#DEMO#Current min_wait is ");
-            client_sock->write(QString::number(min_wait).toUtf8());
-            client_sock->write(" milliseconds.#1#%");
-          }
+            client_sock->write("CT#DEMO#min_wait is deprecated. Use the client Settings for minimum wait instead!");
         }
         else if (contents[1].startsWith("/help"))
         {
-            client_sock->write("CT#DEMO#Available commands:\nload, play, pause, max_wait, min_wait, help#1#%");
+            client_sock->write("CT#DEMO#Available commands:\nload, play, pause, max_wait, help#1#%");
         }
     }
 }
@@ -283,11 +259,11 @@ void DemoServer::playback()
         AOPacket wait_packet = AOPacket(current_packet);
 
         int duration = wait_packet.get_contents().at(0).toInt();
-        if (max_wait != -1 && duration + elapsed_time > max_wait)
+        if (max_wait != -1 && duration + elapsed_time > max_wait) {
           duration = qMax(0, max_wait - elapsed_time);
-        // We use elapsed_time to make sure that the packet we're using min_wait on is "priority" (e.g. IC)
-        if (elapsed_time == 0 && min_wait != -1 && duration < min_wait)
-          duration = min_wait;
+          // Skip the difference on the timers
+          emit skip_timers(wait_packet.get_contents().at(0).toInt() - duration);
+        }
         elapsed_time += duration;
         timer->start(duration);
     }

--- a/src/demoserver.cpp
+++ b/src/demoserver.cpp
@@ -287,6 +287,9 @@ void DemoServer::playback()
           // Skip the difference on the timers
           emit skip_timers(wait_packet.get_contents().at(0).toInt() - duration);
         }
+        // We use elapsed_time to make sure that the packet we're using min_wait on is "priority" (e.g. IC)
+        if (elapsed_time == 0 && min_wait != -1 && duration < min_wait)
+          duration = min_wait;
         elapsed_time += duration;
         timer->start(duration);
     }

--- a/src/packet_distribution.cpp
+++ b/src/packet_distribution.cpp
@@ -110,11 +110,11 @@ void AOApplication::append_to_demofile(QString packet_string)
     if (get_auto_logging_enabled() && !log_filename.isEmpty())
     {
         QString path = log_filename.left(log_filename.size()).replace(".log", ".demo");
+        append_to_file(packet_string, path, true);
         if (!demo_timer.isValid())
             demo_timer.start();
         else
             append_to_file("wait#"+ QString::number(demo_timer.restart()) + "#%", path, true);
-        append_to_file(packet_string, path, true);
     }
 }
 

--- a/src/packet_distribution.cpp
+++ b/src/packet_distribution.cpp
@@ -110,11 +110,11 @@ void AOApplication::append_to_demofile(QString packet_string)
     if (get_auto_logging_enabled() && !log_filename.isEmpty())
     {
         QString path = log_filename.left(log_filename.size()).replace(".log", ".demo");
-        append_to_file(packet_string, path, true);
         if (!demo_timer.isValid())
             demo_timer.start();
         else
             append_to_file("wait#"+ QString::number(demo_timer.restart()) + "#%", path, true);
+        append_to_file(packet_string, path, true);
     }
 }
 

--- a/src/packet_distribution.cpp
+++ b/src/packet_distribution.cpp
@@ -555,7 +555,6 @@ void AOApplication::server_packet_received(AOPacket *p_packet)
       }
 
       w_courtroom->set_evidence_list(f_evi_list);
-      append_to_demofile(p_packet->to_string(true));
     }
   }
   else if (header == "ARUP") {

--- a/src/packet_distribution.cpp
+++ b/src/packet_distribution.cpp
@@ -555,6 +555,7 @@ void AOApplication::server_packet_received(AOPacket *p_packet)
       }
 
       w_courtroom->set_evidence_list(f_evi_list);
+      append_to_demofile(p_packet->to_string(true));
     }
   }
   else if (header == "ARUP") {
@@ -659,6 +660,7 @@ void AOApplication::server_packet_received(AOPacket *p_packet)
       w_courtroom->set_clock_visibility(id, true);
     else if (type == 3)
       w_courtroom->set_clock_visibility(id, false);
+    append_to_demofile(p_packet->to_string(true));
   }
   else if (header == "CHECK") {
     if (!courtroom_constructed)


### PR DESCRIPTION
Add an "active" check for timers so we can know if the timer is active or not
Add timer packets to the demo file
Emit a skip_timers signal that will adjust the timers to skip the difference when max_wait kicks in
Stop static-casting qint64 to int when we _want_ it to be qint64 for timers
Add a new skip_clocks functionality
Set up demoserver with a signal that asks the courtroom to skip some msecs in timers