### PR TITLE
Overlay emote_buttons with emote_selected image from theme instead of generating files

### DIFF
--- a/include/aoemotebutton.h
+++ b/include/aoemotebutton.h
@@ -5,6 +5,7 @@
 #include <QPainter>
 #include <QDebug>
 #include <QPushButton>
+#include <QLabel>
 
 class AOEmoteButton : public QPushButton {
   Q_OBJECT
@@ -16,16 +17,17 @@ public:
   void set_image(QString p_image, QString p_emote_comment);
   void set_char_image(QString p_char, int p_emote, bool on);
 
+  void set_selected_image(QString p_image);
+
   void set_id(int p_id) { m_id = p_id; }
   int get_id() { return m_id; }
 
 private:
   QWidget *parent;
   AOApplication *ao_app;
+  QLabel *ui_selected = nullptr;
 
   int m_id = 0;
-
-
 signals:
   void emote_clicked(int p_id);
 

--- a/src/aoemotebutton.cpp
+++ b/src/aoemotebutton.cpp
@@ -11,7 +11,22 @@ AOEmoteButton::AOEmoteButton(QWidget *p_parent, AOApplication *p_ao_app,
   this->move(p_x, p_y);
   this->resize(p_w, p_h);
 
+  ui_selected = new QLabel(this);
+  ui_selected->resize(size());
+  ui_selected->setAttribute(Qt::WA_TransparentForMouseEvents);
+  ui_selected->hide();
+
   connect(this, &AOEmoteButton::clicked, this, &AOEmoteButton::on_clicked);
+}
+
+void AOEmoteButton::set_selected_image(QString p_image)
+{
+  if (file_exists(p_image)) {
+    ui_selected->setStyleSheet("border-image: url(\"" + p_image + "\")");
+  }
+  else {
+    ui_selected->setStyleSheet("background-color: rgba(0, 0, 0, 128)");
+  }
 }
 
 void AOEmoteButton::set_image(QString p_image, QString p_emote_comment)
@@ -45,33 +60,19 @@ void AOEmoteButton::set_char_image(QString p_char, int p_emote, bool on)
     suffixedPaths.append(ao_app->get_image_suffix(ao_app->get_character_path(
         p_char, "emotions/button" + emotion_number + suffix)));
   }
+  QString image = suffixedPaths[on];
 
   QString emoteComment = ao_app->get_emote_comment(p_char, p_emote);
-  if (!file_exists(suffixedPaths[on]) && file_exists(suffixedPaths[!on])) {
-    QImage tmpImage(suffixedPaths[!on]);
-    tmpImage = tmpImage.convertToFormat(QImage::Format_ARGB32);
-    QPoint p1, p2;
-    p2.setY(tmpImage.height());
-
-    QLinearGradient gradient(p1, p2);
-    gradient.setColorAt(0, Qt::transparent);
-    gradient.setColorAt(1, QColor(0, 0, 0, 159));
-
-    QPainter p(&tmpImage);
-    p.fillRect(0, 0, tmpImage.width(), tmpImage.height(), gradient);
-
-    gradient.setColorAt(0, QColor(0, 0, 0, 159));
-    gradient.setColorAt(1, Qt::transparent);
-    p.fillRect(0, 0, tmpImage.width(), tmpImage.height(), gradient);
-
-    p.end();
-
-    // Original suffixed path may be empty, so create the path again
-    suffixedPaths[on] = QString(suffixedPaths[!on]).replace(suffixes[!on], suffixes[on]);
-    tmpImage.save(suffixedPaths[on], "png");
+  if (on && !file_exists(suffixedPaths[1])) {;
+    ui_selected->show();
+    image = suffixedPaths[0];
+  }
+  else {
+    ui_selected->hide();
   }
 
-  set_image(suffixedPaths[on], emoteComment);
+  set_image(image, emoteComment);
 }
 
 void AOEmoteButton::on_clicked() { emit emote_clicked(m_id); }
+

--- a/src/emotes.cpp
+++ b/src/emotes.cpp
@@ -63,13 +63,15 @@ void Courtroom::refresh_emotes()
 
   max_emotes_on_page = emote_columns * emote_rows;
 
+  QString selected_image = ao_app->get_image_suffix(ao_app->get_theme_path("emote_selected", ""));
+
   for (int n = 0; n < max_emotes_on_page; ++n) {
     int x_pos = (button_width + x_spacing) * x_mod_count;
     int y_pos = (button_height + y_spacing) * y_mod_count;
 
     AOEmoteButton *f_emote = new AOEmoteButton(ui_emotes, ao_app, x_pos, y_pos,
                                                button_width, button_height);
-
+    f_emote->set_selected_image(selected_image);
     ui_emote_list.append(f_emote);
 
     f_emote->set_id(n);


### PR DESCRIPTION
Create an "emote_selected" overlay for emote buttons using default theme's emote_selected image

It is used if "_on" button image is not found on the character.
If emote_selected image is missing from the default theme, use a simple transparent black color overlay instead.
Replaces auto-generation of _off images

Closes https://github.com/AttorneyOnline/AO2-Client/issues/675