### PR TITLE
Allow base folder to be overridden by reversing the mount paths lookup

### DIFF
--- a/src/aooptionsdialog.cpp
+++ b/src/aooptionsdialog.cpp
@@ -953,7 +953,7 @@ AOOptionsDialog::AOOptionsDialog(QWidget *parent, AOApplication *p_ao_app)
   ui_asset_lbl = new QLabel(ui_assets_tab);
   ui_asset_lbl->setText(
         tr("Add or remove base folders for use by assets. "
-           "Base folders will be searched in the order provided."));
+           "Base folders will be searched in the reverse order provided (from bottom to up)."));
   ui_asset_lbl->setWordWrap(true);
   ui_assets_tab_layout->addWidget(ui_asset_lbl);
 

--- a/src/aooptionsdialog.cpp
+++ b/src/aooptionsdialog.cpp
@@ -953,7 +953,7 @@ AOOptionsDialog::AOOptionsDialog(QWidget *parent, AOApplication *p_ao_app)
   ui_asset_lbl = new QLabel(ui_assets_tab);
   ui_asset_lbl->setText(
         tr("Add or remove base folders for use by assets. "
-           "Base folders will be searched in the reverse order provided (from bottom to up)."));
+           "Base folders on the bottom are prioritized over those above them."));
   ui_asset_lbl->setWordWrap(true);
   ui_assets_tab_layout->addWidget(ui_asset_lbl);
 

--- a/src/path_functions.cpp
+++ b/src/path_functions.cpp
@@ -267,8 +267,17 @@ QString AOApplication::get_real_path(const VPath &vpath) {
 
   // Cache miss; try all known mount paths
   QStringList bases = get_mount_paths();
-  bases.push_front(get_base_path());
+  bases.prepend(get_base_path());
+  // base
+  // content 1
+  // content 2
 
+  // We search last to first
+  std::reverse(bases.begin(), bases.end());
+
+  // content 2
+  // content 1
+  // base
   for (const QString &base : bases) {
     QDir baseDir(base);
     QString path = baseDir.absoluteFilePath(vpath.toQString());


### PR DESCRIPTION
If base folder is not allowed to be overridden, it kind of defeats the whole point of multiple asset folders in the first place.
This PR changes the order of lookup, from first to last to last to first. Meaning the *newest* base folder will be prioritized over the *oldest*.