### PR TITLE
Swap out "UNUSED()" macro for "Q_UNUSED()"

### DIFF
--- a/include/aoapplication.h
+++ b/include/aoapplication.h
@@ -1,8 +1,6 @@
 #ifndef AOAPPLICATION_H
 #define AOAPPLICATION_H
 
-#define UNUSED(x) (void)(x)
-
 #include "aopacket.h"
 #include "datatypes.h"
 #include "demoserver.h"

--- a/src/aoapplication.cpp
+++ b/src/aoapplication.cpp
@@ -198,10 +198,10 @@ void AOApplication::call_announce_menu(Courtroom *court)
 void CALLBACK AOApplication::BASSreset(HSTREAM handle, DWORD channel,
                                        DWORD data, void *user)
 {
-  UNUSED(handle);
-  UNUSED(channel);
-  UNUSED(data);
-  UNUSED(user);
+  Q_UNUSED(handle);
+  Q_UNUSED(channel);
+  Q_UNUSED(data);
+  Q_UNUSED(user);
   doBASSreset();
 }
 

--- a/src/aomusicplayer.cpp
+++ b/src/aomusicplayer.cpp
@@ -150,8 +150,8 @@ void AOMusicPlayer::set_volume(int p_value, int channel)
 
 void CALLBACK loopProc(HSYNC handle, DWORD channel, DWORD data, void *user)
 {
-  UNUSED(handle);
-  UNUSED(data);
+  Q_UNUSED(handle);
+  Q_UNUSED(data);
   QWORD loop_start = *(static_cast<unsigned *>(user));
   BASS_ChannelLock(channel, true);
   BASS_ChannelSetPosition(channel, loop_start, BASS_POS_BYTE);

--- a/src/charselect.cpp
+++ b/src/charselect.cpp
@@ -147,7 +147,7 @@ void Courtroom::set_char_select_page()
 
 void Courtroom::on_char_list_double_clicked(QTreeWidgetItem *p_item, int column)
 {
-  UNUSED(column);
+  Q_UNUSED(column);
   int cid = p_item->text(1).toInt();
   if (cid == -1 && !p_item->isExpanded()) {
     p_item->setExpanded(true);

--- a/src/courtroom.cpp
+++ b/src/courtroom.cpp
@@ -4584,7 +4584,7 @@ void Courtroom::set_sfx_dropdown()
 
 void Courtroom::on_sfx_dropdown_changed(int p_index)
 {
-  UNUSED(p_index);
+  Q_UNUSED(p_index);
   ui_ic_chat_message->setFocus();
   ui_sfx_remove->hide();
   custom_sfx = "";
@@ -4964,7 +4964,7 @@ void Courtroom::music_stop(bool no_effects)
 void Courtroom::on_area_list_double_clicked(QTreeWidgetItem *p_item, int column)
 {
   column = 0; // The metadata
-  UNUSED(column); // so gcc shuts up
+  Q_UNUSED(column); // so gcc shuts up
   QString p_area = p_item->text(0);
 
   QStringList packet_contents;


### PR DESCRIPTION
No need to do this ourselves, Qt has this already.

I'm actually fairly sure that these get compiled to exactly the same thing, but it's still cleaner to use Qt's solution than to reimplement it when it's not necessary to.