### PR TITLE
Fix SFX dropdown regressions, make dropdown play sound if custom sound is listed regardless of Pre

### DIFF
--- a/include/datatypes.h
+++ b/include/datatypes.h
@@ -101,6 +101,13 @@ enum CHAT_MESSAGE {
   EFFECTS
 };
 
+enum EMOTE_MOD {
+  IDLE = 0,
+  PREANIM = 1,
+  ZOOM = 5,
+  PREANIM_ZOOM = 6,
+};
+
 enum MUSIC_EFFECT { FADE_IN = 1, FADE_OUT = 2, SYNC_POS = 4 };
 
 #endif // DATATYPES_H

--- a/src/courtroom.cpp
+++ b/src/courtroom.cpp
@@ -1866,58 +1866,69 @@ void Courtroom::on_chat_return_pressed()
   packet_contents.append(f_side);
 
   int f_emote_mod = ao_app->get_emote_mod(current_char, current_emote);
-  QString f_sfx = "0";
+  QString f_sfx = "1";
 // EMOTE MOD OVERRIDES:
   // Emote_mod 2 is only used by objection check later, having it in the char.ini does nothing
-  if (f_emote_mod == 2)
-    f_emote_mod = 1;
+  if (f_emote_mod == 2) {
+    f_emote_mod = PREANIM;
+  }
   // No clue what emote_mod 3 is even supposed to be.
-  if (f_emote_mod == 3)
-    f_emote_mod = 0;
+  if (f_emote_mod == 3) {
+    f_emote_mod = IDLE;
+  }
   // Emote_mod 4 seems to be a legacy bugfix that just refers it to emote_mod 5 which is zoom emote
-  if (f_emote_mod == 4)
-    f_emote_mod = 5;
+  if (f_emote_mod == 4) {
+    f_emote_mod = ZOOM;
+  }
   // If we have "pre" on, and immediate is not checked
   if (ui_pre->isChecked() && !ui_immediate->isChecked()) {
     // Turn idle into preanim
-    if (f_emote_mod == 0)
-      f_emote_mod = 1;
+    if (f_emote_mod == IDLE) {
+      f_emote_mod = PREANIM;
+    }
     // Turn zoom into preanim zoom
-    else if (f_emote_mod == 5 && ao_app->prezoom_enabled)
-      f_emote_mod = 6;
+    else if (f_emote_mod == ZOOM && ao_app->prezoom_enabled) {
+      f_emote_mod = PREANIM_ZOOM;
+    }
     // Play the sfx
     f_sfx = get_char_sfx();
   }
   // If we have "pre" off, or immediate is checked
   else {
     // Turn preanim into idle
-    if (f_emote_mod == 1)
-      f_emote_mod = 0;
+    if (f_emote_mod == PREANIM) {
+      f_emote_mod = IDLE;
+    }
     // Turn preanim zoom into zoom
-    else if (f_emote_mod == 6)
-      f_emote_mod = 5;
+    else if (f_emote_mod == PREANIM_ZOOM) {
+      f_emote_mod = ZOOM;
+    }
 
     // Play the sfx if pre is checked
-    if (ui_pre->isChecked())
+    if (ui_pre->isChecked()) {
       f_sfx = get_char_sfx();
+    }
   }
 
 // TODO: deprecate this garbage. See https://github.com/AttorneyOnline/AO2-Client/issues/692
   // If our objection is enabled
   if (objection_state > 0) {
     // Turn preanim zoom emote mod into non-pre
-    if (f_emote_mod == 5)
-      f_emote_mod = 6;
+    if (f_emote_mod == ZOOM) {
+      f_emote_mod = PREANIM_ZOOM;
+    }
     // Turn it into preanim objection emote mod
-    else
+    else {
       f_emote_mod = 2;
+    }
     // Play the sfx
     f_sfx = get_char_sfx();
   }
 
   // Custom sfx override via sound list dropdown.
-  if (!custom_sfx.isEmpty() || ui_sfx_dropdown->currentIndex() != 0)
+  if (!custom_sfx.isEmpty() || ui_sfx_dropdown->currentIndex() != 0) {
     f_sfx = get_char_sfx();
+  }
 
   packet_contents.append(f_sfx);
   packet_contents.append(QString::number(f_emote_mod));

--- a/src/courtroom.cpp
+++ b/src/courtroom.cpp
@@ -1865,8 +1865,6 @@ void Courtroom::on_chat_return_pressed()
 
   packet_contents.append(f_side);
 
-  packet_contents.append(get_char_sfx());
-
   int f_emote_mod = ao_app->get_emote_mod(current_char, current_emote);
 
   // needed or else legacy won't understand what we're saying
@@ -1889,6 +1887,12 @@ void Courtroom::on_chat_return_pressed()
       f_emote_mod = 5;
   }
 
+  // If our sound list is on "Default", it will play a preanim sfx associated with that char's emote only when pre is checked.
+  // Otherwise, the sfx will always be played.
+  if (!custom_sfx.isEmpty() || ui_sfx_dropdown->currentIndex() != 0 || f_emote_mod == 1 || f_emote_mod == 2 || f_emote_mod == 6)
+    packet_contents.append(get_char_sfx());
+  else
+    packet_contents.append("1");
   packet_contents.append(QString::number(f_emote_mod));
   packet_contents.append(QString::number(m_cid));
 
@@ -2542,7 +2546,8 @@ void Courtroom::handle_ic_message()
   else
   {
     start_chat_ticking();
-    play_sfx();
+    if (emote_mod == 1 || emote_mod == 2 || emote_mod == 6 || immediate)
+      play_sfx();
   }
 
   // if we have instant objections disabled, and queue is not empty, check if next message after this is an objection.
@@ -4597,8 +4602,9 @@ QString Courtroom::get_char_sfx()
   if (!custom_sfx.isEmpty())
     return custom_sfx;
   int index = ui_sfx_dropdown->currentIndex();
-  if (index == 0) // Default
+  if (index == 0) { // Default
     return ao_app->get_sfx_name(current_char, current_emote);
+  }
   if (index == 1) // Nothing
     return "1";
   QString sfx = sound_list[index-2].split("=")[0].trimmed();

--- a/src/courtroom.cpp
+++ b/src/courtroom.cpp
@@ -2054,7 +2054,7 @@ void Courtroom::reset_ui()
   ui_screenshake->set_image("screenshake");
   ui_evidence_present->set_image("present");
 
-  if (ui_pre->isChecked() && !ao_app->is_stickysounds_enabled()) {
+  if (!ao_app->is_stickysounds_enabled()) {
     ui_sfx_dropdown->setCurrentIndex(0);
     ui_sfx_remove->hide();
     custom_sfx = "";
@@ -2497,6 +2497,7 @@ void Courtroom::handle_emote_mod(int emote_mod, bool p_immediate)
     // If immediate is not ticked on...
     if (!p_immediate)
     {
+      play_sfx();
       // Skip preanim.
       handle_ic_speaking();
     }
@@ -2541,8 +2542,7 @@ void Courtroom::handle_ic_message()
   else
   {
     start_chat_ticking();
-    if (emote_mod == 1 || emote_mod == 2 || emote_mod == 6 || immediate)
-      play_sfx();
+    play_sfx();
   }
 
   // if we have instant objections disabled, and queue is not empty, check if next message after this is an objection.

--- a/src/courtroom.cpp
+++ b/src/courtroom.cpp
@@ -1866,33 +1866,60 @@ void Courtroom::on_chat_return_pressed()
   packet_contents.append(f_side);
 
   int f_emote_mod = ao_app->get_emote_mod(current_char, current_emote);
-
-  // needed or else legacy won't understand what we're saying
-  if (objection_state > 0 && ui_pre->isChecked()) {
-    if (f_emote_mod == 4 || f_emote_mod == 5)
-      f_emote_mod = 6;
-    else
-      f_emote_mod = 2;
-  }
-  else if (ui_pre->isChecked() && !ui_immediate->isChecked()) {
+  QString f_sfx = "0";
+// EMOTE MOD OVERRIDES:
+  // Emote_mod 2 is only used by objection check later, having it in the char.ini does nothing
+  if (f_emote_mod == 2)
+    f_emote_mod = 1;
+  // No clue what emote_mod 3 is even supposed to be.
+  if (f_emote_mod == 3)
+    f_emote_mod = 0;
+  // Emote_mod 4 seems to be a legacy bugfix that just refers it to emote_mod 5 which is zoom emote
+  if (f_emote_mod == 4)
+    f_emote_mod = 5;
+  // If we have "pre" on, and immediate is not checked
+  if (ui_pre->isChecked() && !ui_immediate->isChecked()) {
+    // Turn idle into preanim
     if (f_emote_mod == 0)
       f_emote_mod = 1;
+    // Turn zoom into preanim zoom
     else if (f_emote_mod == 5 && ao_app->prezoom_enabled)
       f_emote_mod = 6;
+    // Play the sfx
+    f_sfx = get_char_sfx();
   }
+  // If we have "pre" off, or immediate is checked
   else {
+    // Turn preanim into idle
     if (f_emote_mod == 1)
       f_emote_mod = 0;
-    else if (f_emote_mod == 4)
+    // Turn preanim zoom into zoom
+    else if (f_emote_mod == 6)
       f_emote_mod = 5;
+
+    // Play the sfx if pre is checked
+    if (ui_pre->isChecked())
+      f_sfx = get_char_sfx();
   }
 
-  // If our sound list is on "Default", it will play a preanim sfx associated with that char's emote only when pre is checked.
-  // Otherwise, the sfx will always be played.
-  if (!custom_sfx.isEmpty() || ui_sfx_dropdown->currentIndex() != 0 || f_emote_mod == 1 || f_emote_mod == 2 || f_emote_mod == 6)
-    packet_contents.append(get_char_sfx());
-  else
-    packet_contents.append("1");
+// TODO: deprecate this garbage. See https://github.com/AttorneyOnline/AO2-Client/issues/692
+  // If our objection is enabled
+  if (objection_state > 0) {
+    // Turn preanim zoom emote mod into non-pre
+    if (f_emote_mod == 5)
+      f_emote_mod = 6;
+    // Turn it into preanim objection emote mod
+    else
+      f_emote_mod = 2;
+    // Play the sfx
+    f_sfx = get_char_sfx();
+  }
+
+  // Custom sfx override via sound list dropdown.
+  if (!custom_sfx.isEmpty() || ui_sfx_dropdown->currentIndex() != 0)
+    f_sfx = get_char_sfx();
+
+  packet_contents.append(f_sfx);
   packet_contents.append(QString::number(f_emote_mod));
   packet_contents.append(QString::number(m_cid));
 


### PR DESCRIPTION
Fix SFX dropdown not playing a sound despite a sound being selected.
It was waiting on a preanim box to be checked, but that behavior was not intuitive. Plus this is a regression from intended behavior
However, if the soundlist option is on "Default", it will still behave as expected - so all the char.ini's are fine and do not need to be modified.

closes https://github.com/AttorneyOnline/AO2-Client/issues/633