### PR TITLE
Sanity check before removing the ui element.

### DIFF
--- a/src/courtroom.cpp
+++ b/src/courtroom.cpp
@@ -4443,8 +4443,10 @@ void Courtroom::on_sfx_dropdown_changed(int p_index)
 {
   Q_UNUSED(p_index);
   ui_ic_chat_message->setFocus();
-  ui_sfx_remove->hide();
-  custom_sfx = "";
+  if (p_index == 0) {
+      ui_sfx_remove->hide();
+      custom_sfx = "";
+  }
 }
 
 void Courtroom::on_sfx_dropdown_custom(QString p_sfx)

--- a/src/courtroom.cpp
+++ b/src/courtroom.cpp
@@ -4441,7 +4441,6 @@ void Courtroom::set_sfx_dropdown()
 
 void Courtroom::on_sfx_dropdown_changed(int p_index)
 {
-  Q_UNUSED(p_index);
   ui_ic_chat_message->setFocus();
   if (p_index == 0) {
       ui_sfx_remove->hide();


### PR DESCRIPTION
Seems to have been introduced by #389.
We instantly hide the UI element as on_sfx_dropdown_changed is called right after we pick the sfx as there is no check to prevent hiding. This PR corrects this. A simple check, if we are not on the first SFX item, should correct this.