### PR TITLE
Don't reset evidence selection on theme reload

### DIFF
--- a/src/courtroom.cpp
+++ b/src/courtroom.cpp
@@ -1590,9 +1590,6 @@ void Courtroom::update_character(int p_cid, QString char_name, bool reset_emote)
 
 void Courtroom::enter_courtroom()
 {
-  current_evidence_page = 0;
-  current_evidence = 0;
-
   set_evidence_page();
 
   if (ao_app->flipping_supported)


### PR DESCRIPTION
They are defaulted in the header. This SHOULD not affect the client negatively.

closes #857