### PR TITLE
Add support for sounds/ subfolder in themes, misc and char folders

### DIFF
--- a/src/path_functions.cpp
+++ b/src/path_functions.cpp
@@ -207,8 +207,11 @@ QString AOApplication::get_image(QString p_element, QString p_theme, QString p_s
 
 QString AOApplication::get_sfx(QString p_sfx, QString p_misc, QString p_character)
 {
-  QVector<VPath> pathlist = get_asset_paths(p_sfx, current_theme, get_subtheme(), default_theme, p_misc, p_character);
-  pathlist += get_sounds_path(p_sfx); // Sounds folder path
+  QVector<VPath> pathlist;
+  // Search for the SFX in sounds/ folders in our current char folder, any of the themes or miscs
+  pathlist += get_asset_paths("sounds/" + p_sfx, current_theme, get_subtheme(), default_theme, p_misc, p_character);
+  // Sounds folder path
+  pathlist += get_sounds_path(p_sfx);
   QString ret = get_sfx_path(pathlist);
   if (ret.isEmpty()) {
     qWarning().nospace() << "could not find sfx " << p_sfx


### PR DESCRIPTION
Replaces weird behavior where it would prefer an unorganized sound file in any of the above over the sound folder

closes https://github.com/AttorneyOnline/AO2-Client/issues/729