### PR TITLE
UTF-8 support and human sorting for evidence. Again.

### DIFF
--- a/src/evidence.cpp
+++ b/src/evidence.cpp
@@ -739,6 +739,7 @@ void Courtroom::on_evidence_save_clicked()
   ui_evidence_name->setText("");
 
   QSettings inventory(p_path, QSettings::IniFormat);
+  inventory.setIniCodec("UTF-8");
   inventory.clear();
   for (int i = 0; i < local_evidence_list.size(); i++) {
     inventory.beginGroup(QString::number(i));
@@ -765,8 +766,14 @@ void Courtroom::on_evidence_load_clicked()
   ui_evidence_name->setText("");
 
   QSettings inventory(p_path, QSettings::IniFormat);
+  inventory.setIniCodec("UTF-8");
   local_evidence_list.clear();
-  foreach (QString evi, inventory.childGroups()) {
+  QMap<int, QString> sorted_evi;
+  for (const auto &s : inventory.childGroups()) {
+    sorted_evi[s.toInt()] = s;
+  }
+  QStringList evilist(sorted_evi.values());
+  for (const QString &evi : evilist) {
     if (evi == "General")
       continue;
 


### PR DESCRIPTION
Basically already approved (and co-authored) by @oldmud0 (hi ^^) and merged into 2.10-alpha, but just so it's not forgotten, let's compare against master this time.