### PR TITLE
Fix aoimage masking being enabled by default

### DIFF
--- a/include/aoimage.h
+++ b/include/aoimage.h
@@ -22,6 +22,8 @@ public:
 
   bool is_static = false;
 
+  bool masked = false;
+
   bool set_image(QString p_image, QString p_misc = "");
   void set_size_and_pos(QString identifier);
 };

--- a/src/aoimage.cpp
+++ b/src/aoimage.cpp
@@ -17,7 +17,9 @@ AOImage::AOImage(QWidget *parent, AOApplication *p_ao_app, bool make_static) : Q
       f_pixmap =
           f_pixmap.scaled(this->size(), Qt::IgnoreAspectRatio);
       this->setPixmap(f_pixmap);
-      this->setMask(f_pixmap.mask());
+      if (masked) {
+        this->setMask(f_pixmap.mask());
+      }
     });
   }
 }
@@ -49,7 +51,9 @@ bool AOImage::set_image(QString p_image, QString p_misc)
     f_pixmap =
         f_pixmap.scaled(this->size(), Qt::IgnoreAspectRatio);
     this->setPixmap(f_pixmap);
-    this->setMask(f_pixmap.mask());
+    if (masked) {
+      this->setMask(f_pixmap.mask());
+    }
   }
   return true;
 }


### PR DESCRIPTION
Note there's no way to choose if masking is enabled for any given element for theme makers yet, effectively disabling the feature.

Fixes https://github.com/AttorneyOnline/AO2-Client/issues/640