### PR TITLE
Removed unused prompt remove favorite server method in AOApplication

### DIFF
--- a/include/aoapplication.h
+++ b/include/aoapplication.h
@@ -138,7 +138,6 @@ public:
   // Adds the server to favorite_servers.ini
   void add_favorite_server(int p_server);
   void remove_favorite_server(int p_server);
-  void prompt_remove_favorite_server(int p_server);
 
   void set_server_list(QVector<server_type> &servers) { server_list = servers; }
   QVector<server_type> &get_server_list() { return server_list; }

--- a/src/aoapplication.cpp
+++ b/src/aoapplication.cpp
@@ -180,11 +180,6 @@ void AOApplication::remove_favorite_server(int p_server)
   save_favorite_list();
 }
 
-void AOApplication::prompt_remove_favorite_server(int p_server)
-{
-
-}
-
 void AOApplication::server_disconnected()
 {
   if (courtroom_constructed) {


### PR DESCRIPTION
The method removed was meant to provide a prompt before removing the favorite server. I accidentally left it in, removing it will not affect the functionality of the client.

Apologies for needless addition.