### PR TITLE
Add showname and selfname colors to courtroom_fonts.ini

### DIFF
--- a/include/chatlogpiece.h
+++ b/include/chatlogpiece.h
@@ -14,15 +14,15 @@ public:
   chatlogpiece(QString p_name, QString p_showname, QString p_message,
                QString p_action, int color, bool selfname, QDateTime p_datetime);
 
-  QString &get_name() const { return name; };
-  QString &get_showname() const { return showname; };
-  QString &get_message() const { return message; };
-  QString &get_action() const { return action; };
-  bool get_selfname() const { return selfname; };
-  QDateTime &get_datetime() const { return datetime; };
-  QString &get_datetime_as_string() const { return datetime.toString(); };
-  int get_chat_color() const { return color; };
-  QString &get_full() const;
+  QString get_name() { return name; };
+  QString get_showname() { return showname; };
+  QString get_message() { return message; };
+  QString get_action() { return action; };
+  bool get_selfname() { return selfname; };
+  QDateTime get_datetime() { return datetime; };
+  QString get_datetime_as_string() { return datetime.toString(); };
+  int get_chat_color() { return color; };
+  QString get_full();
 
 private:
   QString name;

--- a/include/chatlogpiece.h
+++ b/include/chatlogpiece.h
@@ -10,17 +10,18 @@ class chatlogpiece {
 public:
   chatlogpiece();
   chatlogpiece(QString p_name, QString p_showname, QString p_message,
-               QString p_action,int color);
+               QString p_action,int color, bool selfname);
   chatlogpiece(QString p_name, QString p_showname, QString p_message,
-               QString p_action, int color, QDateTime p_datetime);
+               QString p_action, int color, bool selfname, QDateTime p_datetime);
 
-  QString get_name();
-  QString get_showname();
-  QString get_message();
-  QString get_action();
-  QDateTime get_datetime();
-  QString get_datetime_as_string();
-  int get_chat_color();
+  QString get_name() { return name; };
+  QString get_showname() { return showname; };
+  QString get_message() { return message; };
+  QString get_action() { return action; };
+  bool get_selfname() { return selfname; };
+  QDateTime get_datetime() { return datetime; };
+  QString get_datetime_as_string() { return datetime.toString(); };
+  int get_chat_color() { return color; };
   QString get_full();
 
 private:
@@ -28,6 +29,7 @@ private:
   QString showname;
   QString message;
   QString action;
+  bool selfname;
   QDateTime datetime;
   int color;
 };

--- a/include/chatlogpiece.h
+++ b/include/chatlogpiece.h
@@ -21,7 +21,7 @@ public:
   bool get_selfname() const { return selfname; };
   QDateTime get_datetime() { return datetime; };
   QString get_datetime_as_string() { return datetime.toString(); };
-  int get_chat_color() { return color; };
+  int get_chat_color() const { return color; };
   QString get_full();
 
 private:

--- a/include/chatlogpiece.h
+++ b/include/chatlogpiece.h
@@ -14,15 +14,15 @@ public:
   chatlogpiece(QString p_name, QString p_showname, QString p_message,
                QString p_action, int color, bool selfname, QDateTime p_datetime);
 
-  QString get_name() { return name; };
-  QString get_showname() { return showname; };
-  QString get_message() { return message; };
-  QString get_action() { return action; };
-  bool get_selfname() { return selfname; };
-  QDateTime get_datetime() { return datetime; };
-  QString get_datetime_as_string() { return datetime.toString(); };
-  int get_chat_color() { return color; };
-  QString get_full();
+  QString &get_name() const { return name; };
+  QString &get_showname() const { return showname; };
+  QString &get_message() const { return message; };
+  QString &get_action() const { return action; };
+  bool get_selfname() const { return selfname; };
+  QDateTime &get_datetime() const { return datetime; };
+  QString &get_datetime_as_string() const { return datetime.toString(); };
+  int get_chat_color() const { return color; };
+  QString &get_full() const;
 
 private:
   QString name;

--- a/include/chatlogpiece.h
+++ b/include/chatlogpiece.h
@@ -18,7 +18,7 @@ public:
   QString get_showname() { return showname; };
   QString get_message() { return message; };
   QString get_action() { return action; };
-  bool get_selfname() { return selfname; };
+  bool get_selfname() const { return selfname; };
   QDateTime get_datetime() { return datetime; };
   QString get_datetime_as_string() { return datetime.toString(); };
   int get_chat_color() { return color; };

--- a/include/courtroom.h
+++ b/include/courtroom.h
@@ -277,14 +277,14 @@ public:
                          int default_color = 0);
 
   void log_ic_text(QString p_name, QString p_showname, QString p_message,
-                   QString p_action = "", int p_color = 0);
+                   QString p_action = "", int p_color = 0, bool p_selfname = false);
 
   // adds text to the IC chatlog. p_name first as bold then p_text then a newlin
   // this function keeps the chatlog scrolled to the top unless there's text
   // selected
   // or the user isn't already scrolled to the top
   void append_ic_text(QString p_text, QString p_name = "", QString action = "",
-                      int color = 0, QDateTime timestamp = QDateTime::currentDateTime());
+                      int color = 0, bool selfname = false, QDateTime timestamp = QDateTime::currentDateTime());
 
   // prints who played the song to IC chat and plays said song(if found on local
   // filesystem) takes in a list where the first element is the song name and

--- a/src/chatlogpiece.cpp
+++ b/src/chatlogpiece.cpp
@@ -11,18 +11,19 @@ chatlogpiece::chatlogpiece()
 }
 
 chatlogpiece::chatlogpiece(QString p_name, QString p_showname,
-                           QString p_message, QString p_action, int p_color)
+                           QString p_message, QString p_action, int p_color, bool p_selfname)
 {
   name = p_name;
   showname = p_showname;
   message = p_message;
   action = p_action;
   color = p_color;
+  selfname = p_selfname;
   datetime = QDateTime::currentDateTimeUtc();
 }
 
 chatlogpiece::chatlogpiece(QString p_name, QString p_showname,
-                           QString p_message, QString p_action, int p_color,
+                           QString p_message, QString p_action, int p_color, bool p_selfname,
                            QDateTime p_datetime)
 {
   name = p_name;
@@ -30,22 +31,9 @@ chatlogpiece::chatlogpiece(QString p_name, QString p_showname,
   message = p_message;
   action = p_action;
   color = p_color;
+  selfname = p_selfname;
   datetime = p_datetime.toUTC();
 }
-
-QString chatlogpiece::get_name() { return name; }
-
-QString chatlogpiece::get_showname() { return showname; }
-
-QString chatlogpiece::get_message() { return message; }
-
-QDateTime chatlogpiece::get_datetime() { return datetime; }
-
-QString chatlogpiece::get_action() { return action; }
-
-QString chatlogpiece::get_datetime_as_string() { return datetime.toString(); }
-
-int chatlogpiece::get_chat_color() { return color; }
 
 QString chatlogpiece::get_full()
 {

--- a/src/courtroom.cpp
+++ b/src/courtroom.cpp
@@ -2201,6 +2201,8 @@ void Courtroom::log_chatmessage(QString f_message, int f_char_id, QString f_show
   if (f_displayname.trimmed().isEmpty())
     f_displayname = f_showname;
 
+  bool selfname = f_char_id == m_cid;
+
   if (log_ic_actions) {
     // Check if a custom objection is in use
     int objection_mod = 0;
@@ -2249,13 +2251,13 @@ void Courtroom::log_chatmessage(QString f_message, int f_char_id, QString f_show
       }
       switch (f_log_mode) {
         case IO_ONLY:
-          log_ic_text(f_char, f_displayname, shout_message, tr("shouts"));
+          log_ic_text(f_char, f_displayname, shout_message, tr("shouts"), 0, selfname);
           break;
         case DISPLAY_AND_IO:
-          log_ic_text(f_char, f_displayname, shout_message, tr("shouts"));
+          log_ic_text(f_char, f_displayname, shout_message, tr("shouts"), 0, selfname);
           [[fallthrough]];
         case DISPLAY_ONLY:
-          append_ic_text(shout_message, f_displayname, tr("shouts"));
+          append_ic_text(shout_message, f_displayname, tr("shouts"), 0, selfname);
           break;
       }
     }
@@ -2266,13 +2268,13 @@ void Courtroom::log_chatmessage(QString f_message, int f_char_id, QString f_show
       QString f_evi_name = local_evidence_list.at(f_evi_id - 1).name;
       switch (f_log_mode) {
         case IO_ONLY:
-          log_ic_text(f_showname, f_displayname, f_evi_name, tr("has presented evidence"));
+          log_ic_text(f_showname, f_displayname, f_evi_name, tr("has presented evidence"), 0, selfname);
           break;
         case DISPLAY_AND_IO:
-          log_ic_text(f_showname, f_displayname, f_evi_name, tr("has presented evidence"));
+          log_ic_text(f_showname, f_displayname, f_evi_name, tr("has presented evidence"), 0, selfname);
           [[fallthrough]];
         case DISPLAY_ONLY:
-          append_ic_text(f_evi_name, f_displayname, tr("has presented evidence"));
+          append_ic_text(f_evi_name, f_displayname, tr("has presented evidence"), 0, selfname);
           break;
       }
     }
@@ -2286,13 +2288,13 @@ void Courtroom::log_chatmessage(QString f_message, int f_char_id, QString f_show
     return; // Skip adding message
   switch (f_log_mode) {
     case IO_ONLY:
-      log_ic_text(f_showname, f_displayname, f_message, "",f_color);
+      log_ic_text(f_showname, f_displayname, f_message, "", f_color, selfname);
       break;
     case DISPLAY_AND_IO:
-      log_ic_text(f_showname, f_displayname, f_message, "",f_color);
+      log_ic_text(f_showname, f_displayname, f_message, "", f_color, selfname);
       [[fallthrough]];
     case DISPLAY_ONLY:
-      append_ic_text(f_message, f_displayname, "",f_color);
+      append_ic_text(f_message, f_displayname, "", f_color, selfname);
       break;
   }
   if (!ui_showname_enable->isChecked())
@@ -3100,9 +3102,9 @@ QString Courtroom::filter_ic_text(QString p_text, bool html, int target_pos,
 }
 
 void Courtroom::log_ic_text(QString p_name, QString p_showname,
-                            QString p_message, QString p_action, int p_color)
+                            QString p_message, QString p_action, int p_color, bool p_selfname)
 {
-  chatlogpiece log_entry(p_name, p_showname, p_message, p_action, p_color);
+  chatlogpiece log_entry(p_name, p_showname, p_message, p_action, p_color, p_selfname);
   ic_chatlog_history.append(log_entry);
   if (ao_app->get_text_logging_enabled() && !ao_app->log_filename.isEmpty())
     ao_app->append_to_file(log_entry.get_full(), ao_app->log_filename, true);
@@ -3114,16 +3116,22 @@ void Courtroom::log_ic_text(QString p_name, QString p_showname,
 }
 
 void Courtroom::append_ic_text(QString p_text, QString p_name, QString p_action,
-                               int color, QDateTime timestamp)
+                               int color, bool selfname, QDateTime timestamp)
 {
   last_ic_message = p_name + ":" + p_text;
   QTextCharFormat bold;
   QTextCharFormat normal;
   QTextCharFormat italics;
+  QTextCharFormat own_name;
+  QTextCharFormat other_name;
   QTextBlockFormat format;
   bold.setFontWeight(QFont::Bold);
   normal.setFontWeight(QFont::Normal);
   italics.setFontItalic(true);
+  own_name.setFontWeight(QFont::Bold);
+  own_name.setForeground(ao_app->get_color("ic_chatlog_selfname_color", "courtroom_fonts.ini"));
+  other_name.setFontWeight(QFont::Bold);
+  other_name.setForeground(ao_app->get_color("ic_chatlog_showname_color", "courtroom_fonts.ini"));
   format.setTopMargin(log_margin);
   const QTextCursor old_cursor = ui_ic_chatlog->textCursor();
   const int old_scrollbar_value = ui_ic_chatlog->verticalScrollBar()->value();
@@ -3151,7 +3159,10 @@ void Courtroom::append_ic_text(QString p_text, QString p_name, QString p_action,
   }
 
   // Format the name of the actor
-  ui_ic_chatlog->textCursor().insertText(p_name, bold);
+  if (selfname)
+    ui_ic_chatlog->textCursor().insertText(p_name, own_name);
+  else
+    ui_ic_chatlog->textCursor().insertText(p_name, other_name);
   // Special case for stopping the music
   if (p_action == tr("has stopped the music")) {
     ui_ic_chatlog->textCursor().insertText(" " + p_action + ".", normal);
@@ -3862,13 +3873,14 @@ void Courtroom::handle_song(QStringList *p_contents)
       }
     }
     if (!mute_map.value(n_char)) {
+      bool selfname = n_char == m_cid;
       if (is_stop) {
-        log_ic_text(str_char, str_show, "", tr("has stopped the music"));
-        append_ic_text("", str_show, tr("has stopped the music"));
+        log_ic_text(str_char, str_show, "", tr("has stopped the music"), 0, selfname);
+        append_ic_text("", str_show, tr("has stopped the music"), 0, selfname);
       }
       else {
-        log_ic_text(str_char, str_show, f_song, tr("has played a song"));
-        append_ic_text(f_song_clear, str_show, tr("has played a song"));
+        log_ic_text(str_char, str_show, f_song, tr("has played a song"), 0, selfname);
+        append_ic_text(f_song_clear, str_show, tr("has played a song"), 0, selfname);
       }
     }
   }
@@ -5336,7 +5348,7 @@ void Courtroom::regenerate_ic_chatlog()
     append_ic_text(message,
                    name,
                    item.get_action(), item.get_chat_color(),
-                   item.get_datetime().toLocalTime());
+                   item.get_selfname(), item.get_datetime().toLocalTime());
   }
 }
 

--- a/src/courtroom.cpp
+++ b/src/courtroom.cpp
@@ -3159,10 +3159,8 @@ void Courtroom::append_ic_text(QString p_text, QString p_name, QString p_action,
   }
 
   // Format the name of the actor
-  if (selfname)
-    ui_ic_chatlog->textCursor().insertText(p_name, own_name);
-  else
-    ui_ic_chatlog->textCursor().insertText(p_name, other_name);
+  QTextCharFormat name_format = selfname ? own_name : other_name;
+  ui_ic_chatlog->textCursor().insertText(p_name, name_format);
   // Special case for stopping the music
   if (p_action == tr("has stopped the music")) {
     ui_ic_chatlog->textCursor().insertText(" " + p_action + ".", normal);


### PR DESCRIPTION
Cyan = selfname, light gray = other name
![image](https://user-images.githubusercontent.com/3470436/155218544-ca84ab1a-ef69-4a97-9a3c-39e9b312a1e4.png)

![image](https://user-images.githubusercontent.com/3470436/155218522-a33afb63-3283-4656-9259-ae267d158d4c.png)

To implement, in `courtroom_fonts.ini`:
```ini
ic_chatlog_selfname_color = 0, 255, 255
ic_chatlog_showname_color = 200, 200, 200
```

Closes https://github.com/AttorneyOnline/AO2-Client/issues/671
Also overhauls `chatlogpiece.cpp` and `chatlogpiece.h` slightly
TODO: a settings option to ignore selfname