### PR TITLE
Fix first server in server list not initiating connections unless another server was selected first

### DIFF
--- a/include/lobby.h
+++ b/include/lobby.h
@@ -84,7 +84,7 @@ private:
   QProgressBar *ui_progress_bar;
   AOButton *ui_cancel;
 
-  int last_index;
+  int last_index = -1;
 
   void set_size_and_pos(QWidget *p_widget, QString p_identifier);
 


### PR DESCRIPTION
This happened because `last_index` was uninitialized, which for comparative purposes (depending on the compiler) means it was equal to 0. Because the first item in the server list is at index 0, when selecting it before anything else the function for initiating connections checks that you aren't selecting the same server again by checking against `last_index` and decides that you are because you've selected index 0 and `last_index` evaluates to `true` when compared against 0.

To fix this, `last_index` is initialized at -1 which is an impossible value for a user to obtain. This allows the check against `last_index` to evaluate to `false` when selecting the server at index 0, and operation continues normally from there.