### PR TITLE
Demo playback incorrect timing⚠HUGE, VERY IMPORTANT FIX⚠

### DIFF
--- a/src/packet_distribution.cpp
+++ b/src/packet_distribution.cpp
@@ -110,11 +110,11 @@ void AOApplication::append_to_demofile(QString packet_string)
     if (get_auto_logging_enabled() && !log_filename.isEmpty())
     {
         QString path = log_filename.left(log_filename.size()).replace(".log", ".demo");
-        append_to_file(packet_string, path, true);
         if (!demo_timer.isValid())
             demo_timer.start();
         else
             append_to_file("wait#"+ QString::number(demo_timer.restart()) + "#%", path, true);
+        append_to_file(packet_string, path, true);
     }
 }
 


### PR DESCRIPTION
Fix demo playback being incorrectly timed due to the misplaced order of the wait#% packet (it should go BEFORE the appended message, not AFTER! We're delaying the message we're *writing*, not the *next message*!!!)

(cherry picked from commit 8319ebffe4c22c59c33d9c90161036d9c1ddddd5)