### PR TITLE
Remove MS chat and add debug log

### DIFF
--- a/include/aoapplication.h
+++ b/include/aoapplication.h
@@ -567,6 +567,10 @@ private slots:
 public slots:
   void server_disconnected();
   void loading_cancelled();
+
+signals:
+  void qt_log_message(QtMsgType type, const QMessageLogContext &context,
+                      const QString &msg);
 };
 
 #endif // AOAPPLICATION_H

--- a/include/aotextarea.h
+++ b/include/aotextarea.h
@@ -12,7 +12,8 @@ public:
   AOTextArea(QWidget *p_parent = nullptr);
 
   void append_linked(QString p_message);
-  void append_chatmessage(QString p_name, QString p_message, QString p_colur);
+  void append_chatmessage(QString p_name, QString p_message,
+                          QString p_name_colour, QString p_color = QString());
   void append_error(QString p_message);
 
 private:

--- a/include/courtroom.h
+++ b/include/courtroom.h
@@ -214,8 +214,12 @@ public:
   void list_music();
   void list_areas();
 
-  // these are for OOC chat
-  void append_ms_chatmessage(QString f_name, QString f_message);
+  // Debug log (formerly master server chat log)
+  void debug_message_handler(QtMsgType type, const QMessageLogContext &context,
+                             const QString &msg);
+  void append_debug_message(QString f_message);
+
+  // OOC chat log
   void append_server_chatmessage(QString p_name, QString p_message,
                                  QString p_color);
 
@@ -628,7 +632,7 @@ private:
 
   QTextEdit *ui_ic_chatlog;
 
-  AOTextArea *ui_ms_chatlog;
+  AOTextArea *ui_debug_log;
   AOTextArea *ui_server_chatlog;
 
   QListWidget *ui_mute_list;

--- a/src/aoimage.cpp
+++ b/src/aoimage.cpp
@@ -30,7 +30,7 @@ bool AOImage::set_image(QString p_image, QString p_misc)
                              ao_app->default_theme, p_misc, "", "", is_static || !ao_app->get_animated_theme());
 
   if (!file_exists(p_image)) {
-    qDebug() << "Warning: Image" << p_image << "not found! Can't set!";
+    qWarning() << "Image" << p_image << "not found! Can't set!";
     return false;
   }
   path = p_image;

--- a/src/aolayer.cpp
+++ b/src/aolayer.cpp
@@ -437,7 +437,7 @@ void CharLayer::load_network_effects()
           continue;
         int f_frame = frame_split.at(0).toInt();
         if (f_frame >= max_frames || f_frame < 0) {
-          qDebug() << "Warning: out of bounds" << effects_list[i] << "frame"
+          qWarning() << "out of bounds" << effects_list[i] << "frame"
                    << f_frame << "out of" << max_frames << "for" << m_emote;
           continue;
         }
@@ -461,7 +461,7 @@ void CharLayer::load_network_effects()
 void CharLayer::play_frame_effect(int p_frame)
 {
   if (p_frame >= movie_effects.size()) {
-    qDebug() << "W: Attempted to play a frame effect bigger than the size of movie_effects";
+    qWarning() << "Attempted to play a frame effect bigger than the size of movie_effects";
     return;
   }
   if (p_frame < max_frames) {

--- a/src/aotextarea.cpp
+++ b/src/aotextarea.cpp
@@ -11,7 +11,7 @@ void AOTextArea::append_linked(QString p_message)
 }
 
 void AOTextArea::append_chatmessage(QString p_name, QString p_message,
-                                    QString p_colour)
+                                    QString p_name_colour, QString p_color)
 {
   const QTextCursor old_cursor = this->textCursor();
   const int old_scrollbar_value = this->verticalScrollBar()->value();
@@ -21,14 +21,21 @@ void AOTextArea::append_chatmessage(QString p_name, QString p_message,
   this->moveCursor(QTextCursor::End);
 
   this->append("");
-  this->insertHtml("<b><font color=" + p_colour + ">" + p_name.toHtmlEscaped() +
-                   "</font></b>:&nbsp;");
+  if (!p_name.isEmpty()) {
+    this->insertHtml("<b><font color=" + p_name_colour + ">" + p_name.toHtmlEscaped() +
+                     "</font></b>:&nbsp;");
 
-  // cheap workarounds ahoy
-  p_message += " ";
+    // cheap workarounds ahoy
+    p_message += " ";
+  }
+
   QString result = p_message.toHtmlEscaped()
                        .replace("\n", "<br>")
                        .replace(url_parser_regex, "<a href='\\1'>\\1</a>");
+
+  if (!p_color.isEmpty()) {
+    result = "<font color=" + p_color + ">" + result + "</font>";
+  }
 
   this->insertHtml(result);
 

--- a/src/charselect.cpp
+++ b/src/charselect.cpp
@@ -82,7 +82,7 @@ void Courtroom::set_char_select()
       ao_app->get_element_dimensions("char_select", filename);
 
   if (f_charselect.width < 0 || f_charselect.height < 0) {
-    qDebug() << "W: did not find char_select width or height in "
+    qWarning() << "did not find char_select width or height in "
                 "courtroom_design.ini!";
     this->setFixedSize(714, 668);
   }

--- a/src/courtroom.cpp
+++ b/src/courtroom.cpp
@@ -111,11 +111,13 @@ Courtroom::Courtroom(AOApplication *p_ao_app) : QMainWindow()
   log_timestamp = ao_app->get_log_timestamp();
   log_timestamp_format = ao_app->get_log_timestamp_format();
 
-  ui_ms_chatlog = new AOTextArea(this);
-  ui_ms_chatlog->setReadOnly(true);
-  ui_ms_chatlog->setOpenExternalLinks(true);
-  ui_ms_chatlog->hide();
-  ui_ms_chatlog->setObjectName("ui_ms_chatlog");
+  ui_debug_log = new AOTextArea(this);
+  ui_debug_log->setReadOnly(true);
+  ui_debug_log->setOpenExternalLinks(true);
+  ui_debug_log->hide();
+  ui_debug_log->setObjectName("ui_debug_log");
+  connect(ao_app, &AOApplication::qt_log_message,
+          this, &Courtroom::debug_message_handler);
 
   ui_server_chatlog = new AOTextArea(this);
   ui_server_chatlog->setReadOnly(true);
@@ -560,7 +562,7 @@ void Courtroom::set_courtroom_size()
       ao_app->get_element_dimensions("courtroom", filename);
 
   if (f_courtroom.width < 0 || f_courtroom.height < 0) {
-    qDebug() << "W: did not find courtroom width or height in " << filename;
+    qWarning() << "did not find courtroom width or height in " << filename;
 
     this->setFixedSize(714, 668);
   }
@@ -679,7 +681,7 @@ void Courtroom::set_widgets()
       ao_app->get_element_dimensions("chat_arrow", "courtroom_design.ini");
 
   if (design_ini_result.width < 0 || design_ini_result.height < 0) {
-    qDebug() << "W: could not find \"chat_arrow\" in courtroom_design.ini";
+    qWarning() << "could not find \"chat_arrow\" in courtroom_design.ini";
     ui_vp_chat_arrow->hide();
   }
   else {
@@ -725,8 +727,9 @@ void Courtroom::set_widgets()
   ui_ic_chatlog->setPlaceholderText(log_goes_downwards ? "▼ " + tr("Log goes down") + " ▼"
                                                        : "▲ " + tr("Log goes up") + " ▲");
 
-  set_size_and_pos(ui_ms_chatlog, "ms_chatlog");
-  ui_ms_chatlog->setFrameShape(QFrame::NoFrame);
+  set_size_and_pos(ui_debug_log, "ms_chatlog"); // Old name
+  set_size_and_pos(ui_debug_log, "debug_log"); // New name
+  ui_debug_log->setFrameShape(QFrame::NoFrame);
 
   set_size_and_pos(ui_server_chatlog, "server_chatlog");
   ui_server_chatlog->setFrameShape(QFrame::NoFrame);
@@ -786,7 +789,7 @@ void Courtroom::set_widgets()
       ao_app->get_element_dimensions("music_display", "courtroom_design.ini");
 
   if (design_ini_result.width < 0 || design_ini_result.height < 0) {
-    qDebug() << "W: could not find \"music_display\" in courtroom_design.ini";
+    qWarning() << "could not find \"music_display\" in courtroom_design.ini";
     ui_music_display->hide();
   }
   else {
@@ -1139,7 +1142,7 @@ void Courtroom::set_fonts(QString p_char)
   set_font(ui_vp_showname, "", "showname", p_char);
   set_font(ui_vp_message, "", "message", p_char);
   set_font(ui_ic_chatlog, "", "ic_chatlog", p_char);
-  set_font(ui_ms_chatlog, "", "ms_chatlog", p_char);
+  set_font(ui_debug_log, "", "debug_log", p_char);
   set_font(ui_server_chatlog, "", "server_chatlog", p_char);
   set_font(ui_music_list, "", "music_list", p_char);
   set_font(ui_area_list, "", "area_list", p_char);
@@ -1248,7 +1251,7 @@ void Courtroom::set_size_and_pos(QWidget *p_widget, QString p_identifier, QStrin
       ao_app->get_element_dimensions(p_identifier, filename, p_misc);
 
   if (design_ini_result.width < 0 || design_ini_result.height < 0) {
-    qDebug() << "W: could not find \"" << p_identifier << "\" in " << filename;
+    qWarning() << "could not find \"" << p_identifier << "\" in " << filename;
     p_widget->hide();
   }
   else {
@@ -1282,7 +1285,7 @@ QPoint Courtroom::get_theme_pos(QString p_identifier)
       ao_app->get_element_dimensions(p_identifier, filename);
 
   if (design_ini_result.width < 0 || design_ini_result.height < 0) {
-    qDebug() << "W: could not find \"" << p_identifier << "\" in " << filename;
+    qWarning() << "could not find \"" << p_identifier << "\" in " << filename;
     return QPoint(0, 0);
   }
   else {
@@ -1733,12 +1736,27 @@ void Courtroom::list_areas()
   }
 }
 
-void Courtroom::append_ms_chatmessage(QString f_name, QString f_message)
+void Courtroom::debug_message_handler(QtMsgType type, const QMessageLogContext &context,
+                                      const QString &msg)
 {
-  ui_ms_chatlog->append_chatmessage(
-      f_name, f_message,
-      ao_app->get_color("ms_chatlog_sender_color", "courtroom_fonts.ini")
-          .name());
+  const QMap<QtMsgType, QString> colors = {
+    {QtDebugMsg, "debug"},
+    {QtInfoMsg, "info"},
+    {QtWarningMsg, "warn"},
+    {QtCriticalMsg, "critical"},
+    {QtFatalMsg, "fatal"}
+  };
+  const QString color_id = QString("debug_log_%1_color").arg(colors.value(type, "info"));
+  ui_debug_log->append_chatmessage(
+      QString(), qFormatLogMessage(type, context, msg),
+      QString(), ao_app->get_color(color_id, "courtroom_fonts.ini").name());
+}
+
+void Courtroom::append_debug_message(QString f_message)
+{
+  ui_debug_log->append_chatmessage(
+      QString(), f_message,
+      ao_app->get_color("debug_log_color", "courtroom_fonts.ini").name());
 }
 
 void Courtroom::append_server_chatmessage(QString p_name, QString p_message,
@@ -1757,7 +1775,6 @@ void Courtroom::append_server_chatmessage(QString p_name, QString p_message,
     // Emulate successful authentication
     on_authentication_state_received(1);
   }
-
 
   ui_server_chatlog->append_chatmessage(p_name, p_message, color);
 
@@ -2492,7 +2509,7 @@ void Courtroom::handle_emote_mod(int emote_mod, bool p_immediate)
     break;
   default:
     // This should never happen, but if it does anyway, yell in the console about it.
-    qDebug() << "W: invalid emote mod: " << QString::number(emote_mod);
+    qWarning() << "invalid emote mod: " << QString::number(emote_mod);
   }
 }
 
@@ -2732,7 +2749,7 @@ void Courtroom::initialize_chatbox()
   pos_size_type design_ini_result = ao_app->get_element_dimensions(
       "chat_arrow", "courtroom_design.ini", p_misc);
   if (design_ini_result.width < 0 || design_ini_result.height < 0) {
-    qDebug() << "W: could not find \"chat_arrow\" in courtroom_design.ini";
+    qWarning() << "could not find \"chat_arrow\" in courtroom_design.ini";
     ui_vp_chat_arrow->hide();
   }
   else {
@@ -3246,7 +3263,7 @@ void Courtroom::play_preanim(bool immediate)
     else
       anim_state = 1;
     preanim_done();
-    qDebug() << "W: could not find " + anim_to_find;
+    qWarning() << "could not find " + anim_to_find;
     return;
   }
   ui_vp_player_char->set_static_duration(preanim_duration);
@@ -4199,14 +4216,14 @@ void Courtroom::on_ooc_return_pressed()
 void Courtroom::on_ooc_toggle_clicked()
 {
   if (server_ooc) {
-    ui_ms_chatlog->show();
+    ui_debug_log->show();
     ui_server_chatlog->hide();
-    ui_ooc_toggle->setText(tr("Master"));
+    ui_ooc_toggle->setText(tr("Debug"));
 
     server_ooc = false;
   }
   else {
-    ui_ms_chatlog->hide();
+    ui_debug_log->hide();
     ui_server_chatlog->show();
     ui_ooc_toggle->setText(tr("Server"));
 
@@ -4623,7 +4640,7 @@ void Courtroom::on_mute_list_clicked(QModelIndex p_index)
   }
 
   if (f_cid < 0 || f_cid >= char_list.size()) {
-    qDebug() << "W: " << real_char << " not present in char_list";
+    qWarning() << "" << real_char << " not present in char_list";
     return;
   }
 
@@ -4657,7 +4674,7 @@ void Courtroom::on_pair_list_clicked(QModelIndex p_index)
   }
 
   if (f_cid < -2 || f_cid >= char_list.size()) {
-    qDebug() << "W: " << real_char << " not present in char_list";
+    qWarning() << "" << real_char << " not present in char_list";
     return;
   }
 
@@ -5104,7 +5121,7 @@ void Courtroom::on_text_color_changed(int p_color)
     int c = color_row_to_number.at(p_color);
     QString markdown_start = color_markdown_start_list.at(c);
     if (markdown_start.isEmpty()) {
-      qDebug() << "W: Color list dropdown selected a non-existent markdown "
+      qWarning() << "Color list dropdown selected a non-existent markdown "
                   "start character";
       return;
     }

--- a/src/lobby.cpp
+++ b/src/lobby.cpp
@@ -116,7 +116,7 @@ void Lobby::set_widgets()
   pos_size_type f_lobby = ao_app->get_element_dimensions("lobby", filename);
 
   if (f_lobby.width < 0 || f_lobby.height < 0) {
-    qDebug() << "W: did not find lobby width or height in " << filename;
+    qWarning() << "did not find lobby width or height in " << filename;
 
     // Most common symptom of bad config files and missing assets.
     call_notice(
@@ -205,7 +205,7 @@ void Lobby::set_size_and_pos(QWidget *p_widget, QString p_identifier)
       ao_app->get_element_dimensions(p_identifier, filename);
 
   if (design_ini_result.width < 0 || design_ini_result.height < 0) {
-    qDebug() << "W: could not find " << p_identifier << " in " << filename;
+    qWarning() << "could not find " << p_identifier << " in " << filename;
     p_widget->hide();
   }
   else {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -12,6 +12,8 @@
 
 int main(int argc, char *argv[])
 {
+  qSetMessagePattern("%{type}: %{if-category}%{category}: %{endif}%{message}");
+
 #if QT_VERSION > QT_VERSION_CHECK(5, 6, 0)
   // High-DPI support is for Qt version >=5.6.
   // However, many Linux distros still haven't brought their stable/LTS

--- a/src/networkmanager.cpp
+++ b/src/networkmanager.cpp
@@ -149,8 +149,8 @@ void NetworkManager::on_srv_lookup()
                  ms_socket->state() != QAbstractSocket::HostLookupState &&
                  ms_socket->error() != -1) {
           qDebug() << ms_socket->error();
-          qWarning() << "Error connecting to master server:"
-                     << ms_socket->errorString();
+          qCritical() << "Error connecting to master server:"
+                      << ms_socket->errorString();
           ms_socket->abort();
           ms_socket->close();
           break;

--- a/src/packet_distribution.cpp
+++ b/src/packet_distribution.cpp
@@ -29,7 +29,7 @@ void AOApplication::ms_packet_received(AOPacket *p_packet)
       QStringList sub_contents = i_string.split("&");
 
       if (sub_contents.size() < 4) {
-        qDebug() << "W: malformed packet";
+        qWarning() << "malformed packet";
         continue;
       }
 
@@ -63,7 +63,8 @@ void AOApplication::ms_packet_received(AOPacket *p_packet)
       w_lobby->append_chatmessage(f_name, f_message);
     }
     if (courtroom_constructed && courtroom_loaded) {
-      w_courtroom->append_ms_chatmessage(f_name, f_message);
+      w_courtroom->append_server_chatmessage(tr("[Global] %1").arg(f_name),
+                                             f_message, "0");
     }
   }
   else if (header == "AO2CHECK") {
@@ -453,7 +454,8 @@ void AOApplication::server_packet_received(AOPacket *p_packet)
       goto end;
 
     if (lobby_constructed)
-      w_courtroom->append_ms_chatmessage("", w_lobby->get_chatlog());
+      w_courtroom->append_server_chatmessage(tr("[Global log]"),
+                                             w_lobby->get_chatlog(), "0");
 
     w_courtroom->character_loading_finished();
     w_courtroom->done_received();

--- a/src/text_file_functions.cpp
+++ b/src/text_file_functions.cpp
@@ -167,7 +167,7 @@ QString AOApplication::read_file(QString filename)
   QFile f_log(filename);
 
   if (!f_log.open(QIODevice::ReadOnly | QIODevice::Text)) {
-    qDebug() << "Couldn't open" << filename;
+    qWarning() << "Couldn't open" << filename;
     return "";
   }
 
@@ -699,7 +699,7 @@ QString AOApplication::get_emote_comment(QString p_char, int p_emote)
   QStringList result_contents = f_result.split("#");
 
   if (result_contents.size() < 4) {
-    qDebug() << "W: misformatted char.ini: " << p_char << ", " << p_emote;
+    qWarning() << "misformatted char.ini: " << p_char << ", " << p_emote;
     return "normal";
   }
   return result_contents.at(0);
@@ -713,7 +713,7 @@ QString AOApplication::get_pre_emote(QString p_char, int p_emote)
   QStringList result_contents = f_result.split("#");
 
   if (result_contents.size() < 4) {
-    qDebug() << "W: misformatted char.ini: " << p_char << ", " << p_emote;
+    qWarning() << "misformatted char.ini: " << p_char << ", " << p_emote;
     return "";
   }
   return result_contents.at(1);
@@ -727,7 +727,7 @@ QString AOApplication::get_emote(QString p_char, int p_emote)
   QStringList result_contents = f_result.split("#");
 
   if (result_contents.size() < 4) {
-    qDebug() << "W: misformatted char.ini: " << p_char << ", " << p_emote;
+    qWarning() << "misformatted char.ini: " << p_char << ", " << p_emote;
     return "normal";
   }
   return result_contents.at(2);
@@ -741,7 +741,7 @@ int AOApplication::get_emote_mod(QString p_char, int p_emote)
   QStringList result_contents = f_result.split("#");
 
   if (result_contents.size() < 4) {
-    qDebug() << "W: misformatted char.ini: " << p_char << ", "
+    qWarning() << "misformatted char.ini: " << p_char << ", "
              << QString::number(p_emote);
     return 0;
   }


### PR DESCRIPTION
Since the MS chat has been disabled for quite some time now (and we aren't planning on bringing it back since Discord, Guilded etc. have better chat features), I decided to go ahead and change the pane into a debug log to keep it useful and avoid creating a gaping hole in themes.

![image](https://user-images.githubusercontent.com/5247009/147396386-41595ee7-150f-4aa8-b9ad-9d3bd6abf7bc.png)

Though, maybe it is worth removing the whole switcher and keeping the debug log hidden away where it can't scare people.