### PR TITLE
Remove 'gender' as a valid ini option

### DIFF
--- a/include/aoapplication.h
+++ b/include/aoapplication.h
@@ -464,7 +464,7 @@ public:
   // Returns the desk modifier for p_char's p_emote
   int get_desk_mod(QString p_char, int p_emote);
 
-  // Returns p_char's blips (previously called their "gender")
+  // Returns p_char's blips
   QString get_blips(QString p_char);
 
   // Get a property of a given emote, or get it from "options" if emote doesn't have it

--- a/src/text_file_functions.cpp
+++ b/src/text_file_functions.cpp
@@ -608,12 +608,11 @@ QString AOApplication::get_blips(QString p_char)
     f_result = "male";
   }
 
-  if (!file_exists(get_sfx_suffix(get_sounds_path(f_result)))) {
-    if (file_exists(get_sfx_suffix(get_sounds_path("../blips/" + f_result))))
-      return "../blips/" + f_result; // Return the cool kids variant
-
-    return "sfx-blip" + f_result; // Return legacy variant
+  if (file_exists(get_sfx_suffix(get_sounds_path("../blips/" + f_result)))) {
+    return "../blips/" + f_result; // Return the cool kids version
   }
+
+  qWarning() << "Could not find blips in /sounds/blips/ for " << p_char;
   return f_result;
 }
 

--- a/src/text_file_functions.cpp
+++ b/src/text_file_functions.cpp
@@ -604,9 +604,8 @@ QString AOApplication::get_blips(QString p_char)
   QString f_result = read_char_ini(p_char, "blips", "Options");
 
   if (f_result == "") {
-    f_result = read_char_ini(p_char, "gender", "Options"); // not very PC, FanatSors
-    if (f_result == "")
-      f_result = "male";
+    qWarning() << "Could not find blips option in character (char.ini) of " << p_char;
+    f_result = "male";
   }
 
   if (!file_exists(get_sfx_suffix(get_sounds_path(f_result)))) {


### PR DESCRIPTION
Given that it has now been around a year that blips has replaced gender as the primary option to set a character blip it has been more than enough time for servers to adjust their content to the new standard.

This also removes the legacy lookup variant for blips.

With in-client debug and warnings on the horizon this change is not as much of an issue as it was with prior clients as users can check error messages directly.