### PR TITLE
Disable DPI scaling for good

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -14,13 +14,6 @@ int main(int argc, char *argv[])
 {
   qSetMessagePattern("%{type}: %{if-category}%{category}: %{endif}%{message}");
 
-#if QT_VERSION > QT_VERSION_CHECK(5, 6, 0)
-  // High-DPI support is for Qt version >=5.6.
-  // However, many Linux distros still haven't brought their stable/LTS
-  // packages up to Qt 5.6, so this is conditional.
-  AOApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
-#endif
-
   AOApplication main_app(argc, argv);
 
   AOApplication::addLibraryPath(AOApplication::applicationDirPath() + "/lib");


### PR DESCRIPTION
AO2 has not been properly designed to support DPI scaling, and it's been causing nothing but issues with themes breaking by text going out of bounds etc.