### PR TITLE
Add option to disable music streaming.

### DIFF
--- a/include/aoapplication.h
+++ b/include/aoapplication.h
@@ -194,6 +194,9 @@ public:
   // Returns true if stop music on objection is enabled in the config.ini
   bool objection_stop_music();
 
+  // Returns true if streaming is enabled in the config.ini
+  bool is_streaming_disabled();
+
   // Returns the value of default_music in config.ini
   int get_default_music();
 

--- a/include/aooptionsdialog.h
+++ b/include/aooptionsdialog.h
@@ -142,6 +142,8 @@ private:
   QCheckBox *ui_loopsfx_cb;
   QLabel *ui_objectmusic_lbl;
   QCheckBox *ui_objectmusic_cb;
+  QLabel *ui_disablestreams_lbl;
+  QCheckBox *ui_disablestreams_cb;
   QDialogButtonBox *ui_settings_buttons;
 
   QWidget *ui_casing_tab;

--- a/src/aomusicplayer.cpp
+++ b/src/aomusicplayer.cpp
@@ -31,8 +31,8 @@ QString AOMusicPlayer::play(QString p_song, int channel, bool loop,
   if (f_path.startsWith("http")) {
 
     if (ao_app->is_streaming_disabled()) {
-        return QObject::tr("[MISSING] Streaming disabled.");
         BASS_ChannelStop(m_stream_list[channel]);
+        return QObject::tr("[MISSING] Streaming disabled.");
     }
 
     if (f_path.endsWith(".opus"))

--- a/src/aomusicplayer.cpp
+++ b/src/aomusicplayer.cpp
@@ -29,6 +29,12 @@ QString AOMusicPlayer::play(QString p_song, int channel, bool loop,
   QString f_path = p_song;
   DWORD newstream;
   if (f_path.startsWith("http")) {
+
+    if (ao_app->is_streaming_disabled()) {
+        return QObject::tr("[MISSING] Streaming disabled.");
+        BASS_ChannelStop(m_stream_list[channel]);
+    }
+
     if (f_path.endsWith(".opus"))
       newstream = BASS_OPUS_StreamCreateURL(f_path.toStdString().c_str(), 0, streaming_flags, nullptr, 0);
     else if (f_path.endsWith(".mid"))

--- a/src/aooptionsdialog.cpp
+++ b/src/aooptionsdialog.cpp
@@ -687,7 +687,7 @@ AOOptionsDialog::AOOptionsDialog(QWidget *parent, AOApplication *p_ao_app)
   ui_disablestreams_lbl = new QLabel(ui_audio_widget);
   ui_disablestreams_lbl->setText(tr("Disable Music Streaming:"));
   ui_disablestreams_lbl->setToolTip(
-      tr("If true, AO2 will not play any streamed audio and show the song as missing."));
+      tr("If true, AO2 will not play any streamed audio and show that streaming is disabled."));
   ui_audio_layout->setWidget(row, QFormLayout::LabelRole, ui_disablestreams_lbl);
 
   ui_disablestreams_cb = new QCheckBox(ui_audio_widget);

--- a/src/aooptionsdialog.cpp
+++ b/src/aooptionsdialog.cpp
@@ -683,6 +683,16 @@ AOOptionsDialog::AOOptionsDialog(QWidget *parent, AOApplication *p_ao_app)
 
   ui_audio_layout->setWidget(row, QFormLayout::FieldRole, ui_objectmusic_cb);
 
+  row += 1;
+  ui_disablestreams_lbl = new QLabel(ui_audio_widget);
+  ui_disablestreams_lbl->setText(tr("Disable Music Streaming:"));
+  ui_disablestreams_lbl->setToolTip(
+      tr("If true, AO2 will not play any streamed audio and show the song as missing."));
+  ui_audio_layout->setWidget(row, QFormLayout::LabelRole, ui_disablestreams_lbl);
+
+  ui_disablestreams_cb = new QCheckBox(ui_audio_widget);
+  ui_audio_layout->setWidget(row, QFormLayout::FieldRole, ui_disablestreams_cb);
+
   // The casing tab!
   ui_casing_tab = new QWidget(this);
   ui_settings_tabs->addTab(ui_casing_tab, tr("Casing"));
@@ -1202,6 +1212,7 @@ void AOOptionsDialog::update_values() {
   ui_blank_blips_cb->setChecked(ao_app->get_blank_blip());
   ui_loopsfx_cb->setChecked(ao_app->get_looping_sfx());
   ui_objectmusic_cb->setChecked(ao_app->objection_stop_music());
+  ui_disablestreams_cb->setChecked(ao_app->is_streaming_disabled());
   ui_casing_enabled_cb->setChecked(ao_app->get_casing_enabled());
   ui_casing_def_cb->setChecked(ao_app->get_casing_defence_enabled());
   ui_casing_pro_cb->setChecked(ao_app->get_casing_prosecution_enabled());
@@ -1307,6 +1318,7 @@ void AOOptionsDialog::save_pressed()
   configini->setValue("blank_blip", ui_blank_blips_cb->isChecked());
   configini->setValue("looping_sfx", ui_loopsfx_cb->isChecked());
   configini->setValue("objection_stop_music", ui_objectmusic_cb->isChecked());
+  configini->setValue("streaming_disabled", ui_disablestreams_cb->isChecked());
 
   configini->setValue("casing_enabled", ui_casing_enabled_cb->isChecked());
   configini->setValue("casing_defence_enabled", ui_casing_def_cb->isChecked());

--- a/src/text_file_functions.cpp
+++ b/src/text_file_functions.cpp
@@ -1042,6 +1042,11 @@ bool AOApplication::objection_stop_music()
   return result.startsWith("true");
 }
 
+bool AOApplication::is_streaming_disabled()
+{
+    return configini->value("streaming_disabled", false).toBool();
+}
+
 bool AOApplication::is_instant_objection_enabled()
 {
   QString result = configini->value("instant_objection", "true").value<QString>();


### PR DESCRIPTION
This PR addresses the issue in which streaming is forced by the client, meaning people can't decide if they want to stream audio or not.
This is a problem as players may not want to want to stream music or only have limited data/mobile data.
closes #827 