### PR TITLE
Fix paired character only playing animations once

### DIFF
--- a/src/courtroom.cpp
+++ b/src/courtroom.cpp
@@ -2451,6 +2451,7 @@ void Courtroom::display_pair_character(QString other_charid, QString other_offse
 
       // Play the other pair character's idle animation
       QString filename = "(a)" + m_chatmessage[OTHER_EMOTE];
+      ui_vp_sideplayer_char->set_play_once(false);
       ui_vp_sideplayer_char->load_image(filename, m_chatmessage[OTHER_NAME],
                                             0, false);
       }


### PR DESCRIPTION
I don't know why, I don't want to know why, I shouldn't have to wonder why, but somehow `ui_vp_sideplayer_char` gets its `play_once` variable set to `true` after the first character does a preanimation. So I forced it back to `false`.

Fixes #585.