### PR TITLE
Fix an infinite hang when loading the pair character, fix strange undesired behavior of the pair character

### DIFF
--- a/src/aolayer.cpp
+++ b/src/aolayer.cpp
@@ -304,11 +304,12 @@ void AOLayer::start_playback(QString p_image)
   m_reader.setFileName(p_image);
   if (m_reader.loopCount() == 0)
     play_once = true;
-  if (!continuous)
-    frame = 0;
   last_max_frames = max_frames;
   max_frames = m_reader.imageCount();
-  if (((continuous) && (max_frames != last_max_frames)) || max_frames == 0 || frame >= max_frames) {
+  if (!continuous
+          || ((continuous) && (max_frames != last_max_frames))
+          || max_frames == 0
+          || frame >= max_frames) {
     frame = 0;
     continuous = false;
   }


### PR DESCRIPTION
Fixes a hang when attempting to load the next frame of the pair character's animation when `frame == max_frames`.

Also, completely by accident, fixes https://github.com/AttorneyOnline/AO2-Client/issues/577 and https://github.com/AttorneyOnline/AO2-Client/issues/585.