### PR TITLE
Fix emote icon scaling being nearest neighbor... sometimes?

### DIFF
--- a/src/aoemotebutton.cpp
+++ b/src/aoemotebutton.cpp
@@ -21,15 +21,18 @@ void AOEmoteButton::set_image(QString p_image, QString p_emote_comment)
   if (file_exists(p_image)) {
     this->setText("");
     this->setStyleSheet(
-        "QPushButton { border-image: url(\"" + p_image +
-        "\") 0 0 0 0 stretch stretch; }"
+        "QPushButton { border: none; }"
         "QToolTip { color: #000000; background-color: #ffffff; border: 0px; }");
+    this->setIcon(QPixmap(p_image).scaled(this->size(), Qt::IgnoreAspectRatio, Qt::SmoothTransformation));
+    this->setIconSize(this->size());
   }
   else {
     this->setText(p_emote_comment);
     this->setStyleSheet("QPushButton { border-image: url(); }"
                         "QToolTip { background-image: url(); color: #000000; "
                         "background-color: #ffffff; border: 0px; }");
+    this->setIcon(QIcon());
+    this->setIconSize(this->size());
   }
 }
 


### PR DESCRIPTION
This might be a qt bug with stylesheets that was fixed in some version, as I can't reproduce the attached bug fix - it uses bilinear scaling for me regardless.

https://stackoverflow.com/questions/41690482/how-to-perform-a-smooth-downscaling-of-background-images-in-qt-styles

Fixes https://github.com/AttorneyOnline/AO2-Client/issues/688