### PR TITLE
Add \p for "pause", which lasts 0.1 seconds

### DIFF
--- a/src/courtroom.cpp
+++ b/src/courtroom.cpp
@@ -3047,7 +3047,7 @@ QString Courtroom::filter_ic_text(QString p_text, bool html, int target_pos,
         check_pos_escaped += appendage.size();
         skip = true;
       }
-      if (f_character == "s" || f_character == "f") // screenshake/flash
+      if (f_character == "s" || f_character == "f" || f_character == "p") // screenshake/flash/pause
         skip = true;
 
       parse_escape_seq = false;
@@ -3508,6 +3508,7 @@ void Courtroom::chat_tick()
   QTextBoundaryFinder tbf(QTextBoundaryFinder::Grapheme, f_rest);
   QString f_character;
   int f_char_length;
+  int msg_delay = 0;
 
   tbf.toNextBoundary();
 
@@ -3567,6 +3568,10 @@ void Courtroom::chat_tick()
       this->do_flash();
       formatting_char = true;
     }
+    if (f_character == "p")
+    {
+      formatting_char = true;
+    }
     next_character_is_not_special = false;
   }
 
@@ -3576,14 +3581,19 @@ void Courtroom::chat_tick()
   else if (current_display_speed > 6)
     current_display_speed = 6;
 
-  int msg_delay = text_crawl * message_display_mult[current_display_speed];
+  if (msg_delay == 0)
+    msg_delay = text_crawl * message_display_mult[current_display_speed];
+
   if ((msg_delay <= 0 &&
        tick_pos < f_message.size() - 1) ||
       formatting_char) {
-    chat_tick_timer->start(0); // Don't bother rendering anything out as we're
-                               // doing the SPEED. (there's latency otherwise)
+    if (f_character == "p")
+      chat_tick_timer->start(100); // wait the pause lol
+    else
+      chat_tick_timer->start(0); // Don't bother rendering anything out as we're
+                                 // doing the SPEED. (there's latency otherwise)
     if (!formatting_char || f_character == "n" || f_character == "f" ||
-        f_character == "s")
+        f_character == "s" || f_character == "p")
       real_tick_pos += f_char_length; // Adjust the tick position for the
                                       // scrollbar convenience
   }


### PR DESCRIPTION
Add \p for "pause" similar to \s and \f, which will pause the text for 0.1 seconds
`You know, you have \pa \ppoint, but it's not a \pgood\p point.`
`This...\p\p\p Can't be!`
![Attorney_Online_4IhuDej3Ao](https://user-images.githubusercontent.com/3470436/155385267-6e1925ef-b911-4062-a409-c79f94700314.gif)
