### PR TITLE
Music list streaming support over ASSet packet

### DIFF
--- a/include/aoapplication.h
+++ b/include/aoapplication.h
@@ -501,6 +501,16 @@ public:
   // The file name of the log file in base/logs.
   QString log_filename;
 
+  /**
+   * @brief A QString of an URL that defines the content repository
+   *        send by the server.
+   *
+   * @details Introduced in Version 2.9.2.
+   *        Addresses the issue of contenturl devlivery for WebAO
+   *        without relying on someone adding the link manually.
+   */
+  QString asset_url;
+
   void initBASS();
   static void load_bass_opus_plugin();
   static void CALLBACK BASSreset(HSTREAM handle, DWORD channel, DWORD data,

--- a/include/aomusicplayer.h
+++ b/include/aomusicplayer.h
@@ -25,7 +25,7 @@ public:
   int loop_end[4] = {0, 0, 0, 0};
 
 public slots:
-  void play(QString p_song, int channel = 0, bool loop = false,
+  int play(QString p_song, int channel = 0, bool loop = false,
             int effect_flags = 0);
   void stop(int channel = 0);
 

--- a/src/aomusicplayer.cpp
+++ b/src/aomusicplayer.cpp
@@ -13,12 +13,12 @@ AOMusicPlayer::~AOMusicPlayer()
   }
 }
 
-void AOMusicPlayer::play(QString p_song, int channel, bool loop,
+int AOMusicPlayer::play(QString p_song, int channel, bool loop,
                          int effect_flags)
 {
   channel = channel % m_channelmax;
   if (channel < 0) // wtf?
-    return;
+    return BASS_ERROR_NOCHAN;
   QString f_path = ao_app->get_music_path(p_song);
 
   unsigned int flags = BASS_STREAM_PRESCAN | BASS_STREAM_AUTOFREE |
@@ -125,6 +125,7 @@ void AOMusicPlayer::play(QString p_song, int channel, bool loop,
 
   this->set_looping(loop, channel); // Have to do this here due to any
                                     // crossfading-related changes, etc.
+  return BASS_ErrorGetCode();
 }
 
 void AOMusicPlayer::stop(int channel)

--- a/src/courtroom.cpp
+++ b/src/courtroom.cpp
@@ -3825,7 +3825,7 @@ void Courtroom::handle_song(QStringList *p_contents)
   }
 
   if(!file_exists(ao_app->get_sfx_suffix(ao_app->get_music_path(f_song))) && !f_song.startsWith("http")
-          && f_song != "~stop.mp3" && ao_app->asset_url != NULL) {
+          && f_song != "~stop.mp3" && !ao_app->asset_url.isEmpty()) {
       f_song = (ao_app->asset_url + "sounds/music/" + f_song).toLower();
   }
 

--- a/src/packet_distribution.cpp
+++ b/src/packet_distribution.cpp
@@ -703,6 +703,16 @@ void AOApplication::server_packet_received(AOPacket *p_packet)
     w_courtroom->on_authentication_state_received(authenticated);
   }
 
+ //AssetURL Packet
+  else if (header == "ASS") {
+    if (f_contents.size() > 1) { // This can never be more than one link.
+      goto end;
+    }
+    QUrl t_asset_url = QUrl::fromPercentEncoding(f_contents.at(0).toUtf8());
+    if (t_asset_url.isValid())
+    asset_url = t_asset_url.toString();
+  }
+
 end:
 
   delete p_packet;


### PR DESCRIPTION
Why implement streaming into the music list?

If a user does not have the content in their base folder, it would try to fall back to a content URL link before showing the file as missing.
As most major servers already have webao repositories, it would be a small thing to set up serverside. 

The PR is mostly aimed to address the massive amount of contents some server supply to their userbase, in excess of 10GB sometimes, which has a significant amount of music files that are not being played and end up being wasted disk space. By offering a streaming solution that uses the music list the user and server owner have an easier option to trade file size with bandwidth usage. It's invisible to those who have the files and can be hidden on the theme for users who prefer to stream music.