### PR TITLE
Fully asynchronous animation loading

### DIFF
--- a/include/aolayer.h
+++ b/include/aolayer.h
@@ -8,6 +8,8 @@
 #include <QTimer>
 #include <QBitmap>
 #include <QtConcurrent/QtConcurrentRun>
+#include <QMutex>
+#include <QWaitCondition>
 
 class AOApplication;
 class VPath;
@@ -140,11 +142,17 @@ protected:
   // Center the QLabel in the viewport based on the dimensions of f_pixmap
   void center_pixmap(QPixmap f_pixmap);
 
-  // Populates the frame and delay vectors with the next frame's data.
-  void load_next_frame();
+private:
+  // Populates the frame and delay vectors.
+  void populate_vectors();
 
-  // used in load_next_frame
-  QFuture<void> future;
+  // used in populate_vectors
+  void load_next_frame();
+  bool exit_loop; //awful solution but i'm not fucking using QThread
+  QFuture<void> frame_loader;
+  QMutex mutex;
+  QWaitCondition frameAdded;
+
 
 signals:
   void done();
@@ -243,4 +251,5 @@ public:
   StickerLayer(QWidget *p_parent, AOApplication *p_ao_app);
   void load_image(QString p_charname);
 };
+
 #endif // AOLAYER_H


### PR DESCRIPTION
new runtime error to add to the collection
![image](https://user-images.githubusercontent.com/32779090/129327599-f1b5687a-31c3-4053-909d-c7cf1ffb2cc0.png)

Animations will now be loaded fully asynchronous from display logic, allowing for around 5x the performance (compared to `aolayer-preload`, upon which this is based). "Old-style" continuous playback (i.e. for a/b pairs with matching frame counts) no longer requires its own loading logic, as it can simply reuse the logic the main thread uses to wait for the correct frame to be loaded. This means one less wall of angry developer comments!

ty @oldmud0 for telling me about QWaitConditions and QMutexes, very cool