### PR TITLE
Add default shownames

### DIFF
--- a/include/aoapplication.h
+++ b/include/aoapplication.h
@@ -278,6 +278,9 @@ public:
   // Returns whether the user would like to have custom shownames on by default.
   bool get_showname_enabled_by_default();
 
+  //Returns the showname the user may have set in config.ini.
+  QString get_default_showname();
+
   // Returns the list of words in callwords.ini
   QStringList get_call_words();
 

--- a/include/aooptionsdialog.h
+++ b/include/aooptionsdialog.h
@@ -78,6 +78,8 @@ private:
   QLabel *ui_username_lbl;
   QLabel *ui_showname_lbl;
   QCheckBox *ui_showname_cb;
+  QLabel *ui_default_showname_lbl;
+  QLineEdit *ui_default_showname_textbox;
   QFrame *ui_net_divider;
   QLabel *ui_ms_lbl;
   QLineEdit *ui_ms_textbox;

--- a/src/aooptionsdialog.cpp
+++ b/src/aooptionsdialog.cpp
@@ -325,6 +325,20 @@ AOOptionsDialog::AOOptionsDialog(QWidget *parent, AOApplication *p_ao_app)
 
   ui_gameplay_form->setWidget(row, QFormLayout::FieldRole, ui_showname_cb);
 
+  row +=1;
+  ui_default_showname_lbl = new QLabel(ui_form_layout_widget);
+  ui_default_showname_lbl->setText(tr("Default showname:"));
+  ui_default_showname_lbl->setToolTip(
+              tr("Your showname will be automatically set to this value "
+                 "when you join a server."));
+
+  ui_gameplay_form->setWidget(row, QFormLayout::LabelRole, ui_default_showname_lbl);
+
+  ui_default_showname_textbox = new QLineEdit(ui_form_layout_widget);
+  ui_default_showname_textbox->setMaxLength(30);
+
+  ui_gameplay_form->setWidget(row, QFormLayout::FieldRole, ui_default_showname_textbox);
+
   row += 1;
   ui_net_divider = new QFrame(ui_form_layout_widget);
   ui_net_divider->setFrameShape(QFrame::HLine);
@@ -961,6 +975,7 @@ void AOOptionsDialog::update_values() {
   ui_sfx_volume_spinbox->setValue(ao_app->get_default_sfx());
   ui_blips_volume_spinbox->setValue(ao_app->get_default_blip());
   ui_bliprate_spinbox->setValue(ao_app->read_blip_rate());
+  ui_default_showname_textbox->setText(ao_app->get_default_showname());
 }
 
 void AOOptionsDialog::save_pressed()
@@ -987,6 +1002,7 @@ void AOOptionsDialog::save_pressed()
   configini->setValue("chat_ratelimit", ui_chat_ratelimit_spinbox->value());
   configini->setValue("default_username", ui_username_textbox->text());
   configini->setValue("show_custom_shownames", ui_showname_cb->isChecked());
+  configini->setValue("default_showname", ui_default_showname_textbox->text());
   configini->setValue("master", ui_ms_textbox->text());
   configini->setValue("discord", ui_discord_cb->isChecked());
   configini->setValue("language", ui_language_combobox->currentText().left(2));

--- a/src/courtroom.cpp
+++ b/src/courtroom.cpp
@@ -161,6 +161,7 @@ Courtroom::Courtroom(AOApplication *p_ao_app) : QMainWindow()
   ui_ic_chat_name = new QLineEdit(this);
   ui_ic_chat_name->setFrame(false);
   ui_ic_chat_name->setPlaceholderText(tr("Showname"));
+  ui_ic_chat_name->setText(p_ao_app->get_default_showname());
   ui_ic_chat_name->setObjectName("ui_ic_chat_name");
 
   ui_ic_chat_message = new AOLineEdit(this);

--- a/src/text_file_functions.cpp
+++ b/src/text_file_functions.cpp
@@ -112,6 +112,12 @@ QString AOApplication::get_default_username()
     return result;
 }
 
+QString AOApplication::get_default_showname()
+{
+    QString result = configini->value("default_showname", "").value<QString>();
+    return result;
+}
+
 QString AOApplication::get_audio_output_device()
 {
   QString result =


### PR DESCRIPTION
Adds a new setting to config.ini to set a default showname. This works similarly to default username, but for IC shownames, setting the client's showname automatically. Like default username, this has a 30 character limit.

* Adds a new option to config.ini, default_showname.
* Adds get_default_showname() for retrieving this showname.