### PR TITLE
Fix case of self_offset received without a y offset

### DIFF
--- a/src/courtroom.cpp
+++ b/src/courtroom.cpp
@@ -3977,10 +3977,9 @@ void Courtroom::set_self_offset(const QString& p_list) {
     }
     else {
       self_offset_v = self_offsets[1].toInt();
-      ui_vp_player_char->move_and_center(ui_viewport->width() * self_offset / 100, ui_viewport->height() * self_offset_v / 100);
-      const int percent = 100;
-      ui_vp_player_char->move(ui_viewport->width() * self_offset / percent, ui_viewport->height() * self_offset_v / percent);
     }
+    ui_vp_player_char->move_and_center(ui_viewport->width() * self_offset / 100,
+                                       ui_viewport->height() * self_offset_v / 100);
 }
 
 void Courtroom::set_ip_list(QString p_list)


### PR DESCRIPTION
caused by typos in #701

it's possible for older clients to send x offsets without a y offset. if you think this case is annoying you can remove it in the next version and handle it server-side instead