### PR TITLE
Fix AOLayer-related regressions, deprecate BS no one uses and return sane behavior

### DIFF
--- a/include/aoapplication.h
+++ b/include/aoapplication.h
@@ -378,10 +378,6 @@ public:
   // Returns the preanim duration of p_char's p_emote
   int get_preanim_duration(QString p_char, QString p_emote);
 
-  // Same as above, but only returns if it has a % in front(refer to Preanims
-  // section in the manual)
-  int get_ao2_preanim_duration(QString p_char, QString p_emote);
-
   // Not in use
   int get_text_delay(QString p_char, QString p_emote);
 

--- a/include/aolayer.h
+++ b/include/aolayer.h
@@ -104,10 +104,6 @@ protected:
 
   QElapsedTimer actual_time;
 
-  // Usually used to turn seconds into milliseconds such as for [Time] tag in
-  // char.ini (which is no longer used)
-  const int tick_ms = 60;
-
   // These are the X and Y values before they are fixed based on the sprite's
   // width.
   int x = 0;

--- a/src/aolayer.cpp
+++ b/src/aolayer.cpp
@@ -238,6 +238,7 @@ void EffectLayer::load_image(QString p_filename, bool p_looping)
 
 void InterfaceLayer::load_image(QString p_filename, QString p_miscname)
 {
+  last_path = "";
   stretch = true;
   QString final_image = ao_app->get_image(p_filename, ao_app->current_theme, ao_app->get_subtheme(), ao_app->default_theme, p_miscname);
   start_playback(final_image);

--- a/src/aolayer.cpp
+++ b/src/aolayer.cpp
@@ -146,6 +146,7 @@ void BackgroundLayer::load_image(QString p_filename)
   qDebug() << "[BackgroundLayer] BG loaded: " << p_filename;
 #endif
   start_playback(ao_app->get_image_suffix(ao_app->get_background_path(p_filename)));
+  play();
 }
 
 void CharLayer::load_image(QString p_filename, QString p_charname,
@@ -189,7 +190,7 @@ void CharLayer::load_image(QString p_filename, QString p_charname,
     }
     is_preanim = true;
     play_once = true;
-    preanim_timer->start(duration * tick_ms);
+    preanim_timer->start(duration);
   }
 #ifdef DEBUG_MOVIE
   qDebug() << "[CharLayer] anim loaded: prefix " << prefix << " filename "
@@ -211,6 +212,7 @@ void CharLayer::load_image(QString p_filename, QString p_charname,
       ao_app->get_theme_path(
           "placeholder", ao_app->default_theme)}; // Default theme placeholder path
   start_playback(ao_app->get_image_path(pathlist));
+  play();
 }
 
 void SplashLayer::load_image(QString p_filename, QString p_charname,
@@ -219,6 +221,7 @@ void SplashLayer::load_image(QString p_filename, QString p_charname,
   transform_mode = ao_app->get_misc_scaling(p_miscname);
   QString final_image = ao_app->get_image(p_filename, ao_app->current_theme, ao_app->get_subtheme(), ao_app->default_theme, p_miscname, p_charname, "placeholder");
   start_playback(final_image);
+  play();
 }
 
 void EffectLayer::load_image(QString p_filename, bool p_looping)
@@ -230,6 +233,7 @@ void EffectLayer::load_image(QString p_filename, bool p_looping)
   continuous = false;
   force_continuous = true;
   start_playback(p_filename); // handled in its own file before we see it
+  play();
 }
 
 void InterfaceLayer::load_image(QString p_filename, QString p_miscname)
@@ -237,6 +241,7 @@ void InterfaceLayer::load_image(QString p_filename, QString p_miscname)
   stretch = true;
   QString final_image = ao_app->get_image(p_filename, ao_app->current_theme, ao_app->get_subtheme(), ao_app->default_theme, p_miscname);
   start_playback(final_image);
+  play();
 }
 
 void StickerLayer::load_image(QString p_charname)
@@ -247,6 +252,7 @@ void StickerLayer::load_image(QString p_charname)
   transform_mode = ao_app->get_misc_scaling(p_miscname);
   QString final_image = ao_app->get_image("sticker/" + p_charname, ao_app->current_theme, ao_app->get_subtheme(), ao_app->default_theme, p_miscname);
   start_playback(final_image);
+  play();
 }
 
 void CharLayer::start_playback(QString p_image)
@@ -257,6 +263,7 @@ void CharLayer::start_playback(QString p_image)
     load_network_effects();
   else // Use default ini FX
     load_effects();
+  play();
 }
 
 void AOLayer::start_playback(QString p_image)
@@ -275,7 +282,7 @@ void AOLayer::start_playback(QString p_image)
   actual_time.restart();
 #endif
   this->clear();
-  freeze();
+  this->freeze();
   movie_frames.clear();
   movie_delays.clear();
   QString scaling_override =
@@ -329,14 +336,12 @@ void AOLayer::start_playback(QString p_image)
   }
   else if (max_frames <= 1) {
     duration = static_duration;
-    play_once = false;
 #ifdef DEBUG_MOVIE
     qDebug() << "max_frames is <= 1, using static duration";
 #endif
   }
   if (duration > 0 && cull_image == true)
     shfx_timer->start(duration);
-  play();
 #ifdef DEBUG_MOVIE
   qDebug() << max_frames << "Setting image to " << image_path
            << "Time taken to process image:" << actual_time.elapsed();
@@ -347,6 +352,12 @@ void AOLayer::start_playback(QString p_image)
 
 void CharLayer::play()
 {
+  if (max_frames <= 1) {
+    if (play_once) {
+      preanim_timer->start(qMax(0, duration));
+    }
+    return;
+  }
   play_frame_effect(frame);
   AOLayer::play();
 }
@@ -354,8 +365,12 @@ void CharLayer::play()
 void AOLayer::play()
 {
   if (max_frames <= 1) {
-    if (play_once)
-      ticker->start(tick_ms);
+    if (play_once) {
+      if (duration > 0)
+        ticker->start(duration);
+      else
+        preanim_done();
+    }
     else
       this->freeze();
   }

--- a/src/courtroom.cpp
+++ b/src/courtroom.cpp
@@ -3223,16 +3223,9 @@ void Courtroom::play_preanim(bool immediate)
   QString f_preanim = m_chatmessage[PRE_EMOTE];
   // all time values in char.inis are multiplied by a constant(time_mod) to get
   // the actual time
-  int ao2_duration = ao_app->get_ao2_preanim_duration(f_char, f_preanim);
+  int preanim_duration = ao_app->get_preanim_duration(f_char, f_preanim);
   int stay_time = ao_app->get_text_delay(f_char, f_preanim) * time_mod;
   int sfx_delay = m_chatmessage[SFX_DELAY].toInt() * time_mod;
-
-  int preanim_duration;
-
-  if (ao2_duration < 0)
-    preanim_duration = ao_app->get_preanim_duration(f_char, f_preanim);
-  else
-    preanim_duration = ao2_duration;
 
   sfx_delay_timer->start(sfx_delay);
   QString anim_to_find =
@@ -3245,15 +3238,6 @@ void Courtroom::play_preanim(bool immediate)
     preanim_done();
     qDebug() << "W: could not find " + anim_to_find;
     return;
-  }
-  else {
-    QImageReader s_reader(anim_to_find);
-    int image_count = s_reader.imageCount();
-    if (image_count <= 1) {
-      preanim_done();
-      qDebug() << "W: tried to play static preanim " + anim_to_find;
-      return;
-    }
   }
   ui_vp_player_char->set_static_duration(preanim_duration);
   ui_vp_player_char->set_play_once(true);
@@ -3276,16 +3260,15 @@ void Courtroom::play_preanim(bool immediate)
       break;
   }
 
-  if (immediate)
+  if (immediate) {
     anim_state = 4;
-  else
-    anim_state = 1;
-
-  if (stay_time >= 0)
-    text_delay_timer->start(stay_time);
-
-  if (immediate)
     handle_ic_speaking();
+  }
+  else {
+    anim_state = 1;
+    if (stay_time >= 0)
+      text_delay_timer->start(stay_time);
+  }
 }
 
 void Courtroom::preanim_done()
@@ -3317,6 +3300,7 @@ void Courtroom::preanim_done()
 
 void Courtroom::start_chat_ticking()
 {
+  text_delay_timer->stop();
   // we need to ensure that the text isn't already ticking because this function
   // can be called by two logic paths
   if (text_state != 0)

--- a/src/text_file_functions.cpp
+++ b/src/text_file_functions.cpp
@@ -669,15 +669,6 @@ int AOApplication::get_preanim_duration(QString p_char, QString p_emote)
   return f_result.toInt();
 }
 
-int AOApplication::get_ao2_preanim_duration(QString p_char, QString p_emote)
-{
-  QString f_result = read_char_ini(p_char, "%" + p_emote, "Time");
-
-  if (f_result == "")
-    return -1;
-  return f_result.toInt();
-}
-
 int AOApplication::get_emote_number(QString p_char)
 {
   QString f_result = read_char_ini(p_char, "number", "Emotions");


### PR DESCRIPTION
Deprecate tick_ms and use actual milliseconds rather than arbitrary 60ms ticks for char.ini [Time]
Fix an extremely weird case where CharLayer::Play() was not called even on the CharLayer class (I don't understand why inheritance was straight up just ignored)
Fix using preanims with static images just breaking everything
Deprecate weird insanity [Time] with the % sign BS (What was this for again? Literally no one used this nor was aware of it)
Fix text_stay_time timer firing even if we're immediate
Just in case, stop the text delay timer when start_chat_ticking is called