### PR TITLE
Fix evidence system, improve evidence user experience

### DIFF
--- a/include/courtroom.h
+++ b/include/courtroom.h
@@ -757,7 +757,6 @@ private:
   AOButton *ui_evidence_transfer;
   AOButton *ui_evidence_save;
   AOButton *ui_evidence_load;
-  AOButton *ui_evidence_edit;
   QPlainTextEdit *ui_evidence_description;
 
 
@@ -888,7 +887,6 @@ private slots:
   void on_evidence_image_button_clicked();
   void on_evidence_clicked(int p_id);
   void on_evidence_double_clicked(int p_id);
-  void on_evidence_edit_clicked();
 
   void on_evidence_hover(int p_id, bool p_state);
 

--- a/src/evidence.cpp
+++ b/src/evidence.cpp
@@ -684,7 +684,6 @@ void Courtroom::evidence_close()
   ui_evidence_description->setReadOnly(true);
   ui_evidence_name->setReadOnly(true);
   ui_evidence_image_name->setReadOnly(true);
-  ui_evidence_image_button->setDisabled(true);
   ui_evidence_overlay->hide();
   ui_ic_chat_message->setFocus();
 }

--- a/src/evidence.cpp
+++ b/src/evidence.cpp
@@ -97,7 +97,7 @@ void Courtroom::initialize_evidence()
   connect(ui_evidence_name, &QLineEdit::textChanged, this,
           &Courtroom::on_evidence_edited);
   connect(ui_evidence_image_name, &QLineEdit::textChanged, this,
-          &Courtroom::on_evidence_image_name_edited);
+          &Courtroom::on_evidence_edited);
   connect(ui_evidence_description, &QPlainTextEdit::textChanged, this,
           &Courtroom::on_evidence_edited);
 

--- a/src/evidence.cpp
+++ b/src/evidence.cpp
@@ -50,7 +50,6 @@ void Courtroom::initialize_evidence()
   ui_evidence_image_button = new AOButton(ui_evidence_overlay, ao_app);
   ui_evidence_image_button->setText(tr("Choose.."));
   ui_evidence_image_button->setObjectName("ui_evidence_image_button");
-  ui_evidence_image_button->setDisabled(true);
   ui_evidence_x = new AOButton(ui_evidence_overlay, ao_app);
   ui_evidence_x->setToolTip(
       tr("Close the evidence display/editing overlay.\n"
@@ -64,12 +63,8 @@ void Courtroom::initialize_evidence()
   ui_evidence_description = new QPlainTextEdit(ui_evidence_overlay);
   ui_evidence_description->setFrameStyle(QFrame::NoFrame);
   ui_evidence_description->setToolTip(
-      tr("Click the pencil icon to edit. Press [X] to update your changes."));
+      tr("Click to edit. Press [X] to update your changes."));
   ui_evidence_description->setObjectName("ui_evidence_description");
-
-  ui_evidence_edit = new AOButton(ui_evidence_overlay, ao_app);
-  ui_evidence_edit->setToolTip(tr("Edit this piece of evidence."));
-  ui_evidence_edit->setObjectName("ui_evidence_edit");
 
   connect(ui_evidence_name, &QLineEdit::returnPressed, this,
           &Courtroom::on_evidence_name_edited);
@@ -105,7 +100,6 @@ void Courtroom::initialize_evidence()
           &Courtroom::on_evidence_image_name_edited);
   connect(ui_evidence_description, &QPlainTextEdit::textChanged, this,
           &Courtroom::on_evidence_edited);
-  connect(ui_evidence_edit, &AOButton::clicked, this, &Courtroom::on_evidence_edit_clicked);
 
   ui_evidence->hide();
 }
@@ -161,9 +155,6 @@ void Courtroom::refresh_evidence()
 
   set_size_and_pos(ui_evidence_ok, "evidence_ok");
   ui_evidence_ok->set_image("evidence_ok");
-
-  set_size_and_pos(ui_evidence_edit, "evidence_edit");
-  ui_evidence_edit->set_image("evidence_edit");
 
   set_size_and_pos(ui_evidence_switch, "evidence_switch");
   if (current_evidence_global) {
@@ -272,8 +263,7 @@ void Courtroom::set_evidence_list(QVector<evi_type> &p_evi_list)
       evidence_close();
       ui_evidence_name->setText("");
     }
-    else if (ui_evidence_description->isReadOnly()) // We haven't double clicked
-                                                    // to edit it or anything
+    else if (ui_evidence_ok->isHidden()) // We haven't clicked to edit it or anything
     {
       on_evidence_double_clicked(current_evidence);
     }
@@ -302,6 +292,7 @@ void Courtroom::set_evidence_list(QVector<evi_type> &p_evi_list)
       switch (ret) {
       case QMessageBox::Yes:
         // "Keep changes"
+        ui_evidence_ok->hide();
         break;
       case QMessageBox::No:
         // "Discard changes and keep theirs"
@@ -387,7 +378,6 @@ void Courtroom::on_evidence_name_edited()
 
 void Courtroom::on_evidence_image_name_edited()
 {
-  ui_evidence_image_name->setReadOnly(true);
   if (current_evidence >= local_evidence_list.size())
     return;
 }
@@ -417,8 +407,6 @@ void Courtroom::on_evidence_image_button_clicked()
 
 void Courtroom::on_evidence_clicked(int p_id)
 {
-  ui_evidence_name->setReadOnly(true);
-
   int f_real_id = p_id + max_evidence_on_page * current_evidence_page;
 
   if (f_real_id == local_evidence_list.size()) {
@@ -465,15 +453,16 @@ void Courtroom::on_evidence_double_clicked(int p_id)
 
   ui_evidence_description->clear();
   ui_evidence_description->appendPlainText(f_evi.description);
-  ui_evidence_description->setReadOnly(true);
-  ui_evidence_description->setToolTip(tr("Click the pencil to edit..."));
+  ui_evidence_description->setReadOnly(false);
+  ui_evidence_description->setToolTip(tr("Click to edit..."));
 
   ui_evidence_name->setText(f_evi.name);
-  ui_evidence_name->setReadOnly(true);
-  ui_evidence_name->setToolTip(tr("Click the pencil to edit..."));
+  ui_evidence_name->setReadOnly(false);
+  ui_evidence_name->setToolTip(tr("Click to edit..."));
+
   ui_evidence_image_name->setText(f_evi.image);
-  ui_evidence_image_name->setReadOnly(true);
-  ui_evidence_image_name->setToolTip(tr("Click the pencil to edit..."));
+  ui_evidence_image_name->setReadOnly(false);
+  ui_evidence_image_name->setToolTip(tr("Click to edit..."));
 
   ui_evidence_overlay->show();
   ui_evidence_ok->hide();
@@ -483,7 +472,6 @@ void Courtroom::on_evidence_double_clicked(int p_id)
 
 void Courtroom::on_evidence_hover(int p_id, bool p_state)
 {
-  ui_evidence_name->setReadOnly(true);
   int final_id = p_id + max_evidence_on_page * current_evidence_page;
 
   if (p_state) {
@@ -592,11 +580,7 @@ void Courtroom::on_evidence_x_clicked()
 
 void Courtroom::on_evidence_ok_clicked()
 {
-  ui_evidence_name->setReadOnly(true);
-  ui_evidence_description->setReadOnly(true);
-  ui_evidence_image_name->setReadOnly(true);
-  ui_evidence_edit->show();
-  ui_evidence_image_button->setDisabled(true);
+  ui_evidence_ok->hide();
   if (current_evidence < local_evidence_list.size()) {
     evi_type f_evi = local_evidence_list.at(current_evidence);
     if (current_evidence_global) {
@@ -679,22 +663,6 @@ void Courtroom::on_evidence_transfer_clicked()
   msgBox->exec();
 }
 
-void Courtroom::on_evidence_edit_clicked()
-{
-    if (!ui_evidence_overlay->isVisible())
-        return;
-    if (!ui_evidence_edit->isHidden()) {
-        ui_evidence_name->setReadOnly(false);
-        ui_evidence_image_name->setReadOnly(false);
-        ui_evidence_description->setReadOnly(false);
-        ui_evidence_image_button->setDisabled(false);
-        ui_evidence_edit->hide();
-    }
-    else {
-        return;
-    }
-}
-
 void Courtroom::on_evidence_edited()
 {
   if (current_evidence >=
@@ -714,12 +682,8 @@ void Courtroom::on_evidence_edited()
 void Courtroom::evidence_close()
 {
   ui_evidence_description->setReadOnly(true);
-  ui_evidence_description->setToolTip("");
   ui_evidence_name->setReadOnly(true);
-  ui_evidence_name->setToolTip("");
   ui_evidence_image_name->setReadOnly(true);
-  ui_evidence_image_name->setToolTip("");
-  ui_evidence_edit->show();
   ui_evidence_image_button->setDisabled(true);
   ui_evidence_overlay->hide();
   ui_ic_chat_message->setFocus();


### PR DESCRIPTION
Polish up the evidence system so it's a single-click editing
Fix evidence editing changes caused by #587
Fix issues with "ok" button detecting itself as "changes from the server"
Fix "ok" button remaining after you press it once, allowing you to spam evidence update packets by spamclicking it