### PR TITLE
Fix get_court_sfx using latin1 instead of utf-8

### DIFF
--- a/src/path_functions.cpp
+++ b/src/path_functions.cpp
@@ -173,6 +173,7 @@ QString AOApplication::get_config_value(QString p_identifier, QString p_config, 
         p = get_case_sensitive_path(p);
         if (file_exists(p)) {
             QSettings settings(p, QSettings::IniFormat);
+            settings.setIniCodec("UTF-8");
             QVariant value = settings.value(p_identifier);
             if (value.type() == QVariant::StringList) {
 //              qDebug() << "got" << p << "is a string list, returning" << value.toStringList().join(",");

--- a/src/text_file_functions.cpp
+++ b/src/text_file_functions.cpp
@@ -277,6 +277,7 @@ QString AOApplication::read_design_ini(QString p_identifier,
                                        QString p_design_path)
 {
   QSettings settings(p_design_path, QSettings::IniFormat);
+  settings.setIniCodec("UTF-8");
   QVariant value = settings.value(p_identifier);
   if (value.type() == QVariant::StringList) {
     return value.toStringList().join(",");
@@ -521,6 +522,7 @@ QString AOApplication::read_char_ini(QString p_char, QString p_search_line,
   QSettings settings(get_character_path(p_char, "char.ini"),
                      QSettings::IniFormat);
   settings.beginGroup(target_tag);
+  settings.setIniCodec("UTF-8");
   QString value = settings.value(p_search_line).value<QString>();
   settings.endGroup();
   return value;
@@ -541,6 +543,7 @@ QStringList AOApplication::read_ini_tags(QString p_path, QString target_tag)
 {
   QStringList r_values;
   QSettings settings(p_path, QSettings::IniFormat);
+  settings.setIniCodec("UTF-8");
   if (!target_tag.isEmpty())
     settings.beginGroup(target_tag);
   QStringList keys = settings.allKeys();

--- a/src/text_file_functions.cpp
+++ b/src/text_file_functions.cpp
@@ -278,7 +278,6 @@ QString AOApplication::read_design_ini(QString p_identifier,
 {
   QSettings settings(p_design_path, QSettings::IniFormat);
   settings.setIniCodec("UTF-8");
-  // FIXME: we can't do the above because it makes the character "?" invisible in IC chat. Why
   QVariant value = settings.value(p_identifier);
   if (value.type() == QVariant::StringList) {
     return value.toStringList().join(",");

--- a/src/text_file_functions.cpp
+++ b/src/text_file_functions.cpp
@@ -477,7 +477,7 @@ QString AOApplication::get_court_sfx(QString p_identifier, QString p_misc)
 {
   QString value = get_config_value(p_identifier, "courtroom_sounds.ini", current_theme, get_subtheme(), default_theme, p_misc);
   if (!value.isEmpty())
-    return value.toLatin1();
+    return value.toUtf8();
   return "";
 }
 

--- a/src/text_file_functions.cpp
+++ b/src/text_file_functions.cpp
@@ -278,6 +278,7 @@ QString AOApplication::read_design_ini(QString p_identifier,
 {
   QSettings settings(p_design_path, QSettings::IniFormat);
   settings.setIniCodec("UTF-8");
+  // FIXME: we can't do the above because it makes the character "?" invisible in IC chat. Why
   QVariant value = settings.value(p_identifier);
   if (value.type() == QVariant::StringList) {
     return value.toStringList().join(",");
@@ -436,7 +437,7 @@ QString AOApplication::get_chat_markup(QString p_identifier, QString p_chat)
   // New Chadly method
   QString value = get_config_value(p_identifier, "chat_config.ini", current_theme, get_subtheme(), default_theme, p_chat);
   if (!value.isEmpty())
-    return value.toLatin1();
+    return value.toUtf8();
 
   // Backwards ass compatibility
   QStringList backwards_paths{get_theme_path("misc/" + p_chat + "/config.ini"),
@@ -447,7 +448,7 @@ QString AOApplication::get_chat_markup(QString p_identifier, QString p_chat)
   for (const QString &p : backwards_paths) {
     QString value = read_design_ini(p_identifier, p);
     if (!value.isEmpty()) {
-      return value.toLatin1();
+      return value.toUtf8();
     }
   }
 


### PR DESCRIPTION
Noticed one latin1 instance to correct in https://github.com/AttorneyOnline/AO2-Client/pull/535