### PR TITLE
[WIP] Frameskip

### DIFF
--- a/include/aoapplication.h
+++ b/include/aoapplication.h
@@ -259,6 +259,9 @@ public:
   // from the config.ini.
   bool is_category_stop_enabled();
 
+  // Returns the value of whether frameskip should be enabled from the config.ini
+  bool is_frameskip_enabled();
+
   // Returns the value of the maximum amount of lines the IC chatlog
   // may contain, from config.ini.
   int get_max_log_size();

--- a/include/aolayer.h
+++ b/include/aolayer.h
@@ -54,6 +54,8 @@ public:
   Qt::TransformationMode transform_mode = Qt::FastTransformation; // transformation mode to use for this image
   bool stretch = false; // Should we stretch/squash this image to fill the screen?
   bool masked = true; // Set a mask to the dimensions of the widget?
+  bool frameskip = false; // Are we only playing every other frame for this animation?
+  int real_frame = 0; // The actual frame we're on. For syncing frame effects.
 
   // Set the movie's image to provided paths, preparing for playback.
   void start_playback(QString p_image);
@@ -202,6 +204,7 @@ private:
 private slots:
   void preanim_done() override; // overridden so we don't accidentally cull characters
   void movie_ticker() override; // overridden so we can play effects
+  void play_real_frame_effect(); // plays the effect for real_frame, used to sync frame effects when using frameskip
 
 signals:
   void shake();

--- a/include/aooptionsdialog.h
+++ b/include/aooptionsdialog.h
@@ -119,6 +119,9 @@ private:
   QLabel *ui_continuous_lbl;
   QCheckBox *ui_continuous_cb;
 
+  QLabel *ui_frameskip_lbl;
+  QCheckBox *ui_frameskip_cb;
+
   QLabel *ui_category_stop_lbl;
   QCheckBox *ui_category_stop_cb;
 

--- a/src/aooptionsdialog.cpp
+++ b/src/aooptionsdialog.cpp
@@ -548,6 +548,19 @@ AOOptionsDialog::AOOptionsDialog(QWidget *parent, AOApplication *p_ao_app)
   ui_gameplay_form->setWidget(row, QFormLayout::FieldRole, ui_continuous_cb);
 
   row += 1;
+  ui_frameskip_lbl = new QLabel(ui_form_layout_widget);
+  ui_frameskip_lbl->setText(tr("Frameskip:"));
+  ui_frameskip_lbl->setToolTip(
+      tr("Whether or not to skip every other frame on long full-motion animations (>30fps, >90 frames). Turning off might cause audio desyncs."));
+
+  ui_gameplay_form->setWidget(row, QFormLayout::LabelRole, ui_frameskip_lbl);
+
+  ui_frameskip_cb = new QCheckBox(ui_form_layout_widget);
+
+  ui_gameplay_form->setWidget(row, QFormLayout::FieldRole, ui_frameskip_cb);
+
+
+  row += 1;
   ui_category_stop_lbl = new QLabel(ui_form_layout_widget);
   ui_category_stop_lbl->setText(tr("Stop Music w/ Category:"));
   ui_category_stop_lbl->setToolTip(
@@ -1088,6 +1101,7 @@ void AOOptionsDialog::update_values() {
   ui_sticker_cb->setChecked(ao_app->is_sticker_enabled());
   ui_continuous_cb->setChecked(ao_app->is_continuous_enabled());
   ui_category_stop_cb->setChecked(ao_app->is_category_stop_enabled());
+  ui_frameskip_cb->setChecked(ao_app->is_frameskip_enabled());
   ui_blank_blips_cb->setChecked(ao_app->get_blank_blip());
   ui_loopsfx_cb->setChecked(ao_app->get_looping_sfx());
   ui_objectmusic_cb->setChecked(ao_app->objection_stop_music());
@@ -1158,6 +1172,7 @@ void AOOptionsDialog::save_pressed()
   configini->setValue("automatic_logging_enabled", ui_log_cb->isChecked());
   configini->setValue("continuous_playback", ui_continuous_cb->isChecked());
   configini->setValue("category_stop", ui_category_stop_cb->isChecked());
+  configini->setValue("frameskip", ui_frameskip_cb->isChecked());
   QFile *callwordsini = new QFile(ao_app->get_base_path() + "callwords.ini");
 
   if (callwordsini->open(QIODevice::WriteOnly | QIODevice::Truncate |

--- a/src/text_file_functions.cpp
+++ b/src/text_file_functions.cpp
@@ -1005,6 +1005,12 @@ bool AOApplication::is_category_stop_enabled()
   return result.startsWith("true");
 }
 
+bool AOApplication::is_frameskip_enabled()
+{
+  QString result = configini->value("frameskip", "true").value<QString>();
+  return result.startsWith("true");
+}
+
 bool AOApplication::get_casing_enabled()
 {
   QString result = configini->value("casing_enabled", "false").value<QString>();


### PR DESCRIPTION
note: this has literally no performance benefits because QImageReader::read() is still being used to advance frames

modification of the imageformat plugins to add `jumpToImage()` is required to make this have any real effect other than looking worse