### PR TITLE
Code to support effects ini version 2

### DIFF
--- a/include/aoutils.h
+++ b/include/aoutils.h
@@ -1,0 +1,16 @@
+#ifndef AOUTILS_H
+#define AOUTILS_H
+
+#include <QFile>
+
+class AOUtils {
+
+public :
+
+    static void migrateEffects(QFile* p_file);
+
+private :
+    AOUtils(){};
+};
+
+#endif //AOUTILS_H

--- a/include/aoutils.h
+++ b/include/aoutils.h
@@ -1,16 +1,11 @@
 #ifndef AOUTILS_H
 #define AOUTILS_H
 
-#include <QFile>
+#include <QSettings>
 
-class AOUtils {
-
-public :
-
-    static void migrateEffects(QFile* p_file);
-
-private :
-    AOUtils(){};
+namespace AOUtils
+{
+void migrateEffects(QSettings &p_fileName);
 };
 
-#endif //AOUTILS_H
+#endif // AOUTILS_H

--- a/include/aoutils.h
+++ b/include/aoutils.h
@@ -1,10 +1,15 @@
 #ifndef AOUTILS_H
 #define AOUTILS_H
 
+#include <QRegularExpression>
 #include <QSettings>
 
 namespace AOUtils
 {
+/**
+ * @brief Migrates the effects from the old format to version 2.
+ * @param QSettings object reference of the old effects.ini
+ */
 void migrateEffects(QSettings &p_fileName);
 };
 

--- a/include/aoutils.h
+++ b/include/aoutils.h
@@ -1,7 +1,6 @@
 #ifndef AOUTILS_H
 #define AOUTILS_H
 
-#include <QRegularExpression>
 #include <QSettings>
 
 namespace AOUtils

--- a/src/aoutils.cpp
+++ b/src/aoutils.cpp
@@ -41,13 +41,13 @@ void AOUtils::migrateEffects(QSettings &p_effects_ini)
 
   QStringList l_key_list;
   const QRegularExpression l_regex(QString("(\\w+)_(%1)$").arg(l_property_list.join("|")));
-  for (const QString &i_key : l_effect_map.keys())
+  for (auto i = l_property_replacement_list.begin(); i != l_property_replacement_list.end(); i++)
   {
-    if (l_regex.match(i_key).hasMatch())
+    if (l_regex.match(i.key()).hasMatch())
     {
       continue;
     }
-    l_key_list.append(i_key);
+    l_key_list.append(i.key());
   }
 
   int i = 0;
@@ -57,6 +57,10 @@ void AOUtils::migrateEffects(QSettings &p_effects_ini)
     p_effects_ini.setValue("name", i_effect_key);
     p_effects_ini.setValue("sound", l_effect_map.value(i_effect_key));
     p_effects_ini.setValue("cull", true);
+
+    if (i_effect_key == "realization") {
+        p_effects_ini.setValue("stretch", true);
+    }
 
     for (const QString &i_property : l_property_list)
     {

--- a/src/aoutils.cpp
+++ b/src/aoutils.cpp
@@ -40,6 +40,12 @@ void AOUtils::migrateEffects(QSettings &p_effects_ini)
   };
 
   QStringList l_key_list;
+  // Matches old effects.ini childKeys that are not the effect name, but a property that applies to an effect.
+  // This is due to the name also being used as a key to apply the sfx property.
+  // Example :
+  // realization_scaling - This would not be appended to the key_list as it matches scaling property.
+  // realization_alt - This would be appened as it contains an underscore, but not a property.
+  // hearts - This would be appended as it does not contain a property
   const QRegularExpression l_regex(QStringLiteral("(\\w+)_(%1)$").arg(l_property_list.join("|")));
   for (auto i = l_effect_map.begin(); i != l_effect_map.end(); i++)
   {

--- a/src/aoutils.cpp
+++ b/src/aoutils.cpp
@@ -41,6 +41,7 @@ void AOUtils::migrateEffects(QFile *p_file)
       l_effect_sort_index++;
       l_effects_ini->setValue(QString::number(l_effect_sort_index) + "/name", l_key);
       l_effects_ini->setValue(QString::number(l_effect_sort_index) + "/sound", l_effects_settings.value(l_key));
+      l_effects_ini->setValue(QString::number(l_effect_sort_index) + "/cull", "true");
     }
 
     if (l_split_key.size() == 2) {

--- a/src/aoutils.cpp
+++ b/src/aoutils.cpp
@@ -1,0 +1,55 @@
+#include "aoutils.h"
+
+#include <QMap>
+#include <QSettings>
+
+void AOUtils::migrateEffects(QFile *p_file)
+{
+  QMap<QString, QString> l_effects_settings;
+  QSettings *l_effects_ini = new QSettings(p_file->fileName(), QSettings::IniFormat);
+  l_effects_ini->setIniCodec("UTF-8");
+  {
+    // Load all known keys into QMap and clear the old ini
+    QStringList keys = l_effects_ini->childKeys();
+    for (const QString &key : qAsConst(keys)) {
+      l_effects_settings.insert(key, l_effects_ini->value(key).toString()); // Don't care about datatype for now.
+    }
+    l_effects_ini->clear();
+    l_effects_ini->sync();
+  }
+  l_effects_ini->setValue("Version/major", "2"); // This is the second revision of effects.ini
+
+  // All abandon hope who read beyond this line. You have been warned.
+
+  // Due to the annoying nature of lexiographic sorting of QSettings we need an index to order the file.
+  int l_effect_sort_index = -1;
+
+  for (auto effectKeyIterator = l_effects_settings.keyBegin(), IteratorEnd = l_effects_settings.keyEnd();
+       effectKeyIterator != IteratorEnd; ++effectKeyIterator) {
+
+    // This split size determines how we process the string :
+    //  Size 1 : We have a category name that will become sound and be added as a name.
+    //  Size 2 : We have a key that needs to be handled, we discard the old group part and take only the key.
+    //  Size 3 : We discard the group part and merge the keys back into a two_word key.
+    QString l_key = effectKeyIterator.operator*();
+    QStringList l_split_key = l_key.split("_");
+
+    if (l_split_key.size() == 1) {
+      // We implicity create the group this way too!
+      l_effect_sort_index++;
+      l_effects_ini->setValue(QString::number(l_effect_sort_index) + "/name", l_key);
+      l_effects_ini->setValue(QString::number(l_effect_sort_index) + "/sound", l_effects_settings.value(l_key));
+    }
+
+    if (l_split_key.size() == 2) {
+      l_effects_ini->setValue(QString::number(l_effect_sort_index) + "/" + l_split_key.at(1), l_effects_settings.value(l_key));
+    }
+
+    if (l_split_key.size() == 3) {
+      QString l_key_name = l_split_key.at(1) + "_" + l_split_key.at(2);
+      l_effects_ini->setValue(QString::number(l_effect_sort_index) + "/" + l_key_name, l_effects_settings.value(l_key));
+    }
+
+      l_effects_ini->sync();
+    }
+}

--- a/src/aoutils.cpp
+++ b/src/aoutils.cpp
@@ -36,7 +36,7 @@ void AOUtils::migrateEffects(QSettings &p_effects_ini)
   };
 
   const QMap<QString, QPair<QString, QString>> l_property_replacement_list{
-    {"under_chatbox", {"layer", "chat"}},
+    {"under_chatbox", {"layer", "character"}},
   };
 
   QStringList l_key_list;
@@ -57,9 +57,11 @@ void AOUtils::migrateEffects(QSettings &p_effects_ini)
     p_effects_ini.setValue("name", i_effect_key);
     p_effects_ini.setValue("sound", l_effect_map.value(i_effect_key));
     p_effects_ini.setValue("cull", true);
+    p_effects_ini.setValue("layer", "character");
 
     if (i_effect_key == "realization") {
         p_effects_ini.setValue("stretch", true);
+        p_effects_ini.setValue("layer", "chat");
     }
 
     for (const QString &i_property : l_property_list)

--- a/src/aoutils.cpp
+++ b/src/aoutils.cpp
@@ -2,9 +2,11 @@
 
 #include <QMap>
 #include <QSettings>
+#include <QDebug>
 
 void AOUtils::migrateEffects(QFile *p_file)
 {
+  qDebug() << "Migrating effect.in at " << p_file->fileName();
   QMap<QString, QString> l_effects_settings;
   QSettings *l_effects_ini = new QSettings(p_file->fileName(), QSettings::IniFormat);
   l_effects_ini->setIniCodec("UTF-8");
@@ -50,6 +52,6 @@ void AOUtils::migrateEffects(QFile *p_file)
       l_effects_ini->setValue(QString::number(l_effect_sort_index) + "/" + l_key_name, l_effects_settings.value(l_key));
     }
 
-      l_effects_ini->sync();
+    l_effects_ini->sync();
     }
 }

--- a/src/aoutils.cpp
+++ b/src/aoutils.cpp
@@ -40,8 +40,8 @@ void AOUtils::migrateEffects(QSettings &p_effects_ini)
   };
 
   QStringList l_key_list;
-  const QRegularExpression l_regex(QString("(\\w+)_(%1)$").arg(l_property_list.join("|")));
-  for (auto i = l_property_replacement_list.begin(); i != l_property_replacement_list.end(); i++)
+  const QRegularExpression l_regex(QStringLiteral("(\\w+)_(%1)$").arg(l_property_list.join("|")));
+  for (auto i = l_effect_map.begin(); i != l_effect_map.end(); i++)
   {
     if (l_regex.match(i.key()).hasMatch())
     {

--- a/src/courtroom.cpp
+++ b/src/courtroom.cpp
@@ -4649,14 +4649,7 @@ void Courtroom::set_effects_dropdown()
     return;
   }
   QStringList effectslist;
-  QStringList char_effects = ao_app->get_effects(current_char);
-  for (int i = 0; i < char_effects.size(); ++i) {
-    QString effect = char_effects[i];
-    if (effect.contains(":")) {
-      effect = effect.section(':', 1);
-    }
-    effectslist.append(effect);
-  }
+  effectslist.append(ao_app->get_effects(current_char));
 
   if (effectslist.empty()) {
     ui_effects_dropdown->hide();

--- a/src/text_file_functions.cpp
+++ b/src/text_file_functions.cpp
@@ -916,6 +916,7 @@ QStringList AOApplication::get_effects(QString p_char)
       }
     }
   }
+  effect_names.removeAll("");
   return effect_names;
 }
 

--- a/src/text_file_functions.cpp
+++ b/src/text_file_functions.cpp
@@ -880,13 +880,13 @@ QStringList AOApplication::get_effects(QString p_char)
   QSettings effects_config(p_path, QSettings::IniFormat);
   effects_config.setIniCodec("UTF-8");
   QStringList effects = effects_config.childGroups();
-  std::sort(effects.begin(), effects.end(), [] (const QString &a, const QString &b) {return a.split(":")[0].toInt() < b.split(":")[0].toInt();});
+  std::sort(effects.begin(), effects.end(), [] (const QString &a, const QString &b) {return a.toInt() < b.toInt();});
   if (p_path != p_misc_path) {
     // If misc path is different from default path, stack the new miscs on top of the defaults
     QSettings effects_config_misc(p_misc_path, QSettings::IniFormat);
     effects_config_misc.setIniCodec("UTF-8");
     QStringList misc_effects = effects_config_misc.childGroups();
-    std::sort(misc_effects.begin(), misc_effects.end(), [] (const QString &a, const QString &b) {return a.split(":")[0].toInt() < b.split(":")[0].toInt();});
+    std::sort(misc_effects.begin(), misc_effects.end(), [] (const QString &a, const QString &b) {return a.toInt() < b.toInt();});
     effects += misc_effects;
   }
   return effects;
@@ -923,10 +923,7 @@ QString AOApplication::get_effect_property(QString fx_name, QString p_char,
       settings.setIniCodec("UTF-8");
       QStringList char_effects = settings.childGroups();
       for (int i = 0; i < char_effects.size(); ++i) {
-        QString effect = char_effects[i];
-        if (effect.contains(":")) {
-          effect = effect.section(':', 1);
-        }
+        QString effect = settings.value(fx_name).toString();
         if (effect.toLower() == fx_name.toLower()) {
           f_result = settings.value(char_effects[i] + "/" + p_property).toString();
           if (!f_result.isEmpty()) {

--- a/src/text_file_functions.cpp
+++ b/src/text_file_functions.cpp
@@ -885,7 +885,7 @@ QStringList AOApplication::get_effects(QString p_char)
     if (theme_file.exists()) {
       QSettings theme_effects = QSettings(p_theme_path, QSettings::IniFormat, this);
       theme_effects.setIniCodec("UTF-8");
-      if (theme_effects.value("Version/major", 0).toInt() > 2) {
+      if (theme_effects.value("Version/major", 0).toInt() < 2) {
         AOUtils::migrateEffects(&theme_file);
       }
       QStringList theme_effect_groups = theme_effects.childGroups();
@@ -904,7 +904,7 @@ QStringList AOApplication::get_effects(QString p_char)
       // If misc path is different from default path, stack the new miscs on top of the defaults
       QSettings misc_effects = QSettings(p_misc_path, QSettings::IniFormat, this);
       misc_effects.setIniCodec("UTF-8");
-      if (misc_effects.value("Version/major", 0).toInt() > 2) {
+      if (misc_effects.value("Version/major", 0).toInt() < 2) {
         AOUtils::migrateEffects(&misc_file);
       }
       QStringList misc_effect_groups = misc_effects.childGroups();

--- a/src/text_file_functions.cpp
+++ b/src/text_file_functions.cpp
@@ -877,19 +877,27 @@ QStringList AOApplication::get_effects(QString p_char)
   QString p_misc = read_char_ini(p_char, "effects", "Options");
   QString p_path = get_asset("effects/effects.ini", current_theme, get_subtheme(), default_theme, "");
   QString p_misc_path = get_asset("effects.ini", current_theme, get_subtheme(), default_theme, p_misc);
+  QStringList effect_names;
   QSettings effects_config(p_path, QSettings::IniFormat);
   effects_config.setIniCodec("UTF-8");
   QStringList effects = effects_config.childGroups();
+  effects.removeAll("version");
   std::sort(effects.begin(), effects.end(), [] (const QString &a, const QString &b) {return a.toInt() < b.toInt();});
+  for (int i = 0; i < effects.size(); ++i) {
+    effect_names.append(effects_config.value(QString::number(i) + "/name").toString());
+  }
   if (p_path != p_misc_path) {
     // If misc path is different from default path, stack the new miscs on top of the defaults
     QSettings effects_config_misc(p_misc_path, QSettings::IniFormat);
     effects_config_misc.setIniCodec("UTF-8");
     QStringList misc_effects = effects_config_misc.childGroups();
+    misc_effects.removeAll("version");
     std::sort(misc_effects.begin(), misc_effects.end(), [] (const QString &a, const QString &b) {return a.toInt() < b.toInt();});
-    effects += misc_effects;
+    for (int i = 0; i < misc_effects.size(); ++i) {
+      effect_names.append(effects_config_misc.value(QString::number(i) + "/name").toString());
+    }
   }
-  return effects;
+  return effect_names;
 }
 
 QString AOApplication::get_effect(QString effect, QString p_char,
@@ -923,7 +931,7 @@ QString AOApplication::get_effect_property(QString fx_name, QString p_char,
       settings.setIniCodec("UTF-8");
       QStringList char_effects = settings.childGroups();
       for (int i = 0; i < char_effects.size(); ++i) {
-        QString effect = settings.value(fx_name).toString();
+        QString effect = settings.value(char_effects[i] + "/name").toString();
         if (effect.toLower() == fx_name.toLower()) {
           f_result = settings.value(char_effects[i] + "/" + p_property).toString();
           if (!f_result.isEmpty()) {


### PR DESCRIPTION
Supports @Salanto version 2 effects ini which uses groups for indexes only, and has the name as a property.
```ini
; Version of the configuration file
[version]
major = 2

; index of the effect for sorting
[0]
; The name of the effect
name = realization
; Sound to play for this effect
sound = sfx-realization
; Whether or not to delete the image once it's done playing. Ignored if loop=true
cull = true
; Which layer it's going to be on. Possible options:
; under - under the character
; character - over the character
; over - over everything in IC
; chat - over the chat box and other UI.
layer = chat
; Should we loop this effect?
loop = false
; Maximum duration for this effect in miliseconds. Put at 0 for no max letting the full animation to play out.
; Useful for single-image effects, such as realization flash.
max_duration = 60
; Should we respect the character's flip tick box and flip with them?
respect_flip = false
; Should we respect the character's offset and offset with them?
respect_offset = false
; Should we use smooth (bilinear) or pixel (nearest neighbor) scaling algorithm?
scaling = smooth
; Once we play the effect, should it remain in the effect dropdown still?
sticky = false
; Should we stretch the effect across the viewport?
stretch = true

[1]
name = hearts
sound = sfx-squee
cull = true
layer = character
loop = false
max_duration = 0
respect_flip = true
respect_offset = true
scaling = smooth
sticky = false
stretch = false
```