### PR TITLE
Make speedlines stretch by default

### DIFF
--- a/src/courtroom.cpp
+++ b/src/courtroom.cpp
@@ -53,6 +53,7 @@ Courtroom::Courtroom(AOApplication *p_ao_app) : QMainWindow()
   ui_vp_background->setObjectName("ui_vp_background");
   ui_vp_speedlines = new SplashLayer(ui_viewport, ao_app);
   ui_vp_speedlines->setObjectName("ui_vp_speedlines");
+  ui_vp_speedlines->stretch = true;
   ui_vp_player_char = new CharLayer(ui_viewport, ao_app);
   ui_vp_player_char->setObjectName("ui_vp_player_char");
   ui_vp_player_char->masked = false;


### PR DESCRIPTION
Fixes #895.

Users who don't want the speedlines to stretch will have to add a `defense_speedlines.[extension].ini` file with `stretch=false` to override this, but I don't think anyone will actually be wanting to do that...

I was hoping to do something more significant, but understanding AO pathing proved too hard for me for now :(