### PR TITLE
Revert "Disable DPI scaling for good (#769)"

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -14,6 +14,13 @@ int main(int argc, char *argv[])
 {
   qSetMessagePattern("%{type}: %{if-category}%{category}: %{endif}%{message}");
 
+#if QT_VERSION > QT_VERSION_CHECK(5, 6, 0)
+  // High-DPI support is for Qt version >=5.6.
+  // However, many Linux distros still haven't brought their stable/LTS
+  // packages up to Qt 5.6, so this is conditional.
+  AOApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
+#endif
+
   AOApplication main_app(argc, argv);
 
   AOApplication::addLibraryPath(AOApplication::applicationDirPath() + "/lib");


### PR DESCRIPTION
This reverts commit 704c279f481e01e4b4e6a774c72fe8cee72ccd0f.

Turns out this did affect Android builds.