### PR TITLE
Add [Overlay] overrides to background design.ini

### DIFF
--- a/src/courtroom.cpp
+++ b/src/courtroom.cpp
@@ -3749,6 +3749,11 @@ void Courtroom::set_scene(QString f_desk_mod, QString f_side)
     f_background = f_side;
     f_desk_image = f_side + "_overlay";
   }
+
+  QString desk_override = ao_app->read_design_ini("overlays/" + f_background, ao_app->get_background_path("design.ini"));
+  if (desk_override != "")
+    f_desk_image = desk_override;
+
   ui_vp_background->load_image(f_background);
   ui_vp_desk->load_image(f_desk_image);
 


### PR DESCRIPTION
Add background overlay overrides so you don't have to copy-paste the same file if you're just using it across multiple pos
To make this work:

1. Create a design.ini in your background folder
2. Set up the overlays, like so:
```ini
[Overlays]
bg_name = overlay_name
```
3. Now, you'll be able to re-use the same overlay for multiple backgrounds, which removes tedium and allows you to even improve file size!

Closes https://github.com/AttorneyOnline/AO2-Client/issues/642