### PR TITLE
Fix chat queue being cleared with no way to see what the msgs were

### DIFF
--- a/include/courtroom.h
+++ b/include/courtroom.h
@@ -226,6 +226,9 @@ public:
   // Parse the chat message packet and unpack it into the m_chatmessage[ITEM] format
   void unpack_chatmessage(QStringList p_contents);
 
+  // Skip the current queue, adding all the queue messages to the logs if desynchronized logs are disabled
+  void skip_chatmessage_queue();
+
   enum LogMode {
     IO_ONLY,
     DISPLAY_ONLY,

--- a/src/courtroom.cpp
+++ b/src/courtroom.cpp
@@ -2019,22 +2019,7 @@ void Courtroom::skip_chatmessage_queue()
 
   while (!chatmessage_queue.isEmpty()) {
     QStringList p_contents = chatmessage_queue.dequeue();
-    for (int n_string = 0; n_string < MS_MAXIMUM; ++n_string) {
-      // Note that we have added stuff that vanilla clients and servers simply
-      // won't send. So now, we have to check if the thing we want even exists
-      // amongst the packet's content. We also have to check if the server even
-      // supports CCCC's IC features, or if it's just japing us. Also, don't
-      // forget! A size 15 message will have indices from 0 to 14.
-      if (n_string < p_contents.size() &&
-          (n_string < MS_MINIMUM || ao_app->cccc_ic_support_enabled)) {
-        m_chatmessage[n_string] = p_contents.at(n_string);
-      }
-      else {
-        m_chatmessage[n_string] = "";
-      }
-      // We have logs displaying as soon as we reach the message in our queue, which is a less confusing but also less accurate experience for the user.
-      log_chatmessage(m_chatmessage[MESSAGE], m_chatmessage[CHAR_ID].toInt(), m_chatmessage[SHOWNAME], m_chatmessage[TEXT_COLOR].toInt(), DISPLAY_ONLY);
-    }
+    log_chatmessage(p_contents[MESSAGE], p_contents[CHAR_ID].toInt(), p_contents[SHOWNAME], p_contents[TEXT_COLOR].toInt(), DISPLAY_ONLY);
   }
 }
 

--- a/src/courtroom.cpp
+++ b/src/courtroom.cpp
@@ -1247,7 +1247,7 @@ void Courtroom::set_background(QString p_background, bool display)
 
     // Clear the message queue
     text_queue_timer->stop();
-    chatmessage_queue.clear();
+    skip_chatmessage_queue();
 
     text_state = 2;
     anim_state = 3;
@@ -1961,8 +1961,10 @@ void Courtroom::chatmessage_enqueue(QStringList p_contents)
     int objection_mod = p_contents[OBJECTION_MOD].split("&")[0].toInt();
     is_objection = objection_mod >= 1 && objection_mod <= 5;
     // If this is an objection, nuke the queue
-    if (is_objection)
-      chatmessage_queue.clear();
+    if (is_objection) {
+      text_queue_timer->stop();
+      skip_chatmessage_queue();
+    }
   }
 
   // Record the log I/O, log files should be accurate.
@@ -2006,6 +2008,34 @@ void Courtroom::chatmessage_dequeue()
     text_queue_timer->stop();
 
   unpack_chatmessage(chatmessage_queue.dequeue());
+}
+
+void Courtroom::skip_chatmessage_queue()
+{
+  if (ao_app->is_desyncrhonized_logs_enabled()) {
+    chatmessage_queue.clear();
+    return;
+  }
+
+  while (!chatmessage_queue.isEmpty()) {
+    QStringList p_contents = chatmessage_queue.dequeue();
+    for (int n_string = 0; n_string < MS_MAXIMUM; ++n_string) {
+      // Note that we have added stuff that vanilla clients and servers simply
+      // won't send. So now, we have to check if the thing we want even exists
+      // amongst the packet's content. We also have to check if the server even
+      // supports CCCC's IC features, or if it's just japing us. Also, don't
+      // forget! A size 15 message will have indices from 0 to 14.
+      if (n_string < p_contents.size() &&
+          (n_string < MS_MINIMUM || ao_app->cccc_ic_support_enabled)) {
+        m_chatmessage[n_string] = p_contents.at(n_string);
+      }
+      else {
+        m_chatmessage[n_string] = "";
+      }
+      // We have logs displaying as soon as we reach the message in our queue, which is a less confusing but also less accurate experience for the user.
+      log_chatmessage(m_chatmessage[MESSAGE], m_chatmessage[CHAR_ID].toInt(), m_chatmessage[SHOWNAME], m_chatmessage[TEXT_COLOR].toInt(), DISPLAY_ONLY);
+    }
+  }
 }
 
 void Courtroom::unpack_chatmessage(QStringList p_contents)


### PR DESCRIPTION
Fix chat messages being lost to the Ether if instant objection was used, or you switched an area during queue being parsed. (Your IC logs will be caught up to speed instead)

Basically, if the chat message queue was still parsing, but something happens to interrupt it (instant objection, switching areas), current behavior is to nuke the queue. Those messages never show up. This way, if you leave a message with the queue still parsing, you will get *all* the messages that were skipped as ic chatlog entries instead. Meaning you will not lose info you were not supposed to lose.