### PR TITLE
Fix character select screen lag/performance overhead

### DIFF
--- a/include/aoimage.h
+++ b/include/aoimage.h
@@ -11,7 +11,7 @@
 
 class AOImage : public QLabel {
 public:
-  AOImage(QWidget *parent, AOApplication *p_ao_app);
+  AOImage(QWidget *parent, AOApplication *p_ao_app, bool make_static = false);
   ~AOImage();
 
   QWidget *m_parent;
@@ -19,6 +19,8 @@ public:
   QMovie *movie;
 
   QString path;
+
+  bool is_static = false;
 
   bool set_image(QString p_image, QString p_misc = "");
   void set_size_and_pos(QString identifier);

--- a/include/courtroom.h
+++ b/include/courtroom.h
@@ -755,7 +755,6 @@ private:
 
   QVector<AOCharButton *> ui_char_button_list;
   QVector<AOCharButton *> ui_char_button_list_filtered;
-  AOImage *ui_selector;
 
   AOButton *ui_back_to_lobby;
 

--- a/src/aocharbutton.cpp
+++ b/src/aocharbutton.cpp
@@ -15,19 +15,19 @@ AOCharButton::AOCharButton(QWidget *parent, AOApplication *p_ao_app, int x_pos,
   this->resize(60, 60);
   this->move(x_pos, y_pos);
 
-  ui_taken = new AOImage(this, ao_app);
+  ui_taken = new AOImage(this, ao_app, true);
   ui_taken->resize(60, 60);
   ui_taken->set_image("char_taken");
   ui_taken->setAttribute(Qt::WA_TransparentForMouseEvents);
   ui_taken->hide();
 
-  ui_passworded = new AOImage(this, ao_app);
+  ui_passworded = new AOImage(this, ao_app, true);
   ui_passworded->resize(60, 60);
   ui_passworded->set_image("char_passworded");
   ui_passworded->setAttribute(Qt::WA_TransparentForMouseEvents);
   ui_passworded->hide();
 
-  ui_selector = new AOImage(parent, ao_app);
+  ui_selector = new AOImage(parent, ao_app, true);
   ui_selector->resize(62, 62);
   ui_selector->move(x_pos - 1, y_pos - 1);
   ui_selector->set_image("char_selector");

--- a/src/aoevidencebutton.cpp
+++ b/src/aoevidencebutton.cpp
@@ -9,14 +9,14 @@ AOEvidenceButton::AOEvidenceButton(QWidget *p_parent, AOApplication *p_ao_app,
   ao_app = p_ao_app;
   m_parent = p_parent;
 
-  ui_selected = new AOImage(this, ao_app);
+  ui_selected = new AOImage(this, ao_app, true);
   ui_selected->resize(p_w, p_h);
   //  ui_selected->move(p_x, p_y);
   ui_selected->set_image("evidence_selected");
   ui_selected->setAttribute(Qt::WA_TransparentForMouseEvents);
   ui_selected->hide();
 
-  ui_selector = new AOImage(this, ao_app);
+  ui_selector = new AOImage(this, ao_app, true);
   ui_selector->resize(p_w, p_h);
   //  ui_selector->move(p_x - 1, p_y - 1);
   ui_selector->set_image("evidence_selector");

--- a/src/aoimage.cpp
+++ b/src/aoimage.cpp
@@ -11,7 +11,7 @@ AOImage::AOImage(QWidget *parent, AOApplication *p_ao_app, bool make_static) : Q
   is_static = make_static;
   if (!is_static) // Only create the QMovie if we're non-static
   {
-    movie = new QMovie();
+    movie = new QMovie(this);
     connect(movie, &QMovie::frameChanged, [=]{
       QPixmap f_pixmap = movie->currentPixmap();
       f_pixmap =

--- a/src/aoimage.cpp
+++ b/src/aoimage.cpp
@@ -4,11 +4,12 @@
 
 #include <QBitmap>
 
-AOImage::AOImage(QWidget *parent, AOApplication *p_ao_app) : QLabel(parent)
+AOImage::AOImage(QWidget *parent, AOApplication *p_ao_app, bool make_static) : QLabel(parent)
 {
   m_parent = parent;
   ao_app = p_ao_app;
   movie = new QMovie();
+  is_static = make_static;
   connect(movie, &QMovie::frameChanged, [=]{
     QPixmap f_pixmap = movie->currentPixmap();
     f_pixmap =
@@ -23,7 +24,7 @@ AOImage::~AOImage() {}
 bool AOImage::set_image(QString p_path, QString p_misc)
 {
   // Check if the user wants animated themes
-  if (ao_app->get_animated_theme())
+  if (!is_static && ao_app->get_animated_theme())
     // We want an animated image
     p_path = ao_app->get_image(p_path, ao_app->current_theme, ao_app->get_subtheme(), ao_app->default_theme, p_misc);
   else

--- a/src/aoimage.cpp
+++ b/src/aoimage.cpp
@@ -8,15 +8,18 @@ AOImage::AOImage(QWidget *parent, AOApplication *p_ao_app, bool make_static) : Q
 {
   m_parent = parent;
   ao_app = p_ao_app;
-  movie = new QMovie();
   is_static = make_static;
-  connect(movie, &QMovie::frameChanged, [=]{
-    QPixmap f_pixmap = movie->currentPixmap();
-    f_pixmap =
-        f_pixmap.scaled(this->size(), Qt::IgnoreAspectRatio);
-    this->setPixmap(f_pixmap);
-    this->setMask(f_pixmap.mask());
-  });
+  if (!is_static) // Only create the QMovie if we're non-static
+  {
+    movie = new QMovie();
+    connect(movie, &QMovie::frameChanged, [=]{
+      QPixmap f_pixmap = movie->currentPixmap();
+      f_pixmap =
+          f_pixmap.scaled(this->size(), Qt::IgnoreAspectRatio);
+      this->setPixmap(f_pixmap);
+      this->setMask(f_pixmap.mask());
+    });
+  }
 }
 
 AOImage::~AOImage() {}
@@ -36,12 +39,14 @@ bool AOImage::set_image(QString p_path, QString p_misc)
     return false;
   }
   path = p_path;
-  movie->stop();
-  movie->setFileName(path);
-  if (ao_app->get_animated_theme() && movie->frameCount() > 1) {
-    movie->start();
+  if (!is_static) {
+    movie->stop();
+    movie->setFileName(path);
+    if (ao_app->get_animated_theme() && movie->frameCount() > 1) {
+      movie->start();
+    }
   }
-  else {
+  if (is_static || !ao_app->get_animated_theme() || movie->frameCount() <= 1) {
     QPixmap f_pixmap(path);
 
     f_pixmap =

--- a/src/charselect.cpp
+++ b/src/charselect.cpp
@@ -21,7 +21,7 @@ void Courtroom::construct_char_select()
 
   ui_char_buttons = new QWidget(ui_char_select_background);
 
-  ui_selector = new AOImage(ui_char_select_background, ao_app);
+  ui_selector = new AOImage(ui_char_select_background, ao_app, true);
   ui_selector->setAttribute(Qt::WA_TransparentForMouseEvents);
   ui_selector->resize(62, 62);
 

--- a/src/charselect.cpp
+++ b/src/charselect.cpp
@@ -21,10 +21,6 @@ void Courtroom::construct_char_select()
 
   ui_char_buttons = new QWidget(ui_char_select_background);
 
-  ui_selector = new AOImage(ui_char_select_background, ao_app, true);
-  ui_selector->setAttribute(Qt::WA_TransparentForMouseEvents);
-  ui_selector->resize(62, 62);
-
   ui_back_to_lobby = new AOButton(ui_char_select_background, ao_app);
 
   ui_char_password = new QLineEdit(ui_char_select_background);

--- a/src/courtroom.cpp
+++ b/src/courtroom.cpp
@@ -972,9 +972,6 @@ void Courtroom::set_widgets()
   set_size_and_pos(ui_sfx_slider, "sfx_slider");
   set_size_and_pos(ui_blip_slider, "blip_slider");
 
-  ui_selector->set_image("char_selector");
-  ui_selector->hide();
-
   set_size_and_pos(ui_back_to_lobby, "back_to_lobby");
   ui_back_to_lobby->setText(tr("Back to Lobby"));
   ui_back_to_lobby->setToolTip(tr("Return back to the server list."));


### PR DESCRIPTION
Caused by Animated Elements being initialized for a metric fuckton of AOImages used by the character select screen. It might be related to excessive File I/O that has to still fall back to static sprites, but this PR instead chooses to simply not allow animated elements for character selectors/overlays and evidence selectors/overlays.