### PR TITLE
Handle expanded desk modifiers on chat ticking start rather than on preanim complete signal

### DIFF
--- a/src/courtroom.cpp
+++ b/src/courtroom.cpp
@@ -3284,6 +3284,22 @@ void Courtroom::preanim_done()
   if (anim_state != 1 && anim_state != 4)
     return;
   anim_state = 1;
+
+  handle_ic_speaking();
+}
+
+void Courtroom::start_chat_ticking()
+{
+  text_delay_timer->stop();
+  // we need to ensure that the text isn't already ticking because this function
+  // can be called by two logic paths
+  if (text_state != 0)
+    return;
+
+  // Display the evidence
+  display_evidence_image();
+
+  // handle expanded desk mods
   switch(m_chatmessage[DESK_MOD].toInt()) {
     case 4:
       set_self_offset(m_chatmessage[SELF_OFFSET]);
@@ -3302,19 +3318,6 @@ void Courtroom::preanim_done()
       set_scene(m_chatmessage[DESK_MOD], m_chatmessage[SIDE]);
       break;
   }
-  handle_ic_speaking();
-}
-
-void Courtroom::start_chat_ticking()
-{
-  text_delay_timer->stop();
-  // we need to ensure that the text isn't already ticking because this function
-  // can be called by two logic paths
-  if (text_state != 0)
-    return;
-
-  // Display the evidence
-  display_evidence_image();
 
   if (m_chatmessage[EFFECTS] != "") {
     QStringList fx_list = m_chatmessage[EFFECTS].split("|");


### PR DESCRIPTION
Fixes https://github.com/AttorneyOnline/AO2-Client/issues/576.