### PR TITLE
Feature: Clicking the evidence icon when it's presented by a player will show the details of that evidence

### DIFF
--- a/include/aoevidencedisplay.h
+++ b/include/aoevidencedisplay.h
@@ -7,6 +7,7 @@
 
 #include <QDebug>
 #include <QLabel>
+#include <QPushButton>
 
 class AOEvidenceDisplay : public QLabel {
   Q_OBJECT
@@ -14,19 +15,23 @@ class AOEvidenceDisplay : public QLabel {
 public:
   AOEvidenceDisplay(QWidget *p_parent, AOApplication *p_ao_app);
 
-  void show_evidence(QString p_evidence_image, bool is_left_side, int p_volume);
-  QLabel *get_evidence_icon();
+  void show_evidence(int p_index, QString p_evidence_image, bool is_left_side, int p_volume);
   void reset();
   void combo_resize(int w, int h);
+
+signals:
+  void show_evidence_details(int index);
 
 private:
   AOApplication *ao_app;
   InterfaceLayer *evidence_movie;
-  QLabel *evidence_icon;
+  QPushButton *evidence_icon;
   AOSfxPlayer *sfx_player;
+  int last_evidence_index = -1;
 
 private slots:
   void show_done();
+  void icon_clicked();
 };
 
 #endif // AOEVIDENCEDISPLAY_H

--- a/include/courtroom.h
+++ b/include/courtroom.h
@@ -812,6 +812,7 @@ private:
 
   void initialize_evidence();
   void refresh_evidence();
+  void show_evidence(int f_real_id);
   void set_evidence_page();
 
   void reset_ui();

--- a/src/aoevidencedisplay.cpp
+++ b/src/aoevidencedisplay.cpp
@@ -8,18 +8,22 @@ AOEvidenceDisplay::AOEvidenceDisplay(QWidget *p_parent, AOApplication *p_ao_app)
     : QLabel(p_parent)
 {
   ao_app = p_ao_app;
-  evidence_icon = new QLabel(this);
+  evidence_icon = new QPushButton(this);
+  evidence_icon->hide();
   sfx_player = new AOSfxPlayer(this, ao_app);
 
   evidence_movie = new InterfaceLayer(this, ao_app);
 
   connect(evidence_movie, &InterfaceLayer::done, this, &AOEvidenceDisplay::show_done);
+  connect(evidence_icon, &QPushButton::clicked, this, &AOEvidenceDisplay::icon_clicked);
 }
 
-void AOEvidenceDisplay::show_evidence(QString p_evidence_image,
+void AOEvidenceDisplay::show_evidence(int p_index, QString p_evidence_image,
                                       bool is_left_side, int p_volume)
 {
   this->reset();
+
+  last_evidence_index = p_index;
 
   sfx_player->set_volume(p_volume);
 
@@ -43,8 +47,11 @@ void AOEvidenceDisplay::show_evidence(QString p_evidence_image,
       ao_app->get_element_dimensions(icon_identifier, "courtroom_design.ini");
 
   f_pixmap = f_pixmap.scaled(icon_dimensions.width, icon_dimensions.height);
-  evidence_icon->setPixmap(f_pixmap);
-  evidence_icon->resize(f_pixmap.size());
+  QIcon f_icon(f_pixmap);
+
+  evidence_icon->setIcon(f_icon);
+  evidence_icon->setIconSize(f_pixmap.rect().size());
+  evidence_icon->resize(f_pixmap.rect().size());
   evidence_icon->move(icon_dimensions.x, icon_dimensions.y);
   evidence_movie->static_duration = 320;
   evidence_movie->max_duration = 1000;
@@ -63,7 +70,11 @@ void AOEvidenceDisplay::reset()
 
 void AOEvidenceDisplay::show_done() { evidence_icon->show(); }
 
-QLabel *AOEvidenceDisplay::get_evidence_icon() { return evidence_icon; }
+void AOEvidenceDisplay::icon_clicked() {
+  if (last_evidence_index != -1) {
+    emit show_evidence_details(last_evidence_index - 1); // i dont know why i have to subtract 1 here
+  }
+}
 
 void AOEvidenceDisplay::combo_resize(int w, int h)
 {

--- a/src/courtroom.cpp
+++ b/src/courtroom.cpp
@@ -552,6 +552,8 @@ Courtroom::Courtroom(AOApplication *p_ao_app) : QMainWindow()
   connect(ui_evidence_button, &AOButton::clicked, this,
           &Courtroom::on_evidence_button_clicked);
 
+  connect(ui_vp_evidence_display, &AOEvidenceDisplay::show_evidence_details, this, &Courtroom::on_evidence_double_clicked);
+
   set_widgets();
 
   set_char_select();
@@ -2837,7 +2839,7 @@ void Courtroom::display_evidence_image()
     // def jud and hlp should display the evidence icon on the RIGHT side
     bool is_left_side = !(side == "def" || side == "hlp" ||
                           side == "jud" || side == "jur");
-    ui_vp_evidence_display->show_evidence(f_image, is_left_side,
+    ui_vp_evidence_display->show_evidence(f_evi_id, f_image, is_left_side,
                                           ui_sfx_slider->value());
   }
 }

--- a/src/courtroom.cpp
+++ b/src/courtroom.cpp
@@ -552,7 +552,7 @@ Courtroom::Courtroom(AOApplication *p_ao_app) : QMainWindow()
   connect(ui_evidence_button, &AOButton::clicked, this,
           &Courtroom::on_evidence_button_clicked);
 
-  connect(ui_vp_evidence_display, &AOEvidenceDisplay::show_evidence_details, this, &Courtroom::on_evidence_double_clicked);
+  connect(ui_vp_evidence_display, &AOEvidenceDisplay::show_evidence_details, this, &Courtroom::show_evidence);
 
   set_widgets();
 

--- a/src/evidence.cpp
+++ b/src/evidence.cpp
@@ -464,6 +464,7 @@ void Courtroom::on_evidence_double_clicked(int p_id)
   ui_evidence_image_name->setReadOnly(false);
   ui_evidence_image_name->setToolTip(tr("Click to edit..."));
 
+  ui_evidence->show();
   ui_evidence_overlay->show();
   ui_evidence_ok->hide();
 

--- a/src/evidence.cpp
+++ b/src/evidence.cpp
@@ -370,6 +370,19 @@ void Courtroom::set_evidence_page()
   }
 }
 
+void Courtroom::show_evidence(int f_real_id)
+{
+  // Make sure we're in the global evidence list
+  evidence_switch(true);
+  // Set the evidence page properly
+  current_evidence_page = f_real_id / max_evidence_on_page;
+  set_evidence_page();
+  // Display the target evidence using the local ID
+  int p_id = f_real_id - (max_evidence_on_page * current_evidence_page);
+  on_evidence_double_clicked(p_id);
+}
+
+
 void Courtroom::on_evidence_name_edited()
 {
   if (current_evidence >= local_evidence_list.size())


### PR DESCRIPTION
Demo:
https://user-images.githubusercontent.com/32779090/166449483-0dec157c-c53e-4890-ba8c-d5ce7fe967d4.mp4

This is something I've wanted for awhile but had thought it would require too much effort. As it turns out, I was wrong - this was surprisingly easy.

Tested with:
- Multiple pages (does not change page, but details appear as expected)
- Clicking evidence that has since been deleted (simply does nothing)
