### PR TITLE
Fix VPath lookup ignoring possibility of remote files

### DIFF
--- a/src/path_functions.cpp
+++ b/src/path_functions.cpp
@@ -253,6 +253,12 @@ QString AOApplication::get_real_path(const VPath &vpath) {
     }
   }
 
+  // Not found in mount paths; check if the file is remote
+  QString remotePath = vpath.toQString();
+  if (remotePath.startsWith("http")) {
+      return remotePath;
+  }
+
   // File or directory not found
   return QString();
 }

--- a/src/path_functions.cpp
+++ b/src/path_functions.cpp
@@ -255,7 +255,7 @@ QString AOApplication::get_real_path(const VPath &vpath) {
 
   // Not found in mount paths; check if the file is remote
   QString remotePath = vpath.toQString();
-  if (remotePath.startsWith("http")) {
+  if (remotePath.startsWith("http:") || remotePath.startsWith("https:")) {
       return remotePath;
   }
 


### PR DESCRIPTION
Adds an additional check in the file path lookup as files on a webserver is currently not accounted for, causing client streaming to be non-functional on master.