### PR TITLE
Fix demo playback not using UTF-8 codec,

### DIFF
--- a/src/demoserver.cpp
+++ b/src/demoserver.cpp
@@ -254,6 +254,7 @@ void DemoServer::load_demo(QString filename)
     demo_data.clear();
     p_path = filename;
     QTextStream demo_stream(&demo_file);
+    demo_stream.setCodec("UTF-8");
     QString line = demo_stream.readLine();
     while (!line.isNull()) {
         if (!line.endsWith("%")) {


### PR DESCRIPTION
making it finally possible to use or Russian chars and other special chars like emoji etc.

(cherry picked from commit f3e96ca6b38a5e069d98f2db4b17dfb7bb3f239b)