### PR TITLE
Fix weird evidence image behavior if mounted path is next to base folder and starts with "base"

### DIFF
--- a/src/evidence.cpp
+++ b/src/evidence.cpp
@@ -397,7 +397,7 @@ void Courtroom::on_evidence_image_name_edited()
 
 void Courtroom::on_evidence_image_button_clicked()
 {
-  QDir dir(ao_app->get_real_path(ao_app->get_evidence_path("")));
+  QDir dir("base/evidence/");
   QFileDialog dialog(this);
   dialog.setFileMode(QFileDialog::ExistingFile);
   dialog.setNameFilter(tr("Images (*.png)"));
@@ -417,7 +417,7 @@ void Courtroom::on_evidence_image_button_clicked()
   bases.prepend(ao_app->get_base_path());
   for (const QString &base : bases) {
     QDir baseDir(base);
-    if (filename.startsWith(baseDir.absolutePath())) {
+    if (filename.startsWith(baseDir.absolutePath() + "/")) {
       dir.setPath(baseDir.absolutePath() + "/evidence");
       break;
     }


### PR DESCRIPTION
"base_Extra" was ignored previously if it's next to the normal "base" folder, since "startswith" would find that the "base" folder is its first find.
Start evidence image search in the base evidence folder rather than the topmost mounted path