### PR TITLE
Fix regression that won't allow us to give a direct base/ path to a char emote

### DIFF
--- a/src/aolayer.cpp
+++ b/src/aolayer.cpp
@@ -197,20 +197,20 @@ void CharLayer::load_image(QString p_filename, QString p_charname,
            << " continuous: " << continuous;
 #endif
   QStringList pathlist = {
-      ao_app->get_image_suffix(ao_app->get_character_path(
-          p_charname, prefix + current_emote)), // Default path
-      ao_app->get_image_suffix(ao_app->get_character_path(
+      current_emote, // The path by itself
+      ao_app->get_character_path(
+          p_charname, prefix + current_emote), // Default path
+      ao_app->get_character_path(
           p_charname,
-          prefix + "/" + current_emote)), // Path check if it's categorized
+          prefix + "/" + current_emote), // Path check if it's categorized
                                           // into a folder
-      ao_app->get_image_suffix(ao_app->get_character_path(
+      ao_app->get_character_path(
           p_charname,
-          current_emote)), // Just use the non-prefixed image, animated or not
-      ao_app->get_image_suffix(
-          ao_app->get_theme_path("placeholder")), // Theme placeholder path
-      ao_app->get_image_suffix(ao_app->get_theme_path(
-          "placeholder", ao_app->default_theme))}; // Default theme placeholder path
-  start_playback(find_image(pathlist));
+          current_emote), // Just use the non-prefixed image, animated or not
+      ao_app->get_theme_path("placeholder"), // Theme placeholder path
+      ao_app->get_theme_path(
+          "placeholder", ao_app->default_theme)}; // Default theme placeholder path
+  start_playback(ao_app->get_image_path(pathlist));
 }
 
 void SplashLayer::load_image(QString p_filename, QString p_charname,

--- a/src/aolayer.cpp
+++ b/src/aolayer.cpp
@@ -197,7 +197,6 @@ void CharLayer::load_image(QString p_filename, QString p_charname,
            << " continuous: " << continuous;
 #endif
   QStringList pathlist = {
-      current_emote, // The path by itself
       ao_app->get_character_path(
           p_charname, prefix + current_emote), // Default path
       ao_app->get_character_path(
@@ -207,6 +206,7 @@ void CharLayer::load_image(QString p_filename, QString p_charname,
       ao_app->get_character_path(
           p_charname,
           current_emote), // Just use the non-prefixed image, animated or not
+      current_emote, // The path by itself after the above fail
       ao_app->get_theme_path("placeholder"), // Theme placeholder path
       ao_app->get_theme_path(
           "placeholder", ao_app->default_theme)}; // Default theme placeholder path

--- a/src/path_functions.cpp
+++ b/src/path_functions.cpp
@@ -105,7 +105,6 @@ QString AOApplication::get_evidence_path(QString p_file)
 QStringList AOApplication::get_asset_paths(QString p_element, QString p_theme, QString p_subtheme, QString p_default_theme, QString p_misc, QString p_character, QString p_placeholder)
 {
     QStringList pathlist;
-    pathlist += p_element; // The path by itself
     if (p_character != "")
       pathlist += get_character_path(p_character, p_element); // Character folder
     if (p_misc != "" && p_theme != "" && p_subtheme != "")
@@ -120,6 +119,7 @@ QStringList AOApplication::get_asset_paths(QString p_element, QString p_theme, Q
       pathlist += get_theme_path(p_element, p_theme); // Theme path
     if (p_default_theme != "")
       pathlist += get_theme_path(p_element, p_default_theme); // Default theme path
+    pathlist += p_element; // The path by itself
     if (p_placeholder != "" && p_theme != "")
       pathlist += get_theme_path(p_placeholder, p_theme); // Placeholder path
     if (p_placeholder != "" && p_default_theme != "")


### PR DESCRIPTION
Fix charlayer regression not allowing us to *directly* refer to an emote we want to use with a file path (base/misc/blank for example)
Actually use the helper funcs for searching images instead of reimplementing the same thing