### PR TITLE
Add setting for default scaling method

### DIFF
--- a/include/aoapplication.h
+++ b/include/aoapplication.h
@@ -490,6 +490,9 @@ public:
   // Get if the theme is animated
   bool get_animated_theme();
 
+  // Get the default scaling method
+  QString get_default_scaling();
+
   // Currently defined subtheme
   QString subtheme;
 

--- a/include/aooptionsdialog.h
+++ b/include/aooptionsdialog.h
@@ -85,6 +85,8 @@ private:
   QCheckBox *ui_discord_cb;
   QLabel *ui_language_label;
   QComboBox *ui_language_combobox;
+  QLabel *ui_scaling_label;
+  QComboBox *ui_scaling_combobox;
 
   QLabel *ui_shake_lbl;
   QCheckBox *ui_shake_cb;

--- a/src/aooptionsdialog.cpp
+++ b/src/aooptionsdialog.cpp
@@ -382,6 +382,20 @@ AOOptionsDialog::AOOptionsDialog(QWidget *parent, AOApplication *p_ao_app)
                               ui_language_combobox);
 
   row += 1;
+  ui_scaling_label = new QLabel(ui_form_layout_widget);
+  ui_scaling_label->setText(tr("Scaling:"));
+  ui_scaling_label->setToolTip(
+        tr("Sets the default scaling method, if there is not one already defined "
+           "specifically for the character."));
+  ui_gameplay_form->setWidget(row, QFormLayout::LabelRole, ui_scaling_label);
+
+  ui_scaling_combobox = new QComboBox(ui_form_layout_widget);
+  // Corresponds with Qt::TransformationMode enum. Please don't change the order.
+  ui_scaling_combobox->addItem(tr("Pixel"), "fast");
+  ui_scaling_combobox->addItem(tr("Smooth"), "smooth");
+  ui_gameplay_form->setWidget(row, QFormLayout::FieldRole, ui_scaling_combobox);
+
+  row += 1;
   ui_shake_lbl = new QLabel(ui_form_layout_widget);
   ui_shake_lbl->setText(tr("Allow Screenshake:"));
   ui_shake_lbl->setToolTip(
@@ -896,6 +910,9 @@ void AOOptionsDialog::update_values() {
       break;
     }
   }
+  Qt::TransformationMode scaling = ao_app->get_scaling(ao_app->get_default_scaling());
+  ui_scaling_combobox->setCurrentIndex(scaling);
+
   // Let's fill the callwords text edit with the already present callwords.
   ui_callwords_textbox->document()->clear();
   foreach (QString callword, ao_app->get_call_words()) {
@@ -973,6 +990,7 @@ void AOOptionsDialog::save_pressed()
   configini->setValue("master", ui_ms_textbox->text());
   configini->setValue("discord", ui_discord_cb->isChecked());
   configini->setValue("language", ui_language_combobox->currentText().left(2));
+  configini->setValue("default_scaling", ui_scaling_combobox->currentData());
   configini->setValue("shake", ui_shake_cb->isChecked());
   configini->setValue("effects", ui_effects_cb->isChecked());
   configini->setValue("framenetwork", ui_framenetwork_cb->isChecked());

--- a/src/text_file_functions.cpp
+++ b/src/text_file_functions.cpp
@@ -290,6 +290,9 @@ QString AOApplication::read_design_ini(QString p_identifier,
 
 Qt::TransformationMode AOApplication::get_scaling(QString p_scaling)
 {
+  if (p_scaling.isEmpty())
+    p_scaling = get_default_scaling();
+
   if (p_scaling == "smooth")
     return Qt::SmoothTransformation;
   return Qt::FastTransformation;
@@ -1084,4 +1087,9 @@ bool AOApplication::get_animated_theme()
   QString result =
       configini->value("animated_theme", "true").value<QString>();
   return result.startsWith("true");
+}
+
+QString AOApplication::get_default_scaling()
+{
+  return configini->value("default_scaling", "fast").value<QString>();
 }


### PR DESCRIPTION
Adds a setting called `default_scaling` that allows the user to configure the default scaling method for assets that do not otherwise specify a scaling method.

Closes #515.