### PR TITLE
Fix demoserver max_wait skips happening even when they're not supposed to

### DIFF
--- a/include/demoserver.h
+++ b/include/demoserver.h
@@ -31,6 +31,7 @@ private:
     QTcpSocket* client_sock = nullptr;
     bool client_connected = false;
     bool partial_packet = false;
+    bool debug_mode = false;
     QString temp_packet = "";
     QQueue<QString> demo_data;
     QString sc_packet;

--- a/src/demoserver.cpp
+++ b/src/demoserver.cpp
@@ -242,7 +242,7 @@ void DemoServer::handle_packet(AOPacket packet)
               int toggle = args.at(1).toInt(&ok);
               if (ok && (toggle == 0 || toggle == 1)) {
                 debug_mode = toggle == 1;
-                QString packet = "CT#DEMO#" + tr("Setting debug mode to %1").arg(debug_mode) + "#1#%";
+                QString packet = "CT#DEMO#" + tr("Setting debug mode to %1").arg(static_cast<int>(debug_mode)) + "#1#%";
                 client_sock->write(packet.toUtf8());
                 // Debug mode disabled?
                 if (!debug_mode) {

--- a/src/demoserver.cpp
+++ b/src/demoserver.cpp
@@ -242,7 +242,7 @@ void DemoServer::handle_packet(AOPacket packet)
               int toggle = args.at(1).toInt(&ok);
               if (ok && (toggle == 0 || toggle == 1)) {
                 debug_mode = toggle == 1;
-                QString packet = "CT#DEMO#" + tr("Setting debug mode to ") + (debug_mode ? "true" : "false") + "#1#%";
+                QString packet = "CT#DEMO#" + tr("Setting debug mode to %1").arg(debug_mode) + "#1#%";
                 client_sock->write(packet.toUtf8());
                 // Debug mode disabled?
                 if (!debug_mode) {

--- a/src/demoserver.cpp
+++ b/src/demoserver.cpp
@@ -259,7 +259,7 @@ void DemoServer::handle_packet(AOPacket packet)
             }
             else
             {
-              QString packet = "CT#DEMO#" + tr("Set debug mode using /debug 1 to enable, and /debug 0 to disable, which will use the fourth timer (TI#4) to show the remaining time until next demo line.") + "#1#%";
+              QString packet = "CT#DEMO#" + tr("Set debug mode using /debug 1 to enable, and /debug 0 to disable, which will use the fifth timer (TI#4) to show the remaining time until next demo line.") + "#1#%";
               client_sock->write(packet.toUtf8());
             }
         }


### PR DESCRIPTION
Fix demoserver max_wait logic being absolutely bonkers, causing random skips that make no sense, and actually comment this piece of code.
.demo reference used: https://cdn.discordapp.com/attachments/278576491191599104/949242991917301780/tech_support.demo

Also adds a `/debug` command. `/debug 1` enables debug mode, `/debug 0` disables it. What it does is show you the current duration before next playback() call, allowing you to visualize wait packets, tweak delays while editing demo, etc.