### PR TITLE
Add Asset Packet

### DIFF
--- a/include/aoapplication.h
+++ b/include/aoapplication.h
@@ -501,6 +501,16 @@ public:
   // The file name of the log file in base/logs.
   QString log_filename;
 
+  /**
+   * @brief A QString of an URL that defines the content repository
+   *        send by the server.
+   *
+   * @details Introduced in Version 2.9.2.
+   *        Addresses the issue of contenturl devlivery for WebAO
+   *        without relying on someone adding the link manually.
+   */
+  QString asset_url;
+
   void initBASS();
   static void load_bass_opus_plugin();
   static void CALLBACK BASSreset(HSTREAM handle, DWORD channel, DWORD data,

--- a/src/packet_distribution.cpp
+++ b/src/packet_distribution.cpp
@@ -703,6 +703,16 @@ void AOApplication::server_packet_received(AOPacket *p_packet)
     w_courtroom->on_authentication_state_received(authenticated);
   }
 
+ //AssetURL Packet
+  else if (header == "ASS") {
+    if (f_contents.size() > 1) { // This can never be more than one link.
+      goto end;
+    }
+    QUrl t_asset_url = QUrl::fromPercentEncoding(f_contents.at(0).toUtf8());
+    if (t_asset_url.isValid())
+    asset_url = t_asset_url.toString();
+  }
+
 end:
 
   delete p_packet;

--- a/src/packet_distribution.cpp
+++ b/src/packet_distribution.cpp
@@ -705,7 +705,7 @@ void AOApplication::server_packet_received(AOPacket *p_packet)
 
  //AssetURL Packet
   else if (header == "ASS") {
-    if (f_contents.size() > 1 || f_contents.size() == 0) { // This can never be more than one link.
+    if (f_contents.size() != 1) {
       goto end;
     }
     QUrl t_asset_url = QUrl::fromPercentEncoding(f_contents.at(0).toUtf8());

--- a/src/packet_distribution.cpp
+++ b/src/packet_distribution.cpp
@@ -705,7 +705,7 @@ void AOApplication::server_packet_received(AOPacket *p_packet)
 
  //AssetURL Packet
   else if (header == "ASS") {
-    if (f_contents.size() > 1) { // This can never be more than one link.
+    if (f_contents.size() > 1 || f_contents.size() == 0) { // This can never be more than one link.
       goto end;
     }
     QUrl t_asset_url = QUrl::fromPercentEncoding(f_contents.at(0).toUtf8());


### PR DESCRIPTION
Adds packet to send the client the URL of an online content repository.

This has multiple purposes. 
For WebAO it would eliminate the need of having the asset URL appended to the link and added manually by sD or Longbbyte on a reboot of the server.
For the client, this provides a general folder to allow content to be retrieved, much like WebAO.