### PR TITLE
use base folder on android so the error matches

### DIFF
--- a/src/path_functions.cpp
+++ b/src/path_functions.cpp
@@ -33,12 +33,12 @@ QString AOApplication::get_base_path()
   QString base_path = "";
 #ifdef ANDROID
   QString sdcard_storage = getenv("SECONDARY_STORAGE");
-  if (dir_exists(sdcard_storage + "/AO2/")) {
-    base_path = sdcard_storage + "/AO2/";
+  if (dir_exists(sdcard_storage + "/base/")) {
+    base_path = sdcard_storage + "/base/";
   }
   else {
     QString external_storage = getenv("EXTERNAL_STORAGE");
-    base_path = external_storage + "/AO2/";
+    base_path = external_storage + "/base/";
   }
 #elif defined(__APPLE__)
   base_path = applicationDirPath() + "/../../../base/";


### PR DESCRIPTION
also makes extracting vanilla or applying updates easier

yes, the 3 current android users will have to rename their AO2 folder

but this makes it more logical and easier to set up the client on android

together with it asking for permission on it's own this could be a realistic solution