### PR TITLE
Fix custom objections not playing sounds

### DIFF
--- a/src/path_functions.cpp
+++ b/src/path_functions.cpp
@@ -264,7 +264,10 @@ QString AOApplication::get_real_suffixed_path(const VPath &vpath,
   // Try cache first
   QString phys_path = asset_lookup_cache.value(qHash(vpath));
   if (!phys_path.isEmpty() && exists(phys_path)) {
-    return phys_path;
+    for (const QString &suffix : suffixes) { // make sure cached asset is the right type
+      if (phys_path.endsWith(suffix, Qt::CaseInsensitive))
+        return phys_path;
+    }
   }
 
   // Cache miss; try each suffix on all known mount paths

--- a/src/text_file_functions.cpp
+++ b/src/text_file_functions.cpp
@@ -506,7 +506,7 @@ QString AOApplication::get_court_sfx(QString p_identifier, QString p_misc)
 QString AOApplication::get_sfx_suffix(VPath sound_to_check)
 {
   return get_real_suffixed_path(sound_to_check,
-                                { "", ".opus", ".ogg", ".mp3", ".wav" });
+                                {".opus", ".ogg", ".mp3", ".wav" });
 }
 
 QString AOApplication::get_image_suffix(VPath path_to_check, bool static_image)


### PR DESCRIPTION
Was caused by the cache not checking against suffixes when a cached asset is found, making the objection player try to play "custom.apng".