### PR TITLE
Fix a segfault caused by animated desks and switching to area without a desk

### DIFF
--- a/src/aolayer.cpp
+++ b/src/aolayer.cpp
@@ -382,7 +382,7 @@ void AOLayer::play()
     else
       this->freeze();
   }
-  else if (!movie_delays.isEmpty()) {
+  else {
     while (movie_delays.size() <= frame) {
         frameAdded.wait(&mutex);
     }

--- a/src/aolayer.cpp
+++ b/src/aolayer.cpp
@@ -382,10 +382,10 @@ void AOLayer::play()
     else
       this->freeze();
   }
-  else {
-      while (movie_delays.size() <= frame) {
-          frameAdded.wait(&mutex);
-      }
+  else if (!movie_delays.isEmpty()) {
+    while (movie_delays.size() <= frame) {
+        frameAdded.wait(&mutex);
+    }
     ticker->start(this->get_frame_delay(movie_delays[frame]));
   }
 }
@@ -531,6 +531,8 @@ void AOLayer::kill()
   this->clear();
   movie_frames.clear();
   movie_delays.clear();
+  last_max_frames = max_frames;
+  max_frames = 0;
   last_path = "";
 }
 


### PR DESCRIPTION
Fix a segfault caused by animated desks because aolayer did not make sure that movie_delays is not empty

This happened because kill() did not actually reset the max_frames. Fix that too.