### PR TITLE
Fix various AOLayer issues

### DIFF
--- a/include/aolayer.h
+++ b/include/aolayer.h
@@ -148,7 +148,7 @@ private:
 
   // used in populate_vectors
   void load_next_frame();
-  std::atomic_bool exit_loop; //awful solution but i'm not fucking using QThread
+  std::atomic_bool exit_loop = false; //awful solution but i'm not fucking using QThread
   QFuture<void> frame_loader;
   QMutex mutex;
   QWaitCondition frameAdded;

--- a/src/aolayer.cpp
+++ b/src/aolayer.cpp
@@ -284,9 +284,11 @@ void AOLayer::start_playback(QString p_image)
     this->kill();
     return;
   }
-  QMutexLocker locker(&mutex);
+
   if (frame_loader.isRunning())
     exit_loop = true; // tell the loader to stop, we have a new image to load
+
+  QMutexLocker locker(&mutex);
   this->show();
 
   if (!ao_app->is_continuous_enabled()) {
@@ -561,13 +563,20 @@ void AOLayer::movie_ticker()
 }
 
 void AOLayer::populate_vectors() {
-    while (!exit_loop && movie_frames.size() < max_frames) {
-        load_next_frame();
 #ifdef DEBUG_MOVIE
-        qDebug() << "[AOLayer::populate_vectors] Loaded frame" << movie_frames.size();
+  qDebug() << "[AOLayer::populate_vectors] Started thread";
 #endif
-    }
-    exit_loop = false;
+  while (!exit_loop && movie_frames.size() < max_frames) {
+    load_next_frame();
+#ifdef DEBUG_MOVIE
+    qDebug() << "[AOLayer::populate_vectors] Loaded frame" << movie_frames.size();
+#endif
+  }
+#ifdef DEBUG_MOVIE
+  if (exit_loop)
+    qDebug() << "[AOLayer::populate_vectors] Exit requested";
+#endif
+  exit_loop = false;
 }
 
 void AOLayer::load_next_frame() {

--- a/src/aolayer.cpp
+++ b/src/aolayer.cpp
@@ -241,6 +241,8 @@ void EffectLayer::load_image(QString p_filename, bool p_looping)
     play_once = true;
   continuous = false;
   force_continuous = true;
+  cull_image = false;
+
   start_playback(p_filename); // path resolution is handled by the caller for EffectLayer objects
   play();
 }
@@ -315,10 +317,10 @@ void AOLayer::start_playback(QString p_image)
   qDebug() << "[AOLayer::start_playback] Stretch:" << stretch << "Filename:" << p_image;
 #endif
   m_reader.setFileName(p_image);
-  if (m_reader.loopCount() == 0)
-    play_once = true;
   last_max_frames = max_frames;
   max_frames = m_reader.imageCount();
+  if (m_reader.loopCount() == 0 && max_frames > 1)
+    play_once = true;
   if (!continuous
           || ((continuous) && (max_frames != last_max_frames))
           || max_frames == 0

--- a/src/text_file_functions.cpp
+++ b/src/text_file_functions.cpp
@@ -875,14 +875,15 @@ QString AOApplication::get_effect(QString effect, QString p_char,
   if (p_folder == "")
     p_folder = read_char_ini(p_char, "effects", "Options");
 
-  QString p_path = get_image("effects/" + effect, current_theme, get_subtheme(), default_theme, "");
-  QString p_misc_path = get_image(effect, current_theme, get_subtheme(), default_theme, p_folder);
+  QStringList paths {
+    get_image("effects/" + effect, current_theme, get_subtheme(), default_theme, ""),
+    get_image(effect, current_theme, get_subtheme(), default_theme, p_folder)
+  };
 
-  if (!file_exists(p_misc_path) && !file_exists(p_path))
-    return "";
-  else if (file_exists(p_misc_path))
-    return p_misc_path;
-  return p_path;
+  for (const auto &p : paths)
+    if (file_exists(p))
+      return p;
+  return {};
 }
 
 QString AOApplication::get_effect_property(QString fx_name, QString p_char,


### PR DESCRIPTION
- In some cases, effects with one frame are loaded but unexpectedly disappear since the animation is considered "finished." Such static effects should be treated as infinitely looping animations.
- Fixed the `realization.png` UI button being loaded as the actual effect instead of the correct `realization` effect in the effects folder.
- Fixed another deadlock with async loading because exit_loop is not initialized properly.
- Fixed a potential race condition with async loading where the main thread does not wait for the previous load task to finish before starting a new load task. 