### PR TITLE
Load serverlist.txt with UTF-8 Codec

### DIFF
--- a/src/lobby.cpp
+++ b/src/lobby.cpp
@@ -306,7 +306,6 @@ void Lobby::on_favorites_clicked()
   ui_public_servers->set_image("publicservers");
 
   ao_app->set_favorite_list();
-  // ao_app->favorite_list = read_serverlist_txt();
 
   list_favorites();
 

--- a/src/text_file_functions.cpp
+++ b/src/text_file_functions.cpp
@@ -265,6 +265,7 @@ QVector<server_type> AOApplication::read_serverlist_txt()
 
   if (serverlist_txt.open(QIODevice::ReadOnly)) {
       QTextStream in(&serverlist_txt);
+      in.setCodec("UTF-8");
 
       while (!in.atEnd()) {
         QString line = in.readLine();


### PR DESCRIPTION
Fixes #738
The values are correctly written, so the default codec, i.E no codec, of QTextStream is likely to blame.