### PR TITLE
Fix excessive calls to arup_append

### DIFF
--- a/src/aoapplication.cpp
+++ b/src/aoapplication.cpp
@@ -26,6 +26,7 @@ AOApplication::~AOApplication()
   destruct_lobby();
   destruct_courtroom();
   delete discord;
+  delete configini;
 }
 
 void AOApplication::construct_lobby()

--- a/src/packet_distribution.cpp
+++ b/src/packet_distribution.cpp
@@ -405,10 +405,6 @@ void AOApplication::server_packet_received(AOPacket *p_packet)
         }
       }
 
-      for (int area_n = 0; area_n < areas; area_n++) {
-        w_courtroom->arup_append(0, "Unknown", "Unknown", "Unknown");
-      }
-
       int total_loading_size =
           char_list_size * 2 + evidence_list_size + music_list_size;
       int loading_value = int(
@@ -416,6 +412,10 @@ void AOApplication::server_packet_received(AOPacket *p_packet)
            static_cast<double>(total_loading_size)) *
           100);
       w_lobby->set_loading_value(loading_value);
+    }
+
+    for (int area_n = 0; area_n < areas; area_n++) {
+      w_courtroom->arup_append(0, "Unknown", "Unknown", "Unknown");
     }
 
     send_server_packet(new AOPacket("RD#%"));


### PR DESCRIPTION
I ran AO through Valgrind and perf. Valgrind didn't seem to pick up many leaks surprisingly - maybe I didn't run it for long enough.

I noticed that arup_append was being called an unusually high amount of times (~90k), and after fixing it, I can only wonder how it was even possible to have such large music counts. Oh, well - if anyone had been experiencing freezing from this issue, it's fixed now.