### PR TITLE
Massively improve AOLayer performance by preloading next frame from disk before the current frame is done ticking

### DIFF
--- a/Attorney_Online.pro
+++ b/Attorney_Online.pro
@@ -19,6 +19,8 @@ QMAKE_LFLAGS += -Wl,-rpath,"'\$$ORIGIN/lib'"
 # Uncomment for verbose network logging
 # DEFINES += DEBUG_NETWORK
 
+DEFINES += DEBUG_MOVIE
+
 # Uncomment for building with debug symbols
 # CONFIG += debug
 

--- a/Attorney_Online.pro
+++ b/Attorney_Online.pro
@@ -19,7 +19,8 @@ QMAKE_LFLAGS += -Wl,-rpath,"'\$$ORIGIN/lib'"
 # Uncomment for verbose network logging
 # DEFINES += DEBUG_NETWORK
 
-DEFINES += DEBUG_MOVIE
+# Uncomment for verbose animation logging
+# DEFINES += DEBUG_MOVIE
 
 # Uncomment for building with debug symbols
 # CONFIG += debug

--- a/include/aolayer.h
+++ b/include/aolayer.h
@@ -7,6 +7,7 @@
 #include <QLabel>
 #include <QTimer>
 #include <QBitmap>
+#include <QtConcurrent/QtConcurrentRun>
 
 class AOApplication;
 class VPath;
@@ -138,6 +139,9 @@ protected:
   void set_frame(QPixmap f_pixmap);
   // Center the QLabel in the viewport based on the dimensions of f_pixmap
   void center_pixmap(QPixmap f_pixmap);
+
+  // Populate the frame and delay vectors. Done asynchronously.
+  void load_next_frame();
 
 signals:
   void done();

--- a/include/aolayer.h
+++ b/include/aolayer.h
@@ -143,6 +143,9 @@ protected:
   // Populates the frame and delay vectors with the next frame's data.
   void load_next_frame();
 
+  // used in load_next_frame
+  QFuture<void> future;
+
 signals:
   void done();
 

--- a/include/aolayer.h
+++ b/include/aolayer.h
@@ -140,7 +140,7 @@ protected:
   // Center the QLabel in the viewport based on the dimensions of f_pixmap
   void center_pixmap(QPixmap f_pixmap);
 
-  // Populate the frame and delay vectors. Done asynchronously.
+  // Populates the frame and delay vectors with the next frame's data.
   void load_next_frame();
 
 signals:

--- a/src/aolayer.cpp
+++ b/src/aolayer.cpp
@@ -529,8 +529,8 @@ void CharLayer::movie_ticker()
 void AOLayer::movie_ticker()
 {
   ++frame;
-  QFuture<void> future;
   if (frame >= movie_frames.size() && frame < max_frames) { // need to load the image
+      future.waitForFinished(); // Do Not want this to be running twice
       future = QtConcurrent::run(this, &AOLayer::load_next_frame);
   }
   else if (frame >= max_frames) {

--- a/src/aolayer.cpp
+++ b/src/aolayer.cpp
@@ -344,7 +344,7 @@ void AOLayer::start_playback(QString p_image)
   if (duration > 0 && cull_image == true)
     shfx_timer->start(duration);
 #ifdef DEBUG_MOVIE
-  qDebug() << max_frames << "Setting image to " << image_path
+  qDebug() << max_frames << "Setting image to " << p_image
            << "Time taken to process image:" << actual_time.elapsed();
 
   actual_time.restart();
@@ -548,11 +548,11 @@ void AOLayer::movie_ticker()
     else
       frame = 0;
   }
+  future.waitForFinished(); // don't set the frame before we definitely have it in memory
 #ifdef DEBUG_MOVIE
   qDebug() << frame << movie_delays[frame]
            << "actual time taken from last frame:" << actual_time.restart();
 #endif
-  future.waitForFinished(); // don't set the frame before we definitely have it in memory
   this->set_frame(movie_frames[frame]);
   ticker->setInterval(this->get_frame_delay(movie_delays[frame]));
   if (frame + 1 >= movie_frames.size() && frame + 1 < max_frames) { // load the next frame before we tick again

--- a/src/aolayer.cpp
+++ b/src/aolayer.cpp
@@ -320,10 +320,7 @@ void AOLayer::start_playback(QString p_image)
     for (int i = frame; i--;) {
       if (i <= -1)
         break;
-      QPixmap l_pixmap = this->get_pixmap(m_reader.read());
-      int l_delay = m_reader.nextImageDelay();
-      movie_frames.append(l_pixmap);
-      movie_delays.append(l_delay);
+      load_next_frame();
     }
   }
   last_path = p_image;


### PR DESCRIPTION
Performance on a 30FPS 640x384 animation, without preloading:
```
1 33 actual time taken from last frame: 35
2 34 actual time taken from last frame: 36
3 33 actual time taken from last frame: 37
4 33 actual time taken from last frame: 37
5 34 actual time taken from last frame: 36
6 33 actual time taken from last frame: 37
7 33 actual time taken from last frame: 36
8 34 actual time taken from last frame: 35
9 33 actual time taken from last frame: 36
```
Average extra delay per frame: 2.7ms

Performance with `aolayer-preload`:
```
1 33 actual time taken from last frame: 37
2 34 actual time taken from last frame: 33
3 33 actual time taken from last frame: 34
4 33 actual time taken from last frame: 32
5 34 actual time taken from last frame: 33
6 33 actual time taken from last frame: 34
7 33 actual time taken from last frame: 33
8 34 actual time taken from last frame: 33
9 33 actual time taken from last frame: 33
```
Average extra delay per frame: 0.2ms

Completely fixes audio de-synchronization caused by the extra time per frame.