### PR TITLE
Fix MSVC builds freezing due to AOLayer concurrency issue

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,9 +31,9 @@ endif()
 target_include_directories(Attorney_Online PRIVATE include)
 
 # Target Lib
-find_package(Qt5 COMPONENTS Core Gui Network Widgets REQUIRED)
+find_package(Qt5 COMPONENTS Core Gui Network Widgets Concurrent REQUIRED)
 target_link_directories(Attorney_Online PRIVATE lib)
-target_link_libraries(Attorney_Online PRIVATE Qt5::Core Qt5::Gui Qt5::Network Qt5::Widgets
+target_link_libraries(Attorney_Online PRIVATE Qt5::Core Qt5::Gui Qt5::Network Qt5::Widgets Qt5::Concurrent
     bass bassopus discord-rpc)
 target_compile_definitions(Attorney_Online PRIVATE DISCORD)
 

--- a/include/aolayer.h
+++ b/include/aolayer.h
@@ -148,7 +148,7 @@ private:
 
   // used in populate_vectors
   void load_next_frame();
-  bool exit_loop; //awful solution but i'm not fucking using QThread
+  std::atomic_bool exit_loop; //awful solution but i'm not fucking using QThread
   QFuture<void> frame_loader;
   QMutex mutex;
   QWaitCondition frameAdded;


### PR DESCRIPTION
Variables accessed across threads should be atomic; otherwise it is Undefined Behavior(TM) and can lead to subtle bugs like this one. Apparently MSVC is more strict about this than GCC and Clang - surprised it hadn't been caught before.

Also gave AOLayer its own thread pool and switched some lock calls to use QMutexLocker semantics.