### PR TITLE
Split logging option into text and demo

### DIFF
--- a/include/aoapplication.h
+++ b/include/aoapplication.h
@@ -504,8 +504,11 @@ public:
   // Get the message for the CM for casing alerts.
   QString get_casing_can_host_cases();
 
-  // Get if automatic logging is enabled
-  bool get_auto_logging_enabled();
+  // Get if text file logging is enabled
+  bool get_text_logging_enabled();
+
+  // Get if demo logging is enabled
+  bool get_demo_logging_enabled();
 
   // Get the subtheme from settings
   QString get_subtheme();

--- a/include/aooptionsdialog.h
+++ b/include/aooptionsdialog.h
@@ -124,6 +124,12 @@ private:
   QLabel *ui_category_stop_lbl;
   QCheckBox *ui_category_stop_cb;
 
+  QLabel *ui_log_text_lbl;
+  QCheckBox *ui_log_text_cb;
+
+  QLabel *ui_log_demo_lbl;
+  QCheckBox *ui_log_demo_cb;
+
   QWidget *ui_callwords_tab;
   QWidget *ui_callwords_widget;
   QVBoxLayout *ui_callwords_layout;
@@ -174,8 +180,6 @@ private:
   QCheckBox *ui_casing_cm_cb;
   QLabel *ui_casing_cm_cases_lbl;
   QLineEdit *ui_casing_cm_cases_textbox;
-  QLabel *ui_log_lbl;
-  QCheckBox *ui_log_cb;
 
   QWidget *ui_assets_tab;
   QVBoxLayout *ui_assets_tab_layout;

--- a/src/aooptionsdialog.cpp
+++ b/src/aooptionsdialog.cpp
@@ -583,6 +583,28 @@ AOOptionsDialog::AOOptionsDialog(QWidget *parent, AOApplication *p_ao_app)
 
   ui_gameplay_form->setWidget(row, QFormLayout::FieldRole, ui_category_stop_cb);
 
+  //Check whether mass logging is enabled
+  row += 1;
+  ui_log_text_lbl = new QLabel(ui_form_layout_widget);
+  ui_log_text_lbl->setText(tr("Log to Text Files:"));
+  ui_log_text_lbl->setToolTip(
+      tr("Text logs of gameplay will be automatically written in the /logs folder."));
+  ui_gameplay_form->setWidget(row, QFormLayout::LabelRole, ui_log_text_lbl);
+
+  ui_log_text_cb = new QCheckBox(ui_form_layout_widget);
+  ui_gameplay_form->setWidget(row, QFormLayout::FieldRole, ui_log_text_cb);
+
+  row += 1;
+  ui_log_demo_lbl = new QLabel(ui_form_layout_widget);
+  ui_log_demo_lbl->setText(tr("Log to Demo Files:"));
+  ui_log_demo_lbl->setToolTip(
+      tr("Gameplay will be automatically recorded as demos in the /logs folder."));
+  ui_gameplay_form->setWidget(row, QFormLayout::LabelRole, ui_log_demo_lbl);
+
+  ui_log_demo_cb = new QCheckBox(ui_form_layout_widget);
+  ui_gameplay_form->setWidget(row, QFormLayout::FieldRole, ui_log_demo_cb);
+
+  // Finish gameplay tab
   QScrollArea *scroll = new QScrollArea(this);
   scroll->setWidget(ui_form_layout_widget);
   ui_gameplay_tab->setLayout(new QVBoxLayout);
@@ -921,19 +943,6 @@ AOOptionsDialog::AOOptionsDialog(QWidget *parent, AOApplication *p_ao_app)
 
   ui_casing_layout->setWidget(row, QFormLayout::FieldRole,
                               ui_casing_cm_cases_textbox);
-  //Check whether mass logging is enabled
-  row += 1;
-  ui_log_lbl = new QLabel(ui_casing_widget);
-  ui_log_lbl->setText(tr("Automatic Logging:"));
-  ui_log_lbl->setToolTip(
-      tr("If checked, all logs will be automatically written in the "
-         "/logs folder."));
-
-  ui_casing_layout->setWidget(row, QFormLayout::LabelRole, ui_log_lbl);
-
-  ui_log_cb = new QCheckBox(ui_casing_widget);
-
-  ui_casing_layout->setWidget(row, QFormLayout::FieldRole, ui_log_cb);
 
   // Assets tab
   ui_assets_tab = new QWidget(this);
@@ -1123,7 +1132,8 @@ void AOOptionsDialog::update_values() {
   ui_casing_jur_cb->setChecked(ao_app->get_casing_juror_enabled());
   ui_casing_steno_cb->setChecked(ao_app->get_casing_steno_enabled());
   ui_casing_cm_cb->setChecked(ao_app->get_casing_cm_enabled());
-  ui_log_cb->setChecked(ao_app->get_auto_logging_enabled());
+  ui_log_text_cb->setChecked(ao_app->get_text_logging_enabled());
+  ui_log_demo_cb->setChecked(ao_app->get_demo_logging_enabled());
   ui_length_spinbox->setValue(ao_app->get_max_log_size());
   ui_log_margin_spinbox->setValue(ao_app->get_log_margin());
   ui_stay_time_spinbox->setValue(ao_app->stay_time());
@@ -1181,7 +1191,8 @@ void AOOptionsDialog::save_pressed()
   configini->setValue("stickypres", ui_stickypres_cb->isChecked());
   configini->setValue("customchat", ui_customchat_cb->isChecked());
   configini->setValue("sticker", ui_sticker_cb->isChecked());
-  configini->setValue("automatic_logging_enabled", ui_log_cb->isChecked());
+  configini->setValue("automatic_logging_enabled", ui_log_text_cb->isChecked());
+  configini->setValue("demo_logging_enabled", ui_log_demo_cb->isChecked());
   configini->setValue("continuous_playback", ui_continuous_cb->isChecked());
   configini->setValue("category_stop", ui_category_stop_cb->isChecked());
   QFile *callwordsini = new QFile(ao_app->get_base_path() + "callwords.ini");

--- a/src/courtroom.cpp
+++ b/src/courtroom.cpp
@@ -1761,7 +1761,7 @@ void Courtroom::append_server_chatmessage(QString p_name, QString p_message,
 
   ui_server_chatlog->append_chatmessage(p_name, p_message, color);
 
-  if (ao_app->get_auto_logging_enabled() && !ao_app->log_filename.isEmpty()) {
+  if (ao_app->get_text_logging_enabled() && !ao_app->log_filename.isEmpty()) {
     QString full = "[OOC][" + QDateTime::currentDateTimeUtc().toString() + "] " + p_name + ": " + p_message;
     ao_app->append_to_file(full, ao_app->log_filename, true);
   }
@@ -3091,7 +3091,7 @@ void Courtroom::log_ic_text(QString p_name, QString p_showname,
 {
   chatlogpiece log_entry(p_name, p_showname, p_message, p_action, p_color);
   ic_chatlog_history.append(log_entry);
-  if (ao_app->get_auto_logging_enabled() && !ao_app->log_filename.isEmpty())
+  if (ao_app->get_text_logging_enabled() && !ao_app->log_filename.isEmpty())
     ao_app->append_to_file(log_entry.get_full(), ao_app->log_filename, true);
 
   while (ic_chatlog_history.size() > log_maximum_blocks &&

--- a/src/packet_distribution.cpp
+++ b/src/packet_distribution.cpp
@@ -107,7 +107,7 @@ end:
 
 void AOApplication::append_to_demofile(QString packet_string)
 {
-    if (get_auto_logging_enabled() && !log_filename.isEmpty())
+    if (get_demo_logging_enabled() && !log_filename.isEmpty())
     {
         QString path = log_filename.left(log_filename.size()).replace(".log", ".demo");
         if (!demo_timer.isValid())
@@ -304,7 +304,7 @@ void AOApplication::server_packet_received(AOPacket *p_packet)
 
     // Remove any characters not accepted in folder names for the server_name
     // here
-    if (AOApplication::get_auto_logging_enabled() && server_name != "Demo playback") {
+    if (AOApplication::get_demo_logging_enabled() && server_name != "Demo playback") {
       this->log_filename = QDateTime::currentDateTime().toUTC().toString(
           "'logs/" + server_name.remove(QRegExp("[\\\\/:*?\"<>|\']")) +
           "/'yyyy-MM-dd hh-mm-ss t'.log'");

--- a/src/text_file_functions.cpp
+++ b/src/text_file_functions.cpp
@@ -1067,10 +1067,17 @@ QString AOApplication::get_casing_can_host_cases()
   return result;
 }
 
-bool AOApplication::get_auto_logging_enabled()
+bool AOApplication::get_text_logging_enabled()
 {
   QString result =
       configini->value("automatic_logging_enabled", "true").value<QString>();
+  return result.startsWith("true");
+}
+
+bool AOApplication::get_demo_logging_enabled()
+{
+  QString result =
+      configini->value("demo_logging_enabled", "true").value<QString>();
   return result.startsWith("true");
 }
 


### PR DESCRIPTION
Apparently, people don't like logging demos because it takes up too much space, even if it might be possible to enable NTFS compression for demo files (or the entire demos folder).