### PR TITLE
Add Qt <5.14 compatibility code, suppress a compiler warning

### DIFF
--- a/src/courtroom.cpp
+++ b/src/courtroom.cpp
@@ -1736,6 +1736,7 @@ void Courtroom::list_areas()
 void Courtroom::debug_message_handler(QtMsgType type, const QMessageLogContext &context,
                                       const QString &msg)
 {
+  Q_UNUSED(context);
   const QMap<QtMsgType, QString> colors = {
     {QtDebugMsg, "debug"},
     {QtInfoMsg, "info"},

--- a/src/lobby.cpp
+++ b/src/lobby.cpp
@@ -199,10 +199,18 @@ void Lobby::loadUI()
       QFile l_changelog(get_base_path() + "changelog.md");
       if (!l_changelog.open(QFile::ReadOnly)) {
           qDebug() << "Unable to locate changelog file. Does it even exist?";
+#if QT_VERSION >= QT_VERSION_CHECK(5, 14, 0)
           ui_game_changelog_text->setMarkdown(l_changelog_text);
+#else
+          ui_game_changelog_text->setPlainText(l_changelog_text); // imperfect solution, but implementing Markdown ourselves for this edge case is out of scope
+#endif
           return;
       }
+#if QT_VERSION >= QT_VERSION_CHECK(5, 14, 0)
       ui_game_changelog_text->setMarkdown(l_changelog.readAll());
+#else
+      ui_game_changelog_text->setPlainText((l_changelog.readAll()));
+#endif
       l_changelog.close();
 
       QTabWidget* l_tabbar = findChild<QTabWidget*>("motd_changelog_tab");


### PR DESCRIPTION
lobby.cpp:
* Added compatibility code so 2.10.1 can run on Qt versions older than 5.14, such as the version that ships with Ubuntu 20.04

courtroom.cpp:
* Used a Q_UNUSED macro on an unused variable to suppress a compiler warning