### PR TITLE
Add support for mounting multiple base folders

### DIFF
--- a/include/aoapplication.h
+++ b/include/aoapplication.h
@@ -554,6 +554,8 @@ private:
   QVector<server_type> server_list;
   QVector<server_type> favorite_list;
   QHash<uint, QString> asset_lookup_cache;
+  QHash<uint, QString> dir_listing_cache;
+  QSet<uint> dir_listing_exist_cache;
 
 private slots:
   void ms_connect_finished(bool connected, bool will_retry);

--- a/include/aoapplication.h
+++ b/include/aoapplication.h
@@ -130,7 +130,6 @@ public:
 
   // implementation in path_functions.cpp
   QString get_base_path();
-  QString get_data_path();
   QString get_theme_path(QString p_file, QString p_theme="");
   QString get_character_path(QString p_char, QString p_file);
   QString get_misc_path(QString p_misc, QString p_file);

--- a/include/aoapplication.h
+++ b/include/aoapplication.h
@@ -37,6 +37,25 @@ class NetworkManager;
 class Lobby;
 class Courtroom;
 
+class VPath : QString {
+  using QString::QString;
+
+public:
+  explicit VPath(const QString &str) : QString(str) {}
+  inline QString const &toQString() const { return *this; }
+  inline bool operator==(const VPath &str) const {
+    return this->toQString() == str.toQString();
+  }
+  inline VPath operator+(const VPath &str) const {
+    return VPath(this->toQString() + str.toQString());
+  }
+};
+
+inline uint qHash(const VPath &key, uint seed)
+{
+  return qHash(key.toQString(), seed);
+}
+
 class AOApplication : public QApplication {
   Q_OBJECT
 
@@ -130,23 +149,25 @@ public:
 
   // implementation in path_functions.cpp
   QString get_base_path();
-  QString get_theme_path(QString p_file, QString p_theme="");
-  QString get_character_path(QString p_char, QString p_file);
-  QString get_misc_path(QString p_misc, QString p_file);
-  QString get_sounds_path(QString p_file);
-  QString get_music_path(QString p_song);
-  QString get_background_path(QString p_file);
-  QString get_default_background_path(QString p_file);
-  QString get_evidence_path(QString p_file);
-  QStringList get_asset_paths(QString p_element, QString p_theme="", QString p_subtheme="", QString p_default_theme="", QString p_misc="", QString p_character="", QString p_placeholder="");
-  QString get_asset_path(QStringList pathlist);
-  QString get_image_path(QStringList pathlist, bool static_image=false);
-  QString get_sfx_path(QStringList pathlist);
+  VPath get_theme_path(QString p_file, QString p_theme="");
+  VPath get_character_path(QString p_char, QString p_file);
+  VPath get_misc_path(QString p_misc, QString p_file);
+  VPath get_sounds_path(QString p_file);
+  VPath get_music_path(QString p_song);
+  VPath get_background_path(QString p_file);
+  VPath get_default_background_path(QString p_file);
+  VPath get_evidence_path(QString p_file);
+  QVector<VPath> get_asset_paths(QString p_element, QString p_theme="", QString p_subtheme="", QString p_default_theme="", QString p_misc="", QString p_character="", QString p_placeholder="");
+  QString get_asset_path(QVector<VPath> pathlist);
+  QString get_image_path(QVector<VPath> pathlist, bool static_image=false);
+  QString get_sfx_path(QVector<VPath> pathlist);
   QString get_config_value(QString p_identifier, QString p_config, QString p_theme="", QString p_subtheme="", QString p_default_theme="", QString p_misc="");
   QString get_asset(QString p_element, QString p_theme="", QString p_subtheme="", QString p_default_theme="", QString p_misc="", QString p_character="", QString p_placeholder="");
-  QString get_image(QString p_element, QString p_theme="", QString p_subtheme="", QString p_default_theme="", QString p_misc="", QString p_character="", QString p_placeholder="");
+  QString get_image(QString p_element, QString p_theme="", QString p_subtheme="", QString p_default_theme="", QString p_misc="", QString p_character="", QString p_placeholder="", bool static_image=false);
   QString get_sfx(QString p_sfx, QString p_misc="", QString p_character="");
   QString get_case_sensitive_path(QString p_file);
+  QString get_real_path(const VPath &vpath);
+  void invalidate_lookup_cache();
 
   ////// Functions for reading and writing files //////
   // Implementations file_functions.cpp
@@ -281,6 +302,7 @@ public:
   QStringList get_call_words();
 
   // returns all of the file's lines in a QStringList
+  QStringList get_list_file(VPath path);
   QStringList get_list_file(QString p_file);
 
   // Process a file and return its text as a QString
@@ -304,6 +326,7 @@ public:
   QVector<server_type> read_serverlist_txt();
 
   // Returns the value of p_identifier in the design.ini file in p_design_path
+  QString read_design_ini(QString p_identifier, VPath p_design_path);
   QString read_design_ini(QString p_identifier, QString p_design_path);
 
   // Returns the coordinates of widget with p_identifier from p_file
@@ -332,19 +355,22 @@ public:
   // Returns the sfx with p_identifier from courtroom_sounds.ini in the current theme path
   QString get_court_sfx(QString p_identifier, QString p_misc="");
 
+  // Find the correct suffix for a given file
+  QString get_suffix(VPath file_to_check, QStringList suffixes);
+
   // Figure out if we can opus this or if we should fall back to wav
-  QString get_sfx_suffix(QString sound_to_check);
+  QString get_sfx_suffix(VPath sound_to_check);
 
   // Can we use APNG for this? If not, WEBP? If not, GIF? If not, fall back to
   // PNG.
-  QString get_image_suffix(QString path_to_check, bool static_image=false);
+  QString get_image_suffix(VPath path_to_check, bool static_image=false);
 
   // Returns the value of p_search_line within target_tag and terminator_tag
   QString read_char_ini(QString p_char, QString p_search_line,
                         QString target_tag);
 
   // Returns a QStringList of all key=value definitions on a given tag.
-  QStringList read_ini_tags(QString p_file, QString target_tag = "");
+  QStringList read_ini_tags(VPath p_file, QString target_tag = "");
 
   // Sets the char.ini p_search_line key under tag target_tag to value.
   void set_char_ini(QString p_char, QString value, QString p_search_line,
@@ -489,6 +515,9 @@ public:
   // Get if the theme is animated
   bool get_animated_theme();
 
+  // Get a list of custom mount paths
+  QStringList get_mount_paths();
+
   // Currently defined subtheme
   QString subtheme;
 
@@ -514,6 +543,7 @@ private:
 
   QVector<server_type> server_list;
   QVector<server_type> favorite_list;
+  QHash<VPath, QString> asset_lookup_cache;
 
 private slots:
   void ms_connect_finished(bool connected, bool will_retry);

--- a/include/aoapplication.h
+++ b/include/aoapplication.h
@@ -167,6 +167,7 @@ public:
   QString get_sfx(QString p_sfx, QString p_misc="", QString p_character="");
   QString get_case_sensitive_path(QString p_file);
   QString get_real_path(const VPath &vpath);
+  QString get_real_suffixed_path(const VPath &vpath, const QStringList &suffixes);
   void invalidate_lookup_cache();
 
   ////// Functions for reading and writing files //////
@@ -354,9 +355,6 @@ public:
 
   // Returns the sfx with p_identifier from courtroom_sounds.ini in the current theme path
   QString get_court_sfx(QString p_identifier, QString p_misc="");
-
-  // Find the correct suffix for a given file
-  QString get_suffix(VPath file_to_check, QStringList suffixes);
 
   // Figure out if we can opus this or if we should fall back to wav
   QString get_sfx_suffix(VPath sound_to_check);

--- a/include/aoapplication.h
+++ b/include/aoapplication.h
@@ -51,7 +51,7 @@ public:
   }
 };
 
-inline uint qHash(const VPath &key, uint seed)
+inline uint qHash(const VPath &key, uint seed = qGlobalQHashSeed())
 {
   return qHash(key.toQString(), seed);
 }
@@ -541,7 +541,7 @@ private:
 
   QVector<server_type> server_list;
   QVector<server_type> favorite_list;
-  QHash<VPath, QString> asset_lookup_cache;
+  QHash<uint, QString> asset_lookup_cache;
 
 private slots:
   void ms_connect_finished(bool connected, bool will_retry);

--- a/include/aolayer.h
+++ b/include/aolayer.h
@@ -9,6 +9,7 @@
 #include <QBitmap>
 
 class AOApplication;
+class VPath;
 
 // "Brief" explanation of what the hell this is:
 //

--- a/include/aooptionsdialog.h
+++ b/include/aooptionsdialog.h
@@ -180,6 +180,9 @@ private:
   QPushButton *ui_mount_remove;
   QPushButton *ui_mount_up;
   QPushButton *ui_mount_down;
+  QPushButton *ui_mount_clear_cache;
+
+  bool asset_cache_dirty = false;
 
   bool needs_default_audiodev();
   void update_values();

--- a/include/aooptionsdialog.h
+++ b/include/aooptionsdialog.h
@@ -23,6 +23,7 @@
 #include <QtWidgets/QWidget>
 
 #include <QDirIterator>
+#include <QListWidget>
 #include <QTextStream>
 
 class Lobby;
@@ -169,6 +170,16 @@ private:
   QLineEdit *ui_casing_cm_cases_textbox;
   QLabel *ui_log_lbl;
   QCheckBox *ui_log_cb;
+
+  QWidget *ui_assets_tab;
+  QVBoxLayout *ui_assets_tab_layout;
+  QGridLayout *ui_mount_buttons_layout;
+  QLabel *ui_asset_lbl;
+  QListWidget *ui_mount_list;
+  QPushButton *ui_mount_add;
+  QPushButton *ui_mount_remove;
+  QPushButton *ui_mount_up;
+  QPushButton *ui_mount_down;
 
   bool needs_default_audiodev();
   void update_values();

--- a/src/aoapplication.cpp
+++ b/src/aoapplication.cpp
@@ -18,7 +18,7 @@ AOApplication::AOApplication(int &argc, char **argv) : QApplication(argc, argv)
   discord = new AttorneyOnline::Discord();
   QObject::connect(net_manager, SIGNAL(ms_connect_finished(bool, bool)),
                    SLOT(ms_connect_finished(bool, bool)));
-  qApp->setStyleSheet("QFrame {background-color:transparent;} QAbstractItemView {background-color: transparent; color: black;}; QLineEdit {background-color:transparent;}");
+  // qApp->setStyleSheet("QFrame {background-color:transparent;} QAbstractItemView {background-color: transparent; color: black;}; QLineEdit {background-color:transparent;}");
 }
 
 AOApplication::~AOApplication()

--- a/src/aoapplication.cpp
+++ b/src/aoapplication.cpp
@@ -19,6 +19,7 @@ AOApplication::AOApplication(int &argc, char **argv) : QApplication(argc, argv)
   QObject::connect(net_manager, SIGNAL(ms_connect_finished(bool, bool)),
                    SLOT(ms_connect_finished(bool, bool)));
   // qApp->setStyleSheet("QFrame {background-color:transparent;} QAbstractItemView {background-color: transparent; color: black;}; QLineEdit {background-color:transparent;}");
+  asset_lookup_cache.reserve(2048);
 }
 
 AOApplication::~AOApplication()

--- a/src/aoapplication.cpp
+++ b/src/aoapplication.cpp
@@ -18,7 +18,7 @@ AOApplication::AOApplication(int &argc, char **argv) : QApplication(argc, argv)
   discord = new AttorneyOnline::Discord();
   QObject::connect(net_manager, SIGNAL(ms_connect_finished(bool, bool)),
                    SLOT(ms_connect_finished(bool, bool)));
-  // qApp->setStyleSheet("QFrame {background-color:transparent;} QAbstractItemView {background-color: transparent; color: black;}; QLineEdit {background-color:transparent;}");
+
   asset_lookup_cache.reserve(2048);
 }
 

--- a/src/aobutton.cpp
+++ b/src/aobutton.cpp
@@ -20,13 +20,8 @@ void AOButton::set_image(QString p_path, QString p_misc)
 {
   movie->stop();
   QString p_image;
-  // Check if the user wants animated themes
-  if (ao_app->get_animated_theme())
-    // We want an animated image
-    p_image = ao_app->get_image(p_path, ao_app->current_theme, ao_app->get_subtheme(), ao_app->default_theme, p_misc);
-  else
-    // Grab a static variant of the image
-    p_image = ao_app->get_image_path(ao_app->get_asset_paths(p_path, ao_app->current_theme, ao_app->get_subtheme(), ao_app->default_theme, p_misc), true);
+  p_image = ao_app->get_image(p_path, ao_app->current_theme, ao_app->get_subtheme(),
+                              ao_app->default_theme, p_misc, "", "", !ao_app->get_animated_theme());
   if (p_image.isEmpty()) {
       this->setIcon(QIcon());
       this->setIconSize(this->size());

--- a/src/aobutton.cpp
+++ b/src/aobutton.cpp
@@ -27,7 +27,7 @@ void AOButton::set_image(QString p_path, QString p_misc)
   else
     // Grab a static variant of the image
     p_image = ao_app->get_image_path(ao_app->get_asset_paths(p_path, ao_app->current_theme, ao_app->get_subtheme(), ao_app->default_theme, p_misc), true);
-  if (!file_exists(p_image)) {
+  if (p_image.isEmpty()) {
       this->setIcon(QIcon());
       this->setIconSize(this->size());
       this->setStyleSheet("");

--- a/src/aoevidencebutton.cpp
+++ b/src/aoevidencebutton.cpp
@@ -32,7 +32,7 @@ AOEvidenceButton::AOEvidenceButton(QWidget *p_parent, AOApplication *p_ao_app,
 
 void AOEvidenceButton::set_image(QString p_image)
 {
-  QString image_path = ao_app->get_evidence_path(p_image);
+  QString image_path = ao_app->get_real_path(ao_app->get_evidence_path(p_image));
   if (file_exists(p_image)) {
     this->setText("");
     this->setStyleSheet(
@@ -57,8 +57,10 @@ void AOEvidenceButton::set_image(QString p_image)
 
 void AOEvidenceButton::set_theme_image(QString p_image)
 {
-  QString theme_image_path = ao_app->get_theme_path(p_image);
-  QString default_image_path = ao_app->get_theme_path(p_image, ao_app->default_theme);
+  QString theme_image_path = ao_app->get_real_path(
+        ao_app->get_theme_path(p_image));
+  QString default_image_path = ao_app->get_real_path(
+        ao_app->get_theme_path(p_image, ao_app->default_theme));
 
   QString final_image_path;
 

--- a/src/aoevidencedisplay.cpp
+++ b/src/aoevidencedisplay.cpp
@@ -35,7 +35,8 @@ void AOEvidenceDisplay::show_evidence(QString p_evidence_image,
     gif_name = "evidence_appear_right";
   }
 
-  QString f_evidence_path = ao_app->get_evidence_path(p_evidence_image);
+  QString f_evidence_path = ao_app->get_real_path(
+        ao_app->get_evidence_path(p_evidence_image));
   QPixmap f_pixmap(f_evidence_path);
 
   pos_size_type icon_dimensions =

--- a/src/aoimage.cpp
+++ b/src/aoimage.cpp
@@ -20,21 +20,16 @@ AOImage::AOImage(QWidget *parent, AOApplication *p_ao_app) : QLabel(parent)
 
 AOImage::~AOImage() {}
 
-bool AOImage::set_image(QString p_path, QString p_misc)
+bool AOImage::set_image(QString p_image, QString p_misc)
 {
-  // Check if the user wants animated themes
-  if (ao_app->get_animated_theme())
-    // We want an animated image
-    p_path = ao_app->get_image(p_path, ao_app->current_theme, ao_app->get_subtheme(), ao_app->default_theme, p_misc);
-  else
-    // Grab a static variant of the image
-    p_path = ao_app->get_image_path(ao_app->get_asset_paths(p_path, ao_app->current_theme, ao_app->get_subtheme(), ao_app->default_theme, p_misc), true);
+  p_image = ao_app->get_image(p_image, ao_app->current_theme, ao_app->get_subtheme(),
+                             ao_app->default_theme, p_misc, "", "", !ao_app->get_animated_theme());
 
-  if (!file_exists(p_path)) {
-    qDebug() << "Warning: Image" << p_path << "not found! Can't set!";
+  if (!file_exists(p_image)) {
+    qDebug() << "Warning: Image" << p_image << "not found! Can't set!";
     return false;
   }
-  path = p_path;
+  path = p_image;
   movie->stop();
   movie->setFileName(path);
   if (ao_app->get_animated_theme() && movie->frameCount() > 1) {

--- a/src/aolayer.cpp
+++ b/src/aolayer.cpp
@@ -137,7 +137,7 @@ void BackgroundLayer::load_image(QString p_filename)
 {
   play_once = false;
   cull_image = false;
-  QString design_path = ao_app->get_background_path("design.ini");
+  VPath design_path = ao_app->get_background_path("design.ini");
   transform_mode =
       ao_app->get_scaling(ao_app->read_design_ini("scaling", design_path));
   stretch = ao_app->read_design_ini("stretch", design_path).startsWith("true");

--- a/src/aomusicplayer.cpp
+++ b/src/aomusicplayer.cpp
@@ -19,7 +19,7 @@ void AOMusicPlayer::play(QString p_song, int channel, bool loop,
   channel = channel % m_channelmax;
   if (channel < 0) // wtf?
     return;
-  QString f_path = ao_app->get_music_path(p_song);
+  QString f_path = ao_app->get_real_path(ao_app->get_music_path(p_song));
 
   unsigned int flags = BASS_STREAM_PRESCAN | BASS_STREAM_AUTOFREE |
                        BASS_UNICODE | BASS_ASYNCFILE;

--- a/src/aooptionsdialog.cpp
+++ b/src/aooptionsdialog.cpp
@@ -75,12 +75,19 @@ AOOptionsDialog::AOOptionsDialog(QWidget *parent, AOApplication *p_ao_app)
   ui_theme_combobox = new QComboBox(ui_form_layout_widget);
 
   // Fill the combobox with the names of the themes.
-  QDirIterator it(ao_app->get_base_path() + "themes", QDir::Dirs,
-                  QDirIterator::NoIteratorFlags);
-  while (it.hasNext()) {
-    QString actualname = QDir(it.next()).dirName();
-    if (actualname != "." && actualname != "..")
-      ui_theme_combobox->addItem(actualname);
+  QSet<QString> themes;
+  QStringList bases = ao_app->get_mount_paths();
+  bases.push_front(ao_app->get_base_path());
+  for (const QString &base : bases) {
+    QDirIterator it(base + "/themes", QDir::Dirs | QDir::NoDotAndDotDot,
+                    QDirIterator::NoIteratorFlags);
+    while (it.hasNext()) {
+      QString actualname = QDir(it.next()).dirName();
+      if (!themes.contains(actualname)) {
+        ui_theme_combobox->addItem(actualname);
+        themes.insert(actualname);
+      }
+    }
   }
 
   QObject::connect(ui_theme_combobox, SIGNAL(currentIndexChanged(int)), this,

--- a/src/charselect.cpp
+++ b/src/charselect.cpp
@@ -157,8 +157,8 @@ void Courtroom::char_clicked(int n_char)
 {
   if (n_char != -1)
   {
-    QString char_ini_path =
-        ao_app->get_character_path(char_list.at(n_char).name, "char.ini");
+    QString char_ini_path = ao_app->get_real_path(
+          ao_app->get_character_path(char_list.at(n_char).name, "char.ini"));
 
     qDebug() << "char_ini_path" << char_ini_path;
 

--- a/src/courtroom.cpp
+++ b/src/courtroom.cpp
@@ -1222,6 +1222,12 @@ void Courtroom::set_stylesheet(QWidget *widget)
 void Courtroom::set_stylesheets()
 {
   set_stylesheet(this);
+  this->setStyleSheet(
+    "QFrame { background-color:transparent; } "
+    "QAbstractItemView { background-color: transparent; color: black; } "
+    "QLineEdit { background-color:transparent; }"
+    + this->styleSheet()
+  );
 }
 
 void Courtroom::set_window_title(QString p_title)

--- a/src/courtroom.cpp
+++ b/src/courtroom.cpp
@@ -501,7 +501,7 @@ void Courtroom::set_widgets()
 {
   QString filename = "courtroom_design.ini";
   // Update the default theme from the courtroom_design.ini, if it's not defined it will be 'default'.
-  QSettings settings(ao_app->get_theme_path(filename, ao_app->current_theme), QSettings::IniFormat);
+  QSettings settings(ao_app->get_real_path(ao_app->get_theme_path(filename, ao_app->current_theme)), QSettings::IniFormat);
   ao_app->default_theme = settings.value("default_theme", "default").toString();
 
   set_fonts();
@@ -1384,11 +1384,11 @@ void Courtroom::update_character(int p_cid)
       custom_obj_menu->setDefaultAction(action);
       objection_custom = "";
     }
-    if (dir_exists(
-            ao_app->get_character_path(current_char, "custom_objections"))) {
-      ui_custom_objection->show();
-      QDir directory(
+    QString custom_objection_dir = ao_app->get_real_path(
           ao_app->get_character_path(current_char, "custom_objections"));
+    if (dir_exists(custom_objection_dir)) {
+      ui_custom_objection->show();
+      QDir directory(custom_objection_dir);
       QStringList custom_obj = directory.entryList(QStringList() << "*.png"
                                                                  << "*.gif"
                                                                  << "*.apng"
@@ -1523,7 +1523,7 @@ void Courtroom::list_music()
     treeItem->setText(0, i_song_listname);
     treeItem->setText(1, i_song);
 
-    QString song_path = ao_app->get_music_path(i_song);
+    QString song_path = ao_app->get_real_path(ao_app->get_music_path(i_song));
 
     if (file_exists(song_path))
       treeItem->setBackground(0, found_brush);
@@ -4333,8 +4333,9 @@ void Courtroom::set_iniswap_dropdown()
     ui_iniswap_remove->hide();
     return;
   }
-  QStringList iniswaps = ao_app->get_list_file(
-      ao_app->get_character_path(char_list.at(m_cid).name, "iniswaps.ini")) + ao_app->get_list_file(ao_app->get_base_path() + "iniswaps.ini");
+  QStringList iniswaps =
+      ao_app->get_list_file(ao_app->get_character_path(char_list.at(m_cid).name, "iniswaps.ini")) +
+      ao_app->get_list_file(ao_app->get_base_path() + "iniswaps.ini");
   iniswaps.removeDuplicates();
   iniswaps.prepend(char_list.at(m_cid).name);
   if (iniswaps.size() <= 0) {
@@ -4390,7 +4391,8 @@ void Courtroom::on_iniswap_context_menu_requested(const QPoint &pos)
 
   menu->setAttribute(Qt::WA_DeleteOnClose);
   menu->addSeparator();
-  if (file_exists(ao_app->get_character_path(current_char, "char.ini")))
+  if (file_exists(ao_app->get_real_path(
+                    ao_app->get_character_path(current_char, "char.ini"))))
     menu->addAction(QString("Edit " + current_char + "/char.ini"), this,
                     SLOT(on_iniswap_edit_requested()));
   if (ui_iniswap_dropdown->itemText(ui_iniswap_dropdown->currentIndex()) !=
@@ -4401,7 +4403,7 @@ void Courtroom::on_iniswap_context_menu_requested(const QPoint &pos)
 }
 void Courtroom::on_iniswap_edit_requested()
 {
-  QString p_path = ao_app->get_character_path(current_char, "char.ini");
+  QString p_path = ao_app->get_real_path(ao_app->get_character_path(current_char, "char.ini"));
   if (!file_exists(p_path))
     return;
   QDesktopServices::openUrl(QUrl::fromLocalFile(p_path));
@@ -4478,7 +4480,8 @@ void Courtroom::on_sfx_context_menu_requested(const QPoint &pos)
 
   menu->setAttribute(Qt::WA_DeleteOnClose);
   menu->addSeparator();
-  if (file_exists(ao_app->get_character_path(current_char, "soundlist.ini")))
+  if (file_exists(ao_app->get_real_path(
+                    ao_app->get_character_path(current_char, "soundlist.ini"))))
     menu->addAction(QString("Edit " + current_char + "/soundlist.ini"), this,
                     SLOT(on_sfx_edit_requested()));
   else
@@ -4491,10 +4494,10 @@ void Courtroom::on_sfx_context_menu_requested(const QPoint &pos)
 
 void Courtroom::on_sfx_edit_requested()
 {
-  QString p_path = ao_app->get_character_path(current_char, "soundlist.ini");
+  QString p_path = ao_app->get_real_path(ao_app->get_character_path(current_char, "soundlist.ini"));
   if (!file_exists(p_path)) {
     p_path = ao_app->get_base_path() + "soundlist.ini";
-    }
+  }
   QDesktopServices::openUrl(QUrl::fromLocalFile(p_path));
 }
 
@@ -4527,12 +4530,11 @@ void Courtroom::set_effects_dropdown()
 
   // ICON-MAKING HELL
   QString p_effect = ao_app->read_char_ini(current_char, "effects", "Options");
-  QString custom_path =
-      ao_app->get_base_path() + "misc/" + p_effect + "/icons/";
-  QString theme_path = ao_app->get_theme_path("effects/icons/");
-  QString default_path = ao_app->get_theme_path("effects/icons/", "default");
+  VPath custom_path("misc/" + p_effect + "/icons/");
+  VPath theme_path = ao_app->get_theme_path("effects/icons/");
+  VPath default_path = ao_app->get_theme_path("effects/icons/", "default");
   for (int i = 0; i < ui_effects_dropdown->count(); ++i) {
-    QString entry = ui_effects_dropdown->itemText(i);
+    VPath entry = VPath(ui_effects_dropdown->itemText(i));
     QString iconpath = ao_app->get_image_suffix(custom_path + entry);
     if (!file_exists(iconpath)) {
       iconpath = ao_app->get_image_suffix(theme_path + entry);
@@ -4566,9 +4568,9 @@ void Courtroom::on_effects_context_menu_requested(const QPoint &pos)
 }
 void Courtroom::on_effects_edit_requested()
 {
-  QString p_path = ao_app->get_theme_path("effects/");
+  QString p_path = ao_app->get_real_path(ao_app->get_theme_path("effects/"));
   if (!dir_exists(p_path)) {
-    p_path = ao_app->get_theme_path("effects/", "default");
+    p_path = ao_app->get_real_path(ao_app->get_theme_path("effects/", "default"));
     if (!dir_exists(p_path)) {
       return;
     }
@@ -4578,7 +4580,7 @@ void Courtroom::on_effects_edit_requested()
 void Courtroom::on_character_effects_edit_requested()
 {
   QString p_effect = ao_app->read_char_ini(current_char, "effects", "Options");
-  QString p_path = ao_app->get_base_path() + "misc/" + p_effect + "/";
+  QString p_path = ao_app->get_real_path(VPath("misc/" + p_effect + "/"));
   if (!dir_exists(p_path))
     return;
 

--- a/src/debug_functions.cpp
+++ b/src/debug_functions.cpp
@@ -1,4 +1,5 @@
 #include <QCoreApplication>
+#include <QElapsedTimer>
 #include <QMessageBox>
 #include <QTimer>
 #include <functional>

--- a/src/file_functions.cpp
+++ b/src/file_functions.cpp
@@ -2,6 +2,9 @@
 
 bool file_exists(QString file_path)
 {
+  if (file_path.isEmpty())
+    return false;
+
   QFileInfo check_file(file_path);
 
   return check_file.exists() && check_file.isFile();

--- a/src/lobby.cpp
+++ b/src/lobby.cpp
@@ -235,6 +235,12 @@ void Lobby::set_stylesheet(QWidget *widget)
 void Lobby::set_stylesheets()
 {
   set_stylesheet(this);
+  this->setStyleSheet(
+    "QFrame { background-color:transparent; } "
+    "QAbstractItemView { background-color: transparent; color: black; } "
+    "QLineEdit { background-color:transparent; }"
+    + this->styleSheet()
+  );
 }
 
 void Lobby::set_font(QWidget *widget, QString p_identifier)

--- a/src/path_functions.cpp
+++ b/src/path_functions.cpp
@@ -242,12 +242,13 @@ QString AOApplication::get_real_path(const VPath &vpath) {
 
   for (const QString &base : bases) {
     QDir baseDir(base);
-    const QString path = baseDir.absoluteFilePath(vpath.toQString());
+    QString path = baseDir.absoluteFilePath(vpath.toQString());
     if (!path.startsWith(baseDir.absolutePath())) {
       qWarning() << "invalid path" << path << "(path is outside vfs)";
       break;
     }
-    if (exists(get_case_sensitive_path(path))) {
+    path = get_case_sensitive_path(path);
+    if (exists(path)) {
       asset_lookup_cache.insert(qHash(vpath), path);
       return path;
     }
@@ -274,12 +275,13 @@ QString AOApplication::get_real_suffixed_path(const VPath &vpath,
   for (const QString &base : bases) {
     for (const QString &suffix : suffixes) {
       QDir baseDir(base);
-      const QString path = baseDir.absoluteFilePath(vpath.toQString() + suffix);
+      QString path = baseDir.absoluteFilePath(vpath.toQString() + suffix);
       if (!path.startsWith(baseDir.absolutePath())) {
         qWarning() << "invalid path" << path << "(path is outside vfs)";
         break;
       }
-      if (exists(get_case_sensitive_path(path))) {
+      path = get_case_sensitive_path(path);
+      if (exists(path)) {
         asset_lookup_cache.insert(qHash(vpath), path);
         return path;
       }

--- a/src/path_functions.cpp
+++ b/src/path_functions.cpp
@@ -150,7 +150,8 @@ QString AOApplication::get_config_value(QString p_identifier, QString p_config, 
 {
     QString path;
 //    qDebug() << "got request for" << p_identifier << "in" << p_config;
-    for (const VPath &p : get_asset_paths(p_config, p_theme, p_subtheme, p_default_theme, p_misc)) {
+    const auto paths = get_asset_paths(p_config, p_theme, p_subtheme, p_default_theme, p_misc);
+    for (const VPath &p : paths) {
         path = get_real_path(p);
         if (!path.isEmpty()) {
             QSettings settings(path, QSettings::IniFormat);

--- a/src/path_functions.cpp
+++ b/src/path_functions.cpp
@@ -39,8 +39,6 @@ QString AOApplication::get_base_path()
   return base_path;
 }
 
-QString AOApplication::get_data_path() { return get_base_path() + "data/"; }
-
 QString AOApplication::get_theme_path(QString p_file, QString p_theme)
 {
   if (p_theme == "")

--- a/src/path_functions.cpp
+++ b/src/path_functions.cpp
@@ -206,17 +206,15 @@ QString AOApplication::get_case_sensitive_path(QString p_file)
     return file_parent_dir + "/" + file_basename;
 
   // last resort, dirlist parent dir and find case insensitive match
-  static QHash<uint, QString> listing_cache;
-  static QHash<uint, bool> listing_exist_cache;
 
-  if (!listing_exist_cache.contains(qHash(file_parent_dir))) {
+  if (!dir_listing_exist_cache.contains(qHash(file_parent_dir))) {
     QStringList files = QDir(file_parent_dir).entryList();
     for (const QString &file : files) {
-      listing_cache.insert(qHash(file_parent_dir % QChar('/') % file.toLower()), file);
+      dir_listing_cache.insert(qHash(file_parent_dir % QChar('/') % file.toLower()), file);
     }
-    listing_exist_cache.insert(qHash(file_parent_dir), true);
+    dir_listing_exist_cache.insert(qHash(file_parent_dir));
   }
-  QString found_file = listing_cache.value(
+  QString found_file = dir_listing_cache.value(
         qHash(file_parent_dir % QChar('/') % file_basename.toLower()));
 
   if (!found_file.isEmpty()) {
@@ -295,4 +293,6 @@ QString AOApplication::get_real_suffixed_path(const VPath &vpath,
 
 void AOApplication::invalidate_lookup_cache() {
   asset_lookup_cache.clear();
+  dir_listing_cache.clear();
+  dir_listing_exist_cache.clear();
 }

--- a/src/path_functions.cpp
+++ b/src/path_functions.cpp
@@ -204,9 +204,6 @@ QString AOApplication::get_case_sensitive_path(QString p_file)
     return file_parent_dir + "/" + file_basename;
 
   // last resort, dirlist parent dir and find case insensitive match
-  QRegExp file_rx =
-      QRegExp(file_basename, Qt::CaseInsensitive, QRegExp::FixedString);
-
   static QHash<uint, QString> listing_cache;
   static QHash<uint, bool> listing_exist_cache;
 
@@ -217,7 +214,8 @@ QString AOApplication::get_case_sensitive_path(QString p_file)
     }
     listing_exist_cache.insert(qHash(file_parent_dir), true);
   }
-  QString found_file = listing_cache.value(qHash(file_parent_dir % QChar('/') % file_basename.toLower()));
+  QString found_file = listing_cache.value(
+        qHash(file_parent_dir % QChar('/') % file_basename.toLower()));
 
   if (!found_file.isEmpty()) {
     return file_parent_dir + "/" + found_file;
@@ -232,7 +230,7 @@ QString AOApplication::get_case_sensitive_path(QString p_file)
 
 QString AOApplication::get_real_path(const VPath &vpath) {
   // Try cache first
-  QString phys_path = asset_lookup_cache.value(vpath);
+  QString phys_path = asset_lookup_cache.value(qHash(vpath));
   if (!phys_path.isEmpty() && exists(phys_path)) {
     return phys_path;
   }
@@ -249,7 +247,7 @@ QString AOApplication::get_real_path(const VPath &vpath) {
       break;
     }
     if (exists(get_case_sensitive_path(path))) {
-      asset_lookup_cache.insert(vpath, path);
+      asset_lookup_cache.insert(qHash(vpath), path);
       return path;
     }
   }
@@ -263,7 +261,7 @@ QString AOApplication::get_real_path(const VPath &vpath) {
 QString AOApplication::get_real_suffixed_path(const VPath &vpath,
                                               const QStringList &suffixes) {
   // Try cache first
-  QString phys_path = asset_lookup_cache.value(vpath);
+  QString phys_path = asset_lookup_cache.value(qHash(vpath));
   if (!phys_path.isEmpty() && exists(phys_path)) {
     return phys_path;
   }
@@ -281,7 +279,7 @@ QString AOApplication::get_real_suffixed_path(const VPath &vpath,
         break;
       }
       if (exists(get_case_sensitive_path(path))) {
-        asset_lookup_cache.insert(vpath, path);
+        asset_lookup_cache.insert(qHash(vpath), path);
         return path;
       }
     }

--- a/src/text_file_functions.cpp
+++ b/src/text_file_functions.cpp
@@ -124,6 +124,11 @@ QStringList AOApplication::get_call_words()
   return get_list_file(get_base_path() + "callwords.ini");
 }
 
+QStringList AOApplication::get_list_file(VPath path)
+{
+  return get_list_file(get_real_path(path));
+}
+
 QStringList AOApplication::get_list_file(QString p_file)
 {
   QStringList return_value;
@@ -273,6 +278,12 @@ QVector<server_type> AOApplication::read_serverlist_txt()
   f_server_list.append(demo_server);
 
   return f_server_list;
+}
+
+QString AOApplication::read_design_ini(QString p_identifier,
+                                       VPath p_design_path)
+{
+  return read_design_ini(p_identifier, get_real_path(p_design_path));
 }
 
 QString AOApplication::read_design_ini(QString p_identifier,
@@ -440,12 +451,14 @@ QString AOApplication::get_chat_markup(QString p_identifier, QString p_chat)
     return value.toLatin1();
 
   // Backwards ass compatibility
-  QStringList backwards_paths{get_theme_path("misc/" + p_chat + "/config.ini"),
-                    get_base_path() + "misc/" + p_chat +
-                        "/config.ini",
-                    get_base_path() + "misc/default/config.ini",
-                    get_theme_path("misc/default/config.ini")};
-  for (const QString &p : backwards_paths) {
+  QVector<VPath> backwards_paths {
+    get_theme_path("misc/" + p_chat + "/config.ini"),
+    VPath("misc/" + p_chat + "/config.ini"),
+    VPath("misc/default/config.ini"),
+    get_theme_path("misc/default/config.ini")
+  };
+
+  for (const VPath &p : backwards_paths) {
     QString value = read_design_ini(p_identifier, p);
     if (!value.isEmpty()) {
       return value.toLatin1();
@@ -482,36 +495,32 @@ QString AOApplication::get_court_sfx(QString p_identifier, QString p_misc)
   return "";
 }
 
-QString AOApplication::get_sfx_suffix(QString sound_to_check)
-{
-  if (file_exists(sound_to_check))
-    return sound_to_check;
-  if (file_exists(sound_to_check + ".opus"))
-    return sound_to_check + ".opus";
-  if (file_exists(sound_to_check + ".ogg"))
-    return sound_to_check + ".ogg";
-  if (file_exists(sound_to_check + ".mp3"))
-    return sound_to_check + ".mp3";
-  if (file_exists(sound_to_check + ".mp4"))
-    return sound_to_check + ".mp4";
-  return sound_to_check + ".wav";
+QString AOApplication::get_suffix(VPath path_to_check, QStringList suffixes) {
+  for (const QString &suffix : suffixes) {
+    QString path = get_real_path(VPath(path_to_check.toQString() + suffix));
+    if (!path.isEmpty())
+      return path;
+  }
+
+  return QString();
 }
 
-QString AOApplication::get_image_suffix(QString path_to_check, bool static_image)
+QString AOApplication::get_sfx_suffix(VPath sound_to_check)
 {
-  if (file_exists(path_to_check))
-    return path_to_check;
+  return get_suffix(sound_to_check, { "", ".opus", ".ogg", ".mp3", ".wav" });
+}
+
+QString AOApplication::get_image_suffix(VPath path_to_check, bool static_image)
+{
+  QStringList suffixes { "" };
   // A better method would to actually use AOImageReader and see if these images have more than 1 frame.
   // However, that might not be performant.
   if (!static_image) {
-    if (file_exists(path_to_check + ".webp"))
-      return path_to_check + ".webp";
-    if (file_exists(path_to_check + ".apng"))
-      return path_to_check + ".apng";
-    if (file_exists(path_to_check + ".gif"))
-      return path_to_check + ".gif";
+    suffixes.append({ ".webp", ".apng", ".gif" });
   }
-  return path_to_check + ".png";
+  suffixes.append(".png");
+
+  return get_suffix(path_to_check, suffixes);
 }
 
 // returns whatever is to the right of "search_line =" within target_tag and
@@ -520,7 +529,7 @@ QString AOApplication::get_image_suffix(QString path_to_check, bool static_image
 QString AOApplication::read_char_ini(QString p_char, QString p_search_line,
                                      QString target_tag)
 {
-  QSettings settings(get_character_path(p_char, "char.ini"),
+  QSettings settings(get_real_path(get_character_path(p_char, "char.ini")),
                      QSettings::IniFormat);
   settings.beginGroup(target_tag);
   QString value = settings.value(p_search_line).value<QString>();
@@ -531,7 +540,7 @@ QString AOApplication::read_char_ini(QString p_char, QString p_search_line,
 void AOApplication::set_char_ini(QString p_char, QString value,
                                  QString p_search_line, QString target_tag)
 {
-  QSettings settings(get_character_path(p_char, "char.ini"),
+  QSettings settings(get_real_path(get_character_path(p_char, "char.ini")),
                      QSettings::IniFormat);
   settings.beginGroup(target_tag);
   settings.setValue(p_search_line, value);
@@ -539,10 +548,10 @@ void AOApplication::set_char_ini(QString p_char, QString value,
 }
 
 // returns all the values of target_tag
-QStringList AOApplication::read_ini_tags(QString p_path, QString target_tag)
+QStringList AOApplication::read_ini_tags(VPath p_path, QString target_tag)
 {
   QStringList r_values;
-  QSettings settings(p_path, QSettings::IniFormat);
+  QSettings settings(get_real_path(p_path), QSettings::IniFormat);
   if (!target_tag.isEmpty())
     settings.beginGroup(target_tag);
   QStringList keys = settings.allKeys();
@@ -1083,4 +1092,9 @@ bool AOApplication::get_animated_theme()
   QString result =
       configini->value("animated_theme", "true").value<QString>();
   return result.startsWith("true");
+}
+
+QStringList AOApplication::get_mount_paths()
+{
+  return configini->value("mount_paths").value<QStringList>();
 }

--- a/src/text_file_functions.cpp
+++ b/src/text_file_functions.cpp
@@ -495,32 +495,21 @@ QString AOApplication::get_court_sfx(QString p_identifier, QString p_misc)
   return "";
 }
 
-QString AOApplication::get_suffix(VPath path_to_check, QStringList suffixes) {
-  for (const QString &suffix : suffixes) {
-    QString path = get_real_path(VPath(path_to_check.toQString() + suffix));
-    if (!path.isEmpty())
-      return path;
-  }
-
-  return QString();
-}
-
 QString AOApplication::get_sfx_suffix(VPath sound_to_check)
 {
-  return get_suffix(sound_to_check, { "", ".opus", ".ogg", ".mp3", ".wav" });
+  return get_real_suffixed_path(sound_to_check,
+                                { "", ".opus", ".ogg", ".mp3", ".wav" });
 }
 
 QString AOApplication::get_image_suffix(VPath path_to_check, bool static_image)
 {
   QStringList suffixes { "" };
-  // A better method would to actually use AOImageReader and see if these images have more than 1 frame.
-  // However, that might not be performant.
   if (!static_image) {
     suffixes.append({ ".webp", ".apng", ".gif" });
   }
   suffixes.append(".png");
 
-  return get_suffix(path_to_check, suffixes);
+  return get_real_suffixed_path(path_to_check, suffixes);
 }
 
 // returns whatever is to the right of "search_line =" within target_tag and


### PR DESCRIPTION
This feature introduces the ability for players to mount multiple base folders in addition to the main AO base folder. When an asset is not found in the main base folder, the list of mounted base folders is searched in order to find the asset.

This can be used to split up assets belonging to various servers and configure an order of precedence when two character folders conflict. It can also be used to store a small subset of characters locally, and then have the rest of the characters be located on another drive or even a network location (as long as it is mounted as an OS drive).

This feature does not introduce any breaking changes. Assets with ambiguous extensions are loaded in the way you would expect them to (try all extensions before moving on to the next mount path). Only setting files (e.g. callwords.ini, serverlist.txt) will continue to be limited to the main base folder.