### PR TITLE
Replace TCP Socket with Websocket

### DIFF
--- a/Attorney_Online.pro
+++ b/Attorney_Online.pro
@@ -1,4 +1,4 @@
-QT += core gui widgets network
+QT += core gui widgets network websockets
 
 TARGET = Attorney_Online
 TEMPLATE = app

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,7 +31,7 @@ endif()
 target_include_directories(Attorney_Online PRIVATE include)
 
 # Target Lib
-find_package(Qt5 COMPONENTS Core Gui Network Widgets Concurrent REQUIRED)
+find_package(Qt5 COMPONENTS Core Gui Network Widgets Concurrent WebSockets REQUIRED)
 target_link_directories(Attorney_Online PRIVATE lib)
 target_link_libraries(Attorney_Online PRIVATE Qt5::Core Qt5::Gui Qt5::Network Qt5::Widgets Qt5::Concurrent
     Qt5::WebSockets bass bassopus discord-rpc)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,7 +34,7 @@ target_include_directories(Attorney_Online PRIVATE include)
 find_package(Qt5 COMPONENTS Core Gui Network Widgets Concurrent REQUIRED)
 target_link_directories(Attorney_Online PRIVATE lib)
 target_link_libraries(Attorney_Online PRIVATE Qt5::Core Qt5::Gui Qt5::Network Qt5::Widgets Qt5::Concurrent
-    bass bassopus discord-rpc)
+    Qt5::WebSockets bass bassopus discord-rpc)
 target_compile_definitions(Attorney_Online PRIVATE DISCORD)
 
 # Subdirectories

--- a/include/networkmanager.h
+++ b/include/networkmanager.h
@@ -30,7 +30,7 @@ public:
   QWebSocket *server_socket;
   QTimer *heartbeat_timer;
 
-  const QString DEFAULT_MS_BASEURL = "https://servers.aceattorneyonline.com";
+  const QString DEFAULT_MS_BASEURL = "http://servers.aceattorneyonline.com";
   QString ms_baseurl = DEFAULT_MS_BASEURL;
 
   const int heartbeat_interval = 60 * 5 * 1000;

--- a/include/networkmanager.h
+++ b/include/networkmanager.h
@@ -6,7 +6,7 @@
 
 #include <QDnsLookup>
 #include <QNetworkAccessManager>
-#include <QTcpSocket>
+#include <QtWebSockets/QWebSocket>
 #include <QTime>
 #include <QTimer>
 
@@ -27,7 +27,7 @@ public:
 
   AOApplication *ao_app;
   QNetworkAccessManager *http;
-  QTcpSocket *server_socket;
+  QWebSocket *server_socket;
   QTimer *heartbeat_timer;
 
   const QString DEFAULT_MS_BASEURL = "https://servers.aceattorneyonline.com";
@@ -45,7 +45,7 @@ public:
 public slots:
   void get_server_list(const std::function<void()> &cb);
   void ship_server_packet(QString p_packet);
-  void handle_server_packet();
+  void handle_server_packet(QString p_data);
 
   void request_document(MSDocumentType document_type,
                         const std::function<void(QString)> &cb);

--- a/src/networkmanager.cpp
+++ b/src/networkmanager.cpp
@@ -135,15 +135,15 @@ void NetworkManager::connect_to_server(server_type p_server)
 
   qInfo().nospace().noquote() << "connecting to " << p_server.ip << ":"
                               << p_server.port;
-  QNetworkRequest req((QUrl(QString("ws://" + p_server.ip + ":" + p_server.port))));
+
+  QNetworkRequest req(QUrl("ws://" + p_server.ip + ":" + QString::number(p_server.port)));
   req.setHeader(QNetworkRequest::UserAgentHeader, get_user_agent());
   server_socket->open(req);
-  qDebug() << req.url();
 }
 
 void NetworkManager::ship_server_packet(QString p_packet)
 {
-  server_socket->sendBinaryMessage(p_packet.toUtf8());
+  server_socket->sendTextMessage(p_packet.toUtf8());
 }
 
 void NetworkManager::handle_server_packet(QString p_data)


### PR DESCRIPTION
This allows Client to work natively with Cloudflare or other Reverse Proxy implementations and removes the long-standing port for WebAO and AO2-Client. WebAO can't be stopped anymore.