### PR TITLE
Fix zooms with no emote modifier defaulting to 1 (show desk)

### DIFF
--- a/src/courtroom.cpp
+++ b/src/courtroom.cpp
@@ -1830,6 +1830,8 @@ void Courtroom::on_chat_return_pressed()
 
   QStringList packet_contents;
   QString f_side;
+  // have to fetch this early for a workaround. i hate this system, but i am stuck with it for now
+  int f_emote_mod = ao_app->get_emote_mod(current_char, current_emote);
 
   if (current_side == "")
     f_side = ao_app->get_char_side(current_char);
@@ -1846,14 +1848,15 @@ void Courtroom::on_chat_return_pressed()
       else if (f_desk_mod == DESK_EMOTE_ONLY_EX || f_desk_mod == DESK_EMOTE_ONLY)
         f_desk_mod = DESK_SHOW;
     }
-    if (f_desk_mod == -1)
+    if (f_desk_mod == -1 && (f_emote_mod == 5 || f_emote_mod == 6)) // workaround for inis that broke after deprecating "chat"
+      f_desk_mod = DESK_HIDE;
+    else if (f_desk_mod == -1)
       f_desk_mod = DESK_SHOW;
   }
 
   packet_contents.append(QString::number(f_desk_mod));
 
   QString f_pre = ao_app->get_pre_emote(current_char, current_emote);
-  int f_emote_mod = ao_app->get_emote_mod(current_char, current_emote);
   QString f_sfx = "1";
   int f_sfx_delay = get_char_sfx_delay();
 


### PR DESCRIPTION
fixes https://github.com/AttorneyOnline/AO2-Client/issues/924

i hate emote mod i hate desk mod i hate switch cases and if statements that use the same values in the same function i hate crappy workarounds i hate the AO2 messaging protocol