### PR TITLE
Allow character select list to refresh even if client is already loaded in

### DIFF
--- a/include/courtroom.h
+++ b/include/courtroom.h
@@ -73,6 +73,7 @@ public:
   void append_evidence(evi_type p_evi) { evidence_list.append(p_evi); }
   void append_music(QString f_music) { music_list.append(f_music); }
   void append_area(QString f_area) { area_list.append(f_area); }
+  void clear_chars() { char_list.clear(); }
   void clear_music() { music_list.clear(); }
   void clear_areas() { area_list.clear(); }
 

--- a/src/charselect.cpp
+++ b/src/charselect.cpp
@@ -306,7 +306,6 @@ void Courtroom::character_loading_finished()
     }
   }
   ui_char_list->expandAll();
-//  filter_character_list();
 }
 
 void Courtroom::filter_character_list()

--- a/src/charselect.cpp
+++ b/src/charselect.cpp
@@ -243,6 +243,7 @@ void Courtroom::character_loading_finished()
       delete item;
     }
     ui_char_button_list.clear();
+    ui_char_list->clear();
   }
 
   // First, we'll make all the character buttons in the very beginning.
@@ -305,7 +306,7 @@ void Courtroom::character_loading_finished()
     }
   }
   ui_char_list->expandAll();
-  filter_character_list();
+//  filter_character_list();
 }
 
 void Courtroom::filter_character_list()

--- a/src/courtroom.cpp
+++ b/src/courtroom.cpp
@@ -1305,13 +1305,14 @@ void Courtroom::done_received()
 
   if (char_list.size() > 0)
   {
-    set_char_select_page();
+    //set_char_select_page();
     set_char_select();
   }
   else
   {
     update_character(m_cid);
     enter_courtroom();
+    set_courtroom_size();
   }
 
   set_mute_list();

--- a/src/courtroom.cpp
+++ b/src/courtroom.cpp
@@ -1305,7 +1305,6 @@ void Courtroom::done_received()
 
   if (char_list.size() > 0)
   {
-    //set_char_select_page();
     set_char_select();
   }
   else

--- a/src/packet_distribution.cpp
+++ b/src/packet_distribution.cpp
@@ -256,16 +256,14 @@ void AOApplication::server_packet_received(AOPacket *p_packet)
       // temporary. the CharsCheck packet sets this properly
       f_char.taken = false;
 
+      w_courtroom->append_char(f_char);
+
       if (!courtroom_loaded) {
         ++loaded_chars;
         w_lobby->set_loading_text(tr("Loading chars:\n%1/%2")
                                       .arg(QString::number(loaded_chars))
                                       .arg(QString::number(char_list_size)));
-      }
 
-      w_courtroom->append_char(f_char);
-
-      if (!courtroom_loaded) {
         int total_loading_size =
             char_list_size * 2 + evidence_list_size + music_list_size;
         int loading_value = int(

--- a/src/packet_distribution.cpp
+++ b/src/packet_distribution.cpp
@@ -240,9 +240,9 @@ void AOApplication::server_packet_received(AOPacket *p_packet)
   }
 
   else if (header == "SC") {
-    if (!courtroom_constructed || courtroom_loaded)
+    if (!courtroom_constructed)
       goto end;
-
+    w_courtroom->clear_chars();
     for (int n_element = 0; n_element < f_contents.size(); ++n_element) {
       QStringList sub_elements = f_contents.at(n_element).split("&");
 
@@ -256,24 +256,30 @@ void AOApplication::server_packet_received(AOPacket *p_packet)
       // temporary. the CharsCheck packet sets this properly
       f_char.taken = false;
 
-      ++loaded_chars;
-
-      w_lobby->set_loading_text(tr("Loading chars:\n%1/%2")
-                                    .arg(QString::number(loaded_chars))
-                                    .arg(QString::number(char_list_size)));
+      if (!courtroom_loaded) {
+        ++loaded_chars;
+        w_lobby->set_loading_text(tr("Loading chars:\n%1/%2")
+                                      .arg(QString::number(loaded_chars))
+                                      .arg(QString::number(char_list_size)));
+      }
 
       w_courtroom->append_char(f_char);
 
-      int total_loading_size =
-          char_list_size * 2 + evidence_list_size + music_list_size;
-      int loading_value = int(
-          ((loaded_chars + generated_chars + loaded_music + loaded_evidence) /
-           static_cast<double>(total_loading_size)) *
-          100);
-      w_lobby->set_loading_value(loading_value);
+      if (!courtroom_loaded) {
+        int total_loading_size =
+            char_list_size * 2 + evidence_list_size + music_list_size;
+        int loading_value = int(
+            ((loaded_chars + generated_chars + loaded_music + loaded_evidence) /
+             static_cast<double>(total_loading_size)) *
+            100);
+        w_lobby->set_loading_value(loading_value);
+      }
     }
 
-    send_server_packet(new AOPacket("RM#%"));
+    if (!courtroom_loaded)
+      send_server_packet(new AOPacket("RM#%"));
+    else
+      w_courtroom->character_loading_finished();
     append_to_demofile(f_packet_encoded);
   }
   else if (header == "SM") {


### PR DESCRIPTION
Allow "SC" packet to be used to refresh the character list even if the client is loaded in
Fix tree list of characters not being cleared properly between "SC" packets
Fix client theme breaking when joining a server with empty character select list
Closes #644 