### PR TITLE
Set Qt::ElideLeft for dropdowns

### DIFF
--- a/src/courtroom.cpp
+++ b/src/courtroom.cpp
@@ -171,17 +171,21 @@ Courtroom::Courtroom(AOApplication *p_ao_app) : QMainWindow()
   initialize_emotes();
 
   ui_pos_dropdown = new QComboBox(this);
+  ui_pos_dropdown->view()->setTextElideMode(Qt::ElideLeft);
   ui_pos_remove = new AOButton(this, ao_app);
 
   ui_iniswap_dropdown = new QComboBox(this);
   ui_iniswap_dropdown->setContextMenuPolicy(Qt::CustomContextMenu);
+  ui_iniswap_dropdown->view()->setTextElideMode(Qt::ElideLeft);
   ui_iniswap_remove = new AOButton(this, ao_app);
 
   ui_sfx_dropdown = new QComboBox(this);
   ui_sfx_dropdown->setContextMenuPolicy(Qt::CustomContextMenu);
+  ui_sfx_dropdown->view()->setTextElideMode(Qt::ElideLeft);
   ui_sfx_remove = new AOButton(this, ao_app);
 
   ui_effects_dropdown = new QComboBox(this);
+  ui_effects_dropdown->view()->setTextElideMode(Qt::ElideLeft);
   ui_effects_dropdown->setContextMenuPolicy(Qt::CustomContextMenu);
 
   ui_defense_bar = new AOImage(this, ao_app);


### PR DESCRIPTION
Per Satoru;1816#4080:

> It'd be useful a way to shorten the iniswaps names inside a character folder in the dropdown. Like, instead of being "char name/iniswap" it could be ".../iniswap" or smth like that. It looks really bad when characters (or iniswaps) have long names.
> For example:
> ![image](https://user-images.githubusercontent.com/32779090/113128816-ce4fc180-91df-11eb-9976-d9ffcd31e3b1.png)
