### PR TITLE
Rework default volume settings

### DIFF
--- a/include/widgets/aooptionsdialog.h
+++ b/include/widgets/aooptionsdialog.h
@@ -87,9 +87,6 @@ private:
   QWidget *ui_audio_tab;
   QWidget *ui_audio_widget;
   QComboBox *ui_audio_device_combobox;
-  QSpinBox *ui_music_volume_spinbox;
-  QSpinBox *ui_sfx_volume_spinbox;
-  QSpinBox *ui_blips_volume_spinbox;
   QSpinBox *ui_suppress_audio_spinbox;
   QFrame *ui_volume_blip_divider;
   QSpinBox *ui_bliprate_spinbox;

--- a/resource/ui/options_dialog.ui
+++ b/resource/ui/options_dialog.ui
@@ -23,7 +23,7 @@
       <enum>Qt::NoFocus</enum>
      </property>
      <property name="currentIndex">
-      <number>0</number>
+      <number>2</number>
      </property>
      <widget class="QWidget" name="gameplay_tab">
       <attribute name="title">
@@ -40,8 +40,8 @@
            <rect>
             <x>0</x>
             <y>0</y>
-            <width>389</width>
-            <height>701</height>
+            <width>394</width>
+            <height>826</height>
            </rect>
           </property>
           <layout class="QFormLayout" name="formLayout">
@@ -613,171 +613,6 @@
        <item row="0" column="1">
         <widget class="QComboBox" name="audio_device_combobox"/>
        </item>
-       <item row="2" column="0">
-        <widget class="QLabel" name="music_volume_lbl">
-         <property name="toolTip">
-          <string>Sets the music's default volume.</string>
-         </property>
-         <property name="text">
-          <string>Music:</string>
-         </property>
-        </widget>
-       </item>
-       <item row="2" column="1">
-        <widget class="QSpinBox" name="music_volume_spinbox">
-         <property name="suffix">
-          <string>%</string>
-         </property>
-         <property name="maximum">
-          <number>100</number>
-         </property>
-        </widget>
-       </item>
-       <item row="3" column="0">
-        <widget class="QLabel" name="sfx_volume_lbl">
-         <property name="toolTip">
-          <string>Sets the SFX's default volume. Interjections and actual sound effects count as 'SFX'.</string>
-         </property>
-         <property name="text">
-          <string>SFX:</string>
-         </property>
-        </widget>
-       </item>
-       <item row="3" column="1">
-        <widget class="QSpinBox" name="sfx_volume_spinbox">
-         <property name="suffix">
-          <string>%</string>
-         </property>
-         <property name="maximum">
-          <number>100</number>
-         </property>
-        </widget>
-       </item>
-       <item row="4" column="0">
-        <widget class="QLabel" name="blips_volume_lbl">
-         <property name="toolTip">
-          <string>Sets the volume of the blips, the talking sound effects.</string>
-         </property>
-         <property name="text">
-          <string>Blips:</string>
-         </property>
-        </widget>
-       </item>
-       <item row="4" column="1">
-        <widget class="QSpinBox" name="blips_volume_spinbox">
-         <property name="suffix">
-          <string>%</string>
-         </property>
-         <property name="maximum">
-          <number>100</number>
-         </property>
-        </widget>
-       </item>
-       <item row="5" column="0">
-        <widget class="QLabel" name="suppress_audio_lbl">
-         <property name="toolTip">
-          <string>How much of the volume to suppress when client is not in focus.</string>
-         </property>
-         <property name="text">
-          <string>Suppress Audio:</string>
-         </property>
-        </widget>
-       </item>
-       <item row="5" column="1">
-        <widget class="QSpinBox" name="suppress_audio_spinbox">
-         <property name="suffix">
-          <string>%</string>
-         </property>
-         <property name="maximum">
-          <number>100</number>
-         </property>
-        </widget>
-       </item>
-       <item row="7" column="0">
-        <widget class="QLabel" name="bliprate_lbl">
-         <property name="toolTip">
-          <string>Sets the delay between playing the blip sounds.</string>
-         </property>
-         <property name="text">
-          <string>Blip rate:</string>
-         </property>
-        </widget>
-       </item>
-       <item row="7" column="1">
-        <widget class="QSpinBox" name="bliprate_spinbox">
-         <property name="toolTip">
-          <string>Play a blip sound \&quot;once per every X symbols\&quot;, where X is the blip rate. 0 plays a blip sound only once.</string>
-         </property>
-        </widget>
-       </item>
-       <item row="8" column="0">
-        <widget class="QLabel" name="blank_blips_lbl">
-         <property name="toolTip">
-          <string>If true, the game will play a blip sound even when a space is 'being said'.</string>
-         </property>
-         <property name="text">
-          <string>Blank blips:</string>
-         </property>
-        </widget>
-       </item>
-       <item row="8" column="1">
-        <widget class="QCheckBox" name="blank_blips_cb">
-         <property name="text">
-          <string/>
-         </property>
-        </widget>
-       </item>
-       <item row="9" column="0">
-        <widget class="QLabel" name="loopsfx_lbl">
-         <property name="toolTip">
-          <string>If true, the game will allow looping sound effects to play on preanimations.</string>
-         </property>
-         <property name="text">
-          <string>Enable Looping SFX:</string>
-         </property>
-        </widget>
-       </item>
-       <item row="9" column="1">
-        <widget class="QCheckBox" name="loopsfx_cb">
-         <property name="text">
-          <string/>
-         </property>
-        </widget>
-       </item>
-       <item row="10" column="0">
-        <widget class="QLabel" name="objectmusic_lbl">
-         <property name="toolTip">
-          <string>If true, AO2 will ask the server to stop music when you use 'Objection!'</string>
-         </property>
-         <property name="text">
-          <string>Kill Music On Objection:</string>
-         </property>
-        </widget>
-       </item>
-       <item row="10" column="1">
-        <widget class="QCheckBox" name="objectmusic_cb">
-         <property name="text">
-          <string/>
-         </property>
-        </widget>
-       </item>
-       <item row="11" column="0">
-        <widget class="QLabel" name="disablestreams_lbl">
-         <property name="toolTip">
-          <string>If true, AO2 will not play any streamed audio and show that streaming is disabled.</string>
-         </property>
-         <property name="text">
-          <string>Music Streaming enabled:</string>
-         </property>
-        </widget>
-       </item>
-       <item row="11" column="1">
-        <widget class="QCheckBox" name="disablestreams_cb">
-         <property name="text">
-          <string/>
-         </property>
-        </widget>
-       </item>
        <item row="1" column="0" colspan="2">
         <widget class="QFrame" name="audio_volume_divider">
          <property name="frameShape">
@@ -788,13 +623,118 @@
          </property>
         </widget>
        </item>
-       <item row="6" column="0" colspan="2">
+       <item row="2" column="0">
+        <widget class="QLabel" name="suppress_audio_lbl">
+         <property name="toolTip">
+          <string>How much of the volume to suppress when client is not in focus.</string>
+         </property>
+         <property name="text">
+          <string>Suppress Audio:</string>
+         </property>
+        </widget>
+       </item>
+       <item row="2" column="1">
+        <widget class="QSpinBox" name="suppress_audio_spinbox">
+         <property name="suffix">
+          <string>%</string>
+         </property>
+         <property name="maximum">
+          <number>100</number>
+         </property>
+        </widget>
+       </item>
+       <item row="3" column="0" colspan="2">
         <widget class="QFrame" name="volume_blip_divider">
          <property name="frameShape">
           <enum>QFrame::HLine</enum>
          </property>
          <property name="frameShadow">
           <enum>QFrame::Sunken</enum>
+         </property>
+        </widget>
+       </item>
+       <item row="4" column="0">
+        <widget class="QLabel" name="bliprate_lbl">
+         <property name="toolTip">
+          <string>Sets the delay between playing the blip sounds.</string>
+         </property>
+         <property name="text">
+          <string>Blip rate:</string>
+         </property>
+        </widget>
+       </item>
+       <item row="4" column="1">
+        <widget class="QSpinBox" name="bliprate_spinbox">
+         <property name="toolTip">
+          <string>Play a blip sound \&quot;once per every X symbols\&quot;, where X is the blip rate. 0 plays a blip sound only once.</string>
+         </property>
+        </widget>
+       </item>
+       <item row="5" column="0">
+        <widget class="QLabel" name="blank_blips_lbl">
+         <property name="toolTip">
+          <string>If true, the game will play a blip sound even when a space is 'being said'.</string>
+         </property>
+         <property name="text">
+          <string>Blank blips:</string>
+         </property>
+        </widget>
+       </item>
+       <item row="5" column="1">
+        <widget class="QCheckBox" name="blank_blips_cb">
+         <property name="text">
+          <string/>
+         </property>
+        </widget>
+       </item>
+       <item row="6" column="0">
+        <widget class="QLabel" name="loopsfx_lbl">
+         <property name="toolTip">
+          <string>If true, the game will allow looping sound effects to play on preanimations.</string>
+         </property>
+         <property name="text">
+          <string>Enable Looping SFX:</string>
+         </property>
+        </widget>
+       </item>
+       <item row="6" column="1">
+        <widget class="QCheckBox" name="loopsfx_cb">
+         <property name="text">
+          <string/>
+         </property>
+        </widget>
+       </item>
+       <item row="7" column="0">
+        <widget class="QLabel" name="objectmusic_lbl">
+         <property name="toolTip">
+          <string>If true, AO2 will ask the server to stop music when you use 'Objection!'</string>
+         </property>
+         <property name="text">
+          <string>Kill Music On Objection:</string>
+         </property>
+        </widget>
+       </item>
+       <item row="7" column="1">
+        <widget class="QCheckBox" name="objectmusic_cb">
+         <property name="text">
+          <string/>
+         </property>
+        </widget>
+       </item>
+       <item row="8" column="0">
+        <widget class="QLabel" name="disablestreams_lbl">
+         <property name="toolTip">
+          <string>If true, AO2 will not play any streamed audio and show that streaming is disabled.</string>
+         </property>
+         <property name="text">
+          <string>Music Streaming enabled:</string>
+         </property>
+        </widget>
+       </item>
+       <item row="8" column="1">
+        <widget class="QCheckBox" name="disablestreams_cb">
+         <property name="text">
+          <string/>
          </property>
         </widget>
        </item>

--- a/resource/ui/options_dialog.ui
+++ b/resource/ui/options_dialog.ui
@@ -23,7 +23,7 @@
       <enum>Qt::NoFocus</enum>
      </property>
      <property name="currentIndex">
-      <number>2</number>
+      <number>0</number>
      </property>
      <widget class="QWidget" name="gameplay_tab">
       <attribute name="title">

--- a/src/courtroom.cpp
+++ b/src/courtroom.cpp
@@ -5822,6 +5822,11 @@ void Courtroom::truncate_label_text(QWidget *p_widget, QString p_identifier)
 
 Courtroom::~Courtroom()
 {
+  //save sound settings
+  Options::getInstance().setMusicVolume(ui_music_slider->value());
+  Options::getInstance().setSfxVolume(ui_sfx_slider->value());
+  Options::getInstance().setBlipVolume(ui_blip_slider->value());
+
   delete music_player;
   delete sfx_player;
   delete objection_player;

--- a/src/widgets/aooptionsdialog.cpp
+++ b/src/widgets/aooptionsdialog.cpp
@@ -450,9 +450,6 @@ void AOOptionsDialog::setupUI()
                                      &Options::audioOutputDevice,
                                      &Options::setAudioOutputDevice);
 
-  FROM_UI(QSpinBox, music_volume_spinbox)
-  FROM_UI(QSpinBox, sfx_volume_spinbox)
-  FROM_UI(QSpinBox, blips_volume_spinbox)
   FROM_UI(QSpinBox, suppress_audio_spinbox)
   FROM_UI(QSpinBox, bliprate_spinbox)
   FROM_UI(QCheckBox, blank_blips_cb)
@@ -460,12 +457,6 @@ void AOOptionsDialog::setupUI()
   FROM_UI(QCheckBox, objectmusic_cb)
   FROM_UI(QCheckBox, disablestreams_cb)
 
-  registerOption<QSpinBox, int>("music_volume_spinbox", &Options::musicVolume,
-                                &Options::setMusicVolume);
-  registerOption<QSpinBox, int>("sfx_volume_spinbox", &Options::sfxVolume,
-                                &Options::setSfxVolume);
-  registerOption<QSpinBox, int>("blips_volume_spinbox", &::Options::blipVolume,
-                                &Options::setBlipVolume);
   registerOption<QSpinBox, int>("suppress_audio_spinbox",
                                 &::Options::defaultSuppressAudio,
                                 &Options::setDefaultSupressedAudio);


### PR DESCRIPTION
Addresses #892 by making the client remember the last volume settings from the sliders. This makes the volume settings in the options dialog unnecessary, so those were removed.