### PR TITLE
Fix CASEA failing to validate packets with exactly six arguments

### DIFF
--- a/src/courtroom.cpp
+++ b/src/courtroom.cpp
@@ -4217,9 +4217,6 @@ void Courtroom::on_ooc_return_pressed()
     ui_ooc_chat_message->clear();
     return;
   }
-  else if (ooc_message.startsWith("/crash")) {
-      abort();
-  }
 
   QStringList packet_contents;
   packet_contents.append(ui_ooc_chat_name->text());

--- a/src/courtroom.cpp
+++ b/src/courtroom.cpp
@@ -4217,6 +4217,9 @@ void Courtroom::on_ooc_return_pressed()
     ui_ooc_chat_message->clear();
     return;
   }
+  else if (ooc_message.startsWith("/crash")) {
+      abort();
+  }
 
   QStringList packet_contents;
   packet_contents.append(ui_ooc_chat_name->text());

--- a/src/packet_distribution.cpp
+++ b/src/packet_distribution.cpp
@@ -619,7 +619,7 @@ void AOApplication::server_packet_received(AOPacket *p_packet)
       w_courtroom->mod_called(f_contents.at(0));
   }
   else if (header == "CASEA") {
-    if (courtroom_constructed && f_contents.size() > 6)
+    if (courtroom_constructed && f_contents.size() >= 6)
       w_courtroom->case_called(f_contents.at(0), f_contents.at(1) == "1",
                                f_contents.at(2) == "1", f_contents.at(3) == "1",
                                f_contents.at(4) == "1",


### PR DESCRIPTION
Per the [network documentation](https://github.com/AttorneyOnline/docs/blob/master/docs/development/network.md#case-alert), `CASEA` has only six arguments. However, due to an oversight, the client will only validate `CASEA` packets with seven or more arguments. This PR corrects that oversight.

Note: This bug appears to have been noticed [at least two years ago](https://github.com/AttorneyOnline/tsuserver3/blame/cd63c384dc673d2a5099a4bc65ba9a9d05455450/server/network/aoprotocol.py#L758) by the tsuserver3 maintainers.