### PR TITLE
Fix blankposting forcing the message queue to sleep up until another message is received

### DIFF
--- a/src/courtroom.cpp
+++ b/src/courtroom.cpp
@@ -3231,6 +3231,10 @@ void Courtroom::start_chat_ticking()
       ui_vp_chatbox->show();
       ui_vp_message->show();
     }
+    // If we're not already waiting on the next message, start the timer. We could be overriden if there's an objection planned.
+    int delay = ao_app->stay_time();
+    if (delay > 0 && !text_queue_timer->isActive())
+      text_queue_timer->start(delay);
     return;
   }
 


### PR DESCRIPTION
Closes https://github.com/AttorneyOnline/AO2-Client/issues/499. Used a .demo file to debug and isolate the context where this bug was discovered. Developers take note, you can request users reporting bugs to send their .demo so you can do the same