### PR TITLE
Tons of bug fixes for IC chat parsing

### DIFF
--- a/src/courtroom.cpp
+++ b/src/courtroom.cpp
@@ -1667,7 +1667,7 @@ void Courtroom::on_chat_return_pressed()
   if (is_muted)
     return;
 
-  if ((anim_state < 3 || text_state < 2) && objection_state == 0)
+  if (text_state < 2 && objection_state == 0)
     return;
 
   ui_ic_chat_message->blockSignals(true);
@@ -2186,8 +2186,6 @@ bool Courtroom::handle_objection()
     objection_mod = m_chatmessage[OBJECTION_MOD].toInt();
   }
 
-
-
   // if an objection is used
   if (objection_mod <= 4 && objection_mod >= 1) {
     ui_vp_objection->set_static_duration(shout_static_time);
@@ -2523,7 +2521,6 @@ void Courtroom::initialize_chatbox()
   if (f_charid >= 0 && f_charid < char_list.size() &&
       (m_chatmessage[SHOWNAME].isEmpty() || !ui_showname_enable->isChecked())) {
     QString real_name = char_list.at(f_charid).name;
-  ui_vp_player_char->set_static_duration(0);
     QString f_showname = ao_app->get_showname(real_name);
 
     ui_vp_showname->setText(f_showname);
@@ -2671,8 +2668,6 @@ void Courtroom::display_evidence_image()
 
 void Courtroom::handle_ic_speaking()
 {
-  // Display the evidence
-  display_evidence_image();
   QString side = m_chatmessage[SIDE];
   int emote_mod = m_chatmessage[EMOTE_MOD].toInt();
   // emote_mod 5 is zoom and emote_mod 6 is zoom w/ preanim.
@@ -3182,6 +3177,9 @@ void Courtroom::play_preanim(bool immediate)
 
 void Courtroom::preanim_done()
 {
+  // Currently, someone's talking over us mid-preanim...
+  if (anim_state != 1 && anim_state != 4)
+    return;
   anim_state = 1;
   switch(m_chatmessage[DESK_MOD].toInt()) {
     case 4:
@@ -3210,6 +3208,9 @@ void Courtroom::start_chat_ticking()
   // can be called by two logic paths
   if (text_state != 0)
     return;
+
+  // Display the evidence
+  display_evidence_image();
 
   if (m_chatmessage[EFFECTS] != "") {
     QStringList fx_list = m_chatmessage[EFFECTS].split("|");
@@ -5254,8 +5255,6 @@ void Courtroom::on_reload_theme_clicked()
   enter_courtroom();
   gen_char_rgb_list(ao_app->get_chat(current_char));
 
-  anim_state = 4;
-  text_state = 3;
   objection_custom = "";
 
   // to update status on the background


### PR DESCRIPTION
Fix anim_state deciding whether you're allowed to send a message or not (the only thing that should decide that is if text is done processing or not)
Fix objections forcing a missingno to appear when you object to someone mid-preanim, and their preanim ends before objection shout finishes. This also resolves a crapton of other bugs related to preanim_done() signal.
Move evidence display from handle_ic_speaking to start_chat_ticking (makes more sense over here)
Remove a misplaced set_static_duration for ui_vp_player_char (must've got here over a strange merge conflict or smth)
Remove useless anim_state and text_state setters in reload_theme func, the func that calls the BG to display already handles everything needed for IC reset