### PR TITLE
Add options to partially or fully disable the streaming functionality.

### DIFF
--- a/include/aoapplication.h
+++ b/include/aoapplication.h
@@ -193,6 +193,12 @@ public:
   // Returns true if stop music on objection is enabled in the config.ini
   bool objection_stop_music();
 
+  //Returns true if streaming is enabled in the config.ini
+  bool streaming_enabled();
+
+  //Returns true if musiclist fallback streaming is enabled in the config.ini
+  bool streaming_fallback_enabled();
+
   // Returns the value of default_music in config.ini
   int get_default_music();
 

--- a/include/aooptionsdialog.h
+++ b/include/aooptionsdialog.h
@@ -152,6 +152,10 @@ private:
   QCheckBox *ui_loopsfx_cb;
   QLabel *ui_objectmusic_lbl;
   QCheckBox *ui_objectmusic_cb;
+  QLabel *ui_streaming_lbl;
+  QCheckBox * ui_streaming_cb;
+  QLabel *ui_fallbackstreaming_lbl;
+  QCheckBox *ui_fallbackstreaming_cb;
   QDialogButtonBox *ui_settings_buttons;
 
   QWidget *ui_casing_tab;

--- a/src/aomusicplayer.cpp
+++ b/src/aomusicplayer.cpp
@@ -31,12 +31,17 @@ int AOMusicPlayer::play(QString p_song, int channel, bool loop,
 
   DWORD newstream;
   if (f_path.startsWith("http")) {
-    if (f_path.endsWith(".opus"))
-      newstream = BASS_OPUS_StreamCreateURL(f_path.toStdString().c_str(), 0, streaming_flags, nullptr, 0);
+    if (ao_app->streaming_enabled()){
+    //No streaming if its disabled.
+      if (f_path.endsWith(".opus"))
+        newstream = BASS_OPUS_StreamCreateURL(f_path.toStdString().c_str(), 0, streaming_flags, nullptr, 0);
+      else
+        newstream = BASS_StreamCreateURL(f_path.toStdString().c_str(), 0, streaming_flags, nullptr, 0);
+    }
     else
-      newstream = BASS_StreamCreateURL(f_path.toStdString().c_str(), 0, streaming_flags, nullptr, 0);
-
-  } else {
+      return 0;
+  }
+  else {
     if (f_path.endsWith(".opus"))
       newstream = BASS_OPUS_StreamCreateFile(FALSE, f_path.utf16(), 0, 0, flags);
     else

--- a/src/aooptionsdialog.cpp
+++ b/src/aooptionsdialog.cpp
@@ -773,6 +773,30 @@ AOOptionsDialog::AOOptionsDialog(QWidget *parent, AOApplication *p_ao_app)
 
   ui_audio_layout->setWidget(row, QFormLayout::FieldRole, ui_objectmusic_cb);
 
+  row += 1;
+  ui_fallbackstreaming_lbl = new QLabel(ui_audio_widget);
+  ui_fallbackstreaming_lbl->setText(tr("Enable fallback music streaming:"));
+  ui_fallbackstreaming_lbl->setToolTip(
+      tr("If true, AO2 will try to fallback on an internet source to play songs from the musiclist."));
+
+  ui_audio_layout->setWidget(row, QFormLayout::LabelRole, ui_fallbackstreaming_lbl);
+
+  ui_fallbackstreaming_cb = new QCheckBox(ui_audio_widget);
+
+  ui_audio_layout->setWidget(row, QFormLayout::FieldRole, ui_fallbackstreaming_cb);
+
+  row += 1;
+  ui_streaming_lbl = new QLabel(ui_audio_widget);
+  ui_streaming_lbl->setText(tr("Enable music streaming:"));
+  ui_streaming_lbl->setToolTip(
+      tr("If true, AO2 will play songs from the internet using the /play command. Disabling this also disabled fallback streaming."));
+
+  ui_audio_layout->setWidget(row, QFormLayout::LabelRole, ui_streaming_lbl);
+
+  ui_streaming_cb = new QCheckBox(ui_audio_widget);
+
+  ui_audio_layout->setWidget(row, QFormLayout::FieldRole, ui_streaming_cb);
+
   // The casing tab!
   ui_casing_tab = new QWidget(this);
   ui_settings_tabs->addTab(ui_casing_tab, tr("Casing"));
@@ -1116,6 +1140,8 @@ void AOOptionsDialog::update_values() {
   ui_blank_blips_cb->setChecked(ao_app->get_blank_blip());
   ui_loopsfx_cb->setChecked(ao_app->get_looping_sfx());
   ui_objectmusic_cb->setChecked(ao_app->objection_stop_music());
+  ui_streaming_cb->setChecked(ao_app->streaming_enabled());
+  ui_fallbackstreaming_cb->setChecked(ao_app->streaming_fallback_enabled());
   ui_casing_enabled_cb->setChecked(ao_app->get_casing_enabled());
   ui_casing_def_cb->setChecked(ao_app->get_casing_defence_enabled());
   ui_casing_pro_cb->setChecked(ao_app->get_casing_prosecution_enabled());
@@ -1203,6 +1229,8 @@ void AOOptionsDialog::save_pressed()
   configini->setValue("blank_blip", ui_blank_blips_cb->isChecked());
   configini->setValue("looping_sfx", ui_loopsfx_cb->isChecked());
   configini->setValue("objection_stop_music", ui_objectmusic_cb->isChecked());
+  configini->setValue("streaming_enabled", ui_streaming_cb->isChecked());
+  configini->setValue("streaming_fallback_enabled", ui_fallbackstreaming_cb->isChecked());
 
   configini->setValue("casing_enabled", ui_casing_enabled_cb->isChecked());
   configini->setValue("casing_defence_enabled", ui_casing_def_cb->isChecked());

--- a/src/courtroom.cpp
+++ b/src/courtroom.cpp
@@ -3836,9 +3836,14 @@ void Courtroom::handle_song(QStringList *p_contents)
       return;
   }
 
+  //Meatgrinder noises.
   if(!file_exists(ao_app->get_sfx_suffix(ao_app->get_music_path(f_song))) && !f_song.startsWith("http")
           && f_song != "~stop.mp3" && !ao_app->asset_url.isEmpty()) {
+      if (ao_app->streaming_enabled() && ao_app->streaming_fallback_enabled())
       f_song = (ao_app->asset_url + "sounds/music/" + f_song).toLower();
+      else
+        //File not found and streaming not an option. Nothing to do here, keep current song playing!
+        return;
   }
 
   bool is_stop = (f_song == "~stop.mp3");
@@ -3863,6 +3868,9 @@ void Courtroom::handle_song(QStringList *p_contents)
   }
 
   int error_code = music_player->play(f_song, channel, looping, effect_flags);
+
+  if (error_code == 0)
+      return;
 
   if (is_stop) {
     ui_music_name->setText(tr("None"));

--- a/src/text_file_functions.cpp
+++ b/src/text_file_functions.cpp
@@ -927,6 +927,16 @@ bool AOApplication::objection_stop_music()
   return result.startsWith("true");
 }
 
+bool AOApplication::streaming_enabled()
+{
+    return configini->value("streaming_enabled", true).toBool();
+}
+
+bool AOApplication::streaming_fallback_enabled()
+{
+    return configini->value("streaming_fallback_enabled", true).toBool();
+}
+
 bool AOApplication::is_instant_objection_enabled()
 {
   QString result = configini->value("instant_objection", "true").value<QString>();


### PR DESCRIPTION
Because some people are in the outback with internet so bad we can't expect them to wait several seconds to load a file that may already be outdated by then. I'm pretty sure somebody who knows what they are doing will have a stroke reading this jank.