### PR TITLE
Remove client-side send waiting

### DIFF
--- a/src/courtroom.cpp
+++ b/src/courtroom.cpp
@@ -1787,9 +1787,6 @@ void Courtroom::on_chat_return_pressed()
   if (is_muted)
     return;
 
-  if (text_state < 2 && objection_state == 0)
-    return;
-
   ui_ic_chat_message->blockSignals(true);
   QTimer::singleShot(ao_app->get_chat_ratelimit(), this,
                      [=] { ui_ic_chat_message->blockSignals(false); });


### PR DESCRIPTION
This piece of code from another era is not needed anymore thanks to the message queue and decent server-side anti-flooding. Player input won't be thrown away since the client waits for an acknowledgement from the server before clearing the input box.