### PR TITLE
Add timestamp colors you can change in courtroom_fonts.ini

### DIFF
--- a/src/charselect.cpp
+++ b/src/charselect.cpp
@@ -189,10 +189,12 @@ void Courtroom::char_clicked(int n_char)
     set_courtroom_size();
   }
 
-  if (n_char != -1)
+  if (n_char != -1) {
     ui_ic_chat_name->setPlaceholderText(char_list.at(n_char).name);
-  else
+  }
+  else {
     ui_ic_chat_name->setPlaceholderText("Spectator");
+  }
 }
 
 void Courtroom::put_button_in_place(int starting, int chars_on_this_page)

--- a/src/charselect.cpp
+++ b/src/charselect.cpp
@@ -191,6 +191,8 @@ void Courtroom::char_clicked(int n_char)
 
   if (n_char != -1)
     ui_ic_chat_name->setPlaceholderText(char_list.at(n_char).name);
+  else
+    ui_ic_chat_name->setPlaceholderText("Spectator");
 }
 
 void Courtroom::put_button_in_place(int starting, int chars_on_this_page)

--- a/src/courtroom.cpp
+++ b/src/courtroom.cpp
@@ -3172,6 +3172,8 @@ void Courtroom::append_ic_text(QString p_text, QString p_name, QString p_action,
   QTextCharFormat italics;
   QTextCharFormat own_name;
   QTextCharFormat other_name;
+  QTextCharFormat timestamp_format;
+  QTextCharFormat selftimestamp_format;
   QTextBlockFormat format;
   bold.setFontWeight(QFont::Bold);
   normal.setFontWeight(QFont::Normal);
@@ -3180,6 +3182,8 @@ void Courtroom::append_ic_text(QString p_text, QString p_name, QString p_action,
   own_name.setForeground(ao_app->get_color("ic_chatlog_selfname_color", "courtroom_fonts.ini"));
   other_name.setFontWeight(QFont::Bold);
   other_name.setForeground(ao_app->get_color("ic_chatlog_showname_color", "courtroom_fonts.ini"));
+  timestamp_format.setForeground(ao_app->get_color("ic_chatlog_timestamp_color", "courtroom_fonts.ini"));
+  selftimestamp_format.setForeground(ao_app->get_color("ic_chatlog_selftimestamp_color", "courtroom_fonts.ini"));
   format.setTopMargin(log_margin);
   const QTextCursor old_cursor = ui_ic_chatlog->textCursor();
   const int old_scrollbar_value = ui_ic_chatlog->verticalScrollBar()->value();
@@ -3198,9 +3202,11 @@ void Courtroom::append_ic_text(QString p_text, QString p_name, QString p_action,
 
   // Timestamp if we're doing that meme
   if (log_timestamp) {
+    // Format the timestamp
+    QTextCharFormat format = selfname ? selftimestamp_format : timestamp_format;
     if (timestamp.isValid()) {
       ui_ic_chatlog->textCursor().insertText(
-        "[" + timestamp.toString(log_timestamp_format) + "] ", normal);
+        "[" + timestamp.toString(log_timestamp_format) + "] ", format);
     } else {
       qCritical() << "could not insert invalid timestamp" << timestamp;
     }


### PR DESCRIPTION
In `courtroom_fonts.ini`:
```
ic_chatlog_timestamp_color = 128, 128, 128
ic_chatlog_selftimestamp_color = 0, 128, 128
```
![Attorney_Online_JVHrJUr1pq](https://user-images.githubusercontent.com/3470436/159923115-446997ee-fe37-4ff4-aaab-5095366405b9.png)

closes https://github.com/AttorneyOnline/AO2-Client/issues/685

