### PR TITLE
Fix multiple issues with screenshake code

### DIFF
--- a/include/courtroom.h
+++ b/include/courtroom.h
@@ -51,7 +51,9 @@
 #include <QMessageBox>
 #include <QParallelAnimationGroup>
 #include <QPropertyAnimation>
-#include <QRandomGenerator>
+#if QT_VERSION > QT_VERSION_CHECK(5, 10, 0)
+#include <QRandomGenerator> //added in Qt 5.10
+#endif
 #include <QRegExp>
 #include <QScrollBar>
 #include <QTextBoundaryFinder>

--- a/include/courtroom.h
+++ b/include/courtroom.h
@@ -51,6 +51,7 @@
 #include <QMessageBox>
 #include <QParallelAnimationGroup>
 #include <QPropertyAnimation>
+#include <QRandomGenerator>
 #include <QRegExp>
 #include <QScrollBar>
 #include <QTextBoundaryFinder>

--- a/src/courtroom.cpp
+++ b/src/courtroom.cpp
@@ -2601,6 +2601,11 @@ void Courtroom::handle_ic_message()
   }
 }
 
+#if QT_VERSION < QT_VERSION_CHECK(5, 10, 0)
+// It's a surprise tool that will help us later.
+inline double NegRand() { return 2*(qrand()/(float)RAND_MAX)-1; } // Returns random double between -1 and 1
+#endif
+
 void Courtroom::do_screenshake()
 {
   if (!ao_app->is_shake_enabled())
@@ -2633,14 +2638,12 @@ void Courtroom::do_screenshake()
     screenshake_animation->setDuration(duration);
     for (int frame = 0; frame < maxframes; frame++) {
       double fraction = double(frame * frequency) / duration;
-#if QT_VERSION > QT_VERSION_CHECK(5, 10, 0)
+#if QT_VERSION < QT_VERSION_CHECK(5, 10, 0)
+      int rand_x = max_deviation*NegRand() + 1;
+      int rand_y = max_deviation*NegRand() + 1;
+#else
       int rand_x = QRandomGenerator::system()->bounded(-max_deviation, max_deviation);
       int rand_y = QRandomGenerator::system()->bounded(-max_deviation, max_deviation);
-#else
-      // Ugly pre-5.10 STLpilled way of getting random negative numbers, for older distributions
-      int range = (max_deviation) - (-max_deviation) + 1;
-      int rand_x = -max_deviation+int(range*qrand()/(RAND_MAX+1.0));
-      int rand_y = -max_deviation+int(range*qrand()/(RAND_MAX+1.0));
 #endif
       screenshake_animation->setKeyValueAt(fraction, QPoint(pos_default.x() + rand_x, pos_default.y() + rand_y));
     }

--- a/src/courtroom.cpp
+++ b/src/courtroom.cpp
@@ -2633,8 +2633,14 @@ void Courtroom::do_screenshake()
     screenshake_animation->setDuration(duration);
     for (int frame = 0; frame < maxframes; frame++) {
       double fraction = double(frame * frequency) / duration;
+#if QT_VERSION > QT_VERSION_CHECK(5, 10, 0)
       int rand_x = QRandomGenerator::system()->bounded(-max_deviation, max_deviation);
       int rand_y = QRandomGenerator::system()->bounded(-max_deviation, max_deviation);
+#else
+      // Ugly pre-5.10 STLpilled way of getting random negative numbers, for older distributions
+      int rand_x = (qrand() % (max_deviation * 2)) - max_deviation;
+      int rand_y = (qrand() % (max_deviation * 2)) - max_deviation;
+#endif
       screenshake_animation->setKeyValueAt(fraction, QPoint(pos_default.x() + rand_x, pos_default.y() + rand_y));
     }
     screenshake_animation->setEndValue(pos_default);

--- a/src/courtroom.cpp
+++ b/src/courtroom.cpp
@@ -2601,11 +2601,6 @@ void Courtroom::handle_ic_message()
   }
 }
 
-#if QT_VERSION < QT_VERSION_CHECK(5, 10, 0)
-// It's a surprise tool that will help us later.
-inline double NegRand() { return 2*(qrand()/(float)RAND_MAX)-1; } // Returns random double between -1 and 1
-#endif
-
 void Courtroom::do_screenshake()
 {
   if (!ao_app->is_shake_enabled())
@@ -2639,8 +2634,8 @@ void Courtroom::do_screenshake()
     for (int frame = 0; frame < maxframes; frame++) {
       double fraction = double(frame * frequency) / duration;
 #if QT_VERSION < QT_VERSION_CHECK(5, 10, 0)
-      int rand_x = max_deviation*NegRand() + 1;
-      int rand_y = max_deviation*NegRand() + 1;
+      int rand_x = max_deviation * (2 * (qrand() / (float)RAND_MAX) - 1) + 1;
+      int rand_y = max_deviation * (2 * (qrand() / (float)RAND_MAX) - 1) + 1;
 #else
       int rand_x = QRandomGenerator::system()->bounded(-max_deviation, max_deviation);
       int rand_y = QRandomGenerator::system()->bounded(-max_deviation, max_deviation);

--- a/src/courtroom.cpp
+++ b/src/courtroom.cpp
@@ -2638,8 +2638,9 @@ void Courtroom::do_screenshake()
       int rand_y = QRandomGenerator::system()->bounded(-max_deviation, max_deviation);
 #else
       // Ugly pre-5.10 STLpilled way of getting random negative numbers, for older distributions
-      int rand_x = (qrand() % (max_deviation * 2)) - max_deviation;
-      int rand_y = (qrand() % (max_deviation * 2)) - max_deviation;
+      int range = (max_deviation) - (-max_deviation) + 1;
+      int rand_x = -max_deviation+int(range*qrand()/(RAND_MAX+1.0));
+      int rand_y = -max_deviation+int(range*qrand()/(RAND_MAX+1.0));
 #endif
       screenshake_animation->setKeyValueAt(fraction, QPoint(pos_default.x() + rand_x, pos_default.y() + rand_y));
     }

--- a/src/courtroom.cpp
+++ b/src/courtroom.cpp
@@ -2609,33 +2609,33 @@ void Courtroom::do_screenshake()
   // This way, the animation is reset in such a way that last played screenshake
   // would return to its "final frame" properly. This properly resets all UI
   // elements without having to bother keeping track of "origin" positions.
-  // Works great wit the chat text being detached from the chat box!
+  // Works great with the chat text being detached from the chat box!
   screenshake_animation_group->setCurrentTime(
       screenshake_animation_group->duration());
   screenshake_animation_group->clear();
 
-  QList<QWidget *> affected_list = {ui_vp_background, ui_vp_player_char,
+  const QList<QWidget *> &affected_list = {ui_vp_background, ui_vp_player_char,
                                     ui_vp_sideplayer_char, ui_vp_chatbox};
 
   // I would prefer if this was its own "shake" function to be honest.
-  foreach (QWidget *ui_element, affected_list) {
+  for (QWidget *ui_element : affected_list) {
     QPropertyAnimation *screenshake_animation =
         new QPropertyAnimation(ui_element, "pos", this);
     QPoint pos_default = QPoint(ui_element->x(), ui_element->y());
 
     int duration = 300; // How long does the screenshake last
     int frequency = 20; // How often in ms is there a "jolt" frame
-    int maxframes = duration / frequency;
-    int max_x = 7; // Max deviation from origin on x axis
-    int max_y = 7; // Max deviation from origin on y axis
+    // Maximum deviation from the origin position. This is 7 pixels for a 256x192 viewport,
+    // so we scale that value in accordance with the current viewport height so the shake
+    // is roughly the same intensity regardless of viewport size. Done as a float operation for maximum accuracy.
+    int max_deviation = 7 * (float(ui_viewport->height()) / 192);
+    int maxframes = 15; // duration / frequency;
     screenshake_animation->setDuration(duration);
     for (int frame = 0; frame < maxframes; frame++) {
       double fraction = double(frame * frequency) / duration;
-      int rng = qrand(); // QRandomGenerator::global()->generate();
-      int rand_x = max_x - (int(rng) % (max_x * 2));
-      int rand_y = max_y - (int(rng + 100) % (max_y * 2));
-      screenshake_animation->setKeyValueAt(
-          fraction, QPoint(pos_default.x() + rand_x, pos_default.y() + rand_y));
+      int rand_x = QRandomGenerator::system()->bounded(-max_deviation, max_deviation);
+      int rand_y = QRandomGenerator::system()->bounded(-max_deviation, max_deviation);
+      screenshake_animation->setKeyValueAt(fraction, QPoint(pos_default.x() + rand_x, pos_default.y() + rand_y));
     }
     screenshake_animation->setEndValue(pos_default);
     screenshake_animation->setEasingCurve(QEasingCurve::Linear);


### PR DESCRIPTION
While working on an independent project, I found multiple issues with the screenshake function:
* Maximum deviation from origin did not work as expected (values frequently exceeded this so-called maximum)
* Random deviation was heavily biased toward positive values, resulting in screenshakes being visibly directed downwards and to the right
* X and Y deviation were calculated using the same randomly generated value, resulting in screenshakes being visibly locked into a linear set of positions
* Screenshake intensity was not scaled to the viewport - A larger viewport would have less intense shaking

I have ported my corrected version. Here are some example videos, so you can see the difference (viewport size 512x384)

**Current screenshake:**
https://user-images.githubusercontent.com/32779090/179497853-4b789143-2f11-4a61-9af6-f2002f1fd5cb.mp4

**My screenshake:**
https://user-images.githubusercontent.com/32779090/179497933-7da6037e-2640-4866-8d9d-573f935a71da.mp4



