### PR TITLE
Fix VPath lookup when checking for buttons

### DIFF
--- a/include/aoapplication.h
+++ b/include/aoapplication.h
@@ -145,6 +145,13 @@ public:
   // Returns the character the player has currently selected
   QString get_current_char();
 
+  // Overwrite flags for VPath lookups.
+  enum class VPathOverwrite {
+    NONE,
+    EMOTE_BUTTON
+  };
+  Q_ENUM(VPathOverwrite);
+
   // implementation in path_functions.cpp
   QString get_base_path();
   VPath get_theme_path(QString p_file, QString p_theme="");
@@ -165,7 +172,8 @@ public:
   QString get_sfx(QString p_sfx, QString p_misc="", QString p_character="");
   QString get_case_sensitive_path(QString p_file);
   QString get_real_path(const VPath &vpath);
-  QString get_real_suffixed_path(const VPath &vpath, const QStringList &suffixes);
+  QString get_real_suffixed_path(const VPath &vpath, const QStringList &suffixes,
+                                 const VPathOverwrite &overwrite = VPathOverwrite::NONE);
   void invalidate_lookup_cache();
 
   ////// Functions for reading and writing files //////
@@ -365,7 +373,7 @@ public:
 
   // Can we use APNG for this? If not, WEBP? If not, GIF? If not, fall back to
   // PNG.
-  QString get_image_suffix(VPath path_to_check, bool static_image=false);
+  QString get_image_suffix(VPath path_to_check, bool static_image=false, const VPathOverwrite &overwrite = AOApplication::VPathOverwrite::NONE);
 
   // Returns the value of p_search_line within target_tag and terminator_tag
   QString read_char_ini(QString p_char, QString p_search_line,

--- a/src/aoemotebutton.cpp
+++ b/src/aoemotebutton.cpp
@@ -62,9 +62,9 @@ void AOEmoteButton::set_char_image(QString p_char, int p_emote, QString suffix)
   QString emotion_number = QString::number(p_emote + 1);
   QString image_path =
       ao_app->get_image_suffix(ao_app->get_character_path(
-          p_char, "emotions/button" + emotion_number + suffix), true);
+          p_char, "emotions/button" + emotion_number + suffix));
 
   this->set_image(image_path, ao_app->get_emote_comment(p_char, p_emote));
 }
 
-void AOEmoteButton::on_clicked() { emit emote_clicked(m_id); }
+void AOEmoteButton::on_clicked() { emote_clicked(m_id); }

--- a/src/aoemotebutton.cpp
+++ b/src/aoemotebutton.cpp
@@ -62,9 +62,9 @@ void AOEmoteButton::set_char_image(QString p_char, int p_emote, QString suffix)
   QString emotion_number = QString::number(p_emote + 1);
   QString image_path =
       ao_app->get_image_suffix(ao_app->get_character_path(
-          p_char, "emotions/button" + emotion_number + suffix));
+          p_char, "emotions/button" + emotion_number + suffix), true, AOApplication::VPathOverwrite::EMOTE_BUTTON);
 
   this->set_image(image_path, ao_app->get_emote_comment(p_char, p_emote));
 }
 
-void AOEmoteButton::on_clicked() { emote_clicked(m_id); }
+void AOEmoteButton::on_clicked() { emit emote_clicked(m_id); }

--- a/src/aoemotebutton.cpp
+++ b/src/aoemotebutton.cpp
@@ -62,9 +62,9 @@ void AOEmoteButton::set_char_image(QString p_char, int p_emote, QString suffix)
   QString emotion_number = QString::number(p_emote + 1);
   QString image_path =
       ao_app->get_image_suffix(ao_app->get_character_path(
-          p_char, "emotions/button" + emotion_number + suffix));
+          p_char, "emotions/button" + emotion_number + suffix), true);
 
   this->set_image(image_path, ao_app->get_emote_comment(p_char, p_emote));
 }
 
-void AOEmoteButton::on_clicked() { emote_clicked(m_id); }
+void AOEmoteButton::on_clicked() { emit emote_clicked(m_id); }

--- a/src/aoemotebutton.cpp
+++ b/src/aoemotebutton.cpp
@@ -62,7 +62,7 @@ void AOEmoteButton::set_char_image(QString p_char, int p_emote, QString suffix)
   QString emotion_number = QString::number(p_emote + 1);
   QString image_path =
       ao_app->get_image_suffix(ao_app->get_character_path(
-          p_char, "emotions/button" + emotion_number + suffix), true, AOApplication::VPathOverwrite::EMOTE_BUTTON);
+          p_char, "emotions/button" + emotion_number + suffix), false, AOApplication::VPathOverwrite::EMOTE_BUTTON);
 
   this->set_image(image_path, ao_app->get_emote_comment(p_char, p_emote));
 }

--- a/src/path_functions.cpp
+++ b/src/path_functions.cpp
@@ -293,6 +293,10 @@ QString AOApplication::get_real_suffixed_path(const VPath &vpath,
         asset_lookup_cache.insert(qHash(vpath), path);
         return path;
       }
+      if (path.contains("emotions/button")) {
+        //Button creation should not run into the void.
+        return path + ".png";
+      }
     }
   }
 

--- a/src/path_functions.cpp
+++ b/src/path_functions.cpp
@@ -293,10 +293,6 @@ QString AOApplication::get_real_suffixed_path(const VPath &vpath,
         asset_lookup_cache.insert(qHash(vpath), path);
         return path;
       }
-      if (path.contains("emotions/button")) {
-        //Button creation should not run into the void.
-        return path + ".png";
-      }
     }
   }
 

--- a/src/path_functions.cpp
+++ b/src/path_functions.cpp
@@ -298,7 +298,8 @@ QString AOApplication::get_real_suffixed_path(const VPath &vpath, const QStringL
         //Checking if the opposite button exists.
         //Then return path to generate a button from it.
         if (exists(path.replace("_on","_off"))) {
-          return path.replace("_off","_on");
+          asset_lookup_cache.insert(qHash(vpath), path.replace("_off","_on"));
+          return path;
         }
       }
     }

--- a/src/path_functions.cpp
+++ b/src/path_functions.cpp
@@ -265,8 +265,8 @@ QString AOApplication::get_real_path(const VPath &vpath) {
 
 // Special case of get_real_path where multiple suffixes need to be tried
 // on each mount path.
-QString AOApplication::get_real_suffixed_path(const VPath &vpath,
-                                              const QStringList &suffixes) {
+QString AOApplication::get_real_suffixed_path(const VPath &vpath, const QStringList &suffixes,
+                                              const VPathOverwrite &overwrite) {
   // Try cache first
   QString phys_path = asset_lookup_cache.value(qHash(vpath));
   if (!phys_path.isEmpty() && exists(phys_path)) {
@@ -293,9 +293,13 @@ QString AOApplication::get_real_suffixed_path(const VPath &vpath,
         asset_lookup_cache.insert(qHash(vpath), path);
         return path;
       }
+
+      if (overwrite == AOApplication::VPathOverwrite::EMOTE_BUTTON) {
+        //Button creation should not run into the void.
+        return path + ".png";
+      }
     }
   }
-
   // File or directory not found
   return QString();
 }

--- a/src/path_functions.cpp
+++ b/src/path_functions.cpp
@@ -295,11 +295,15 @@ QString AOApplication::get_real_suffixed_path(const VPath &vpath, const QStringL
       }
 
       if (overwrite == AOApplication::VPathOverwrite::EMOTE_BUTTON) {
-        //Button creation should not run into the void.
-        return path + ".png";
+        //Checking if the opposite button exists.
+        //Then return path to generate a button from it.
+        if (exists(path.replace("_on","_off"))) {
+          return path.replace("_off","_on");
+        }
       }
     }
   }
+
   // File or directory not found
   return QString();
 }

--- a/src/text_file_functions.cpp
+++ b/src/text_file_functions.cpp
@@ -515,7 +515,8 @@ QString AOApplication::get_sfx_suffix(VPath sound_to_check)
                                 {".opus", ".ogg", ".mp3", ".wav" });
 }
 
-QString AOApplication::get_image_suffix(VPath path_to_check, bool static_image)
+QString AOApplication::get_image_suffix(VPath path_to_check, bool static_image,
+                                        const AOApplication::VPathOverwrite &overwrite)
 {
   QStringList suffixes { "" };
   if (!static_image) {
@@ -523,7 +524,7 @@ QString AOApplication::get_image_suffix(VPath path_to_check, bool static_image)
   }
   suffixes.append(".png");
 
-  return get_real_suffixed_path(path_to_check, suffixes);
+  return get_real_suffixed_path(path_to_check, suffixes, overwrite);
 }
 
 // returns whatever is to the right of "search_line =" within target_tag and


### PR DESCRIPTION
fixes #572 
To explain: VPath returns an empty path when the file could not be found, causing the button generator, which needs the file to not exist, only gets an empty path and can't create the new button.
 To resolve this we check if the path contains "emotions/button" to determine if we look for an emote button.
This also removes the ability for buttons to be animated.  Do we really need this?
Also one less clazy warning.