### PR TITLE
Rework MS list callback logic

### DIFF
--- a/include/networkmanager.h
+++ b/include/networkmanager.h
@@ -55,7 +55,7 @@ signals:
   void server_connected(bool state);
 
 public slots:
-  void get_server_list(const std::function<void()> &cb);
+  void get_server_list();
   void ship_server_packet(QString p_packet);
   void join_to_server();
   void handle_server_packet(const QString& p_data);
@@ -64,8 +64,7 @@ public slots:
                         const std::function<void(QString)> &cb);
   void send_heartbeat();
 private slots:
-  void ms_request_finished(QNetworkReply *reply,
-                           const std::function<void()> &cb);
+  void ms_request_finished(QNetworkReply *reply);
 
 private:
   QString get_user_agent() const {

--- a/src/lobby.cpp
+++ b/src/lobby.cpp
@@ -229,7 +229,7 @@ void Lobby::loadUI()
 
 void Lobby::on_refresh_released()
 {
-  net_manager->get_server_list(std::bind(&Lobby::list_servers, this));
+  net_manager->get_server_list();
   get_motd();
   list_favorites();
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -56,7 +56,7 @@ int main(int argc, char *argv[])
   main_app.installTranslator(&appTranslator);
 
   main_app.construct_lobby();
-  main_app.net_manager->get_server_list(std::bind(&Lobby::list_servers, main_app.w_lobby));
+  main_app.net_manager->get_server_list();
   main_app.net_manager->send_heartbeat();
   main_app.w_lobby->show();
   return main_app.exec();

--- a/src/networkmanager.cpp
+++ b/src/networkmanager.cpp
@@ -29,18 +29,17 @@ NetworkManager::NetworkManager(AOApplication *parent) : QObject(parent)
   heartbeat_timer->start(heartbeat_interval);
 }
 
-void NetworkManager::get_server_list(const std::function<void()> &cb)
+void NetworkManager::get_server_list()
 {
   QNetworkRequest req(QUrl(ms_baseurl + "/servers"));
   req.setRawHeader("User-Agent", get_user_agent().toUtf8());
 
   QNetworkReply *reply = http->get(req);
   connect(reply, &QNetworkReply::finished,
-          this, std::bind(&NetworkManager::ms_request_finished, this, reply, cb));
+          this, std::bind(&NetworkManager::ms_request_finished, this, reply));
 }
 
-void NetworkManager::ms_request_finished(QNetworkReply *reply,
-                                         const std::function<void()> &cb)
+void NetworkManager::ms_request_finished(QNetworkReply *reply)
 {
   QJsonDocument json = QJsonDocument::fromJson(reply->readAll());
   if (json.isNull()) {
@@ -72,8 +71,9 @@ void NetworkManager::ms_request_finished(QNetworkReply *reply,
   }
   ao_app->set_server_list(server_list);
 
-  cb();
-
+  if (ao_app->lobby_constructed) {
+        ao_app->w_lobby->list_servers();
+  }
   reply->deleteLater();
 }
 


### PR DESCRIPTION
Removes the callback pattern from `get_server_list` and `ms_request_finished` since the only callback ever used in these was listing the servers anyhow.

Also fixes a segfault that happened when joining a server before the MS list was acquired (AO would try to have lobby list the servers while lobby didn't exist, after getting a reply for the MS list).

Technically to fix this crash only an if check around the callback was required, so if removing the callback pattern is too much I can have the pull request do only the check ¯\\\_(ツ)_/¯ (accessing lobby from the network manager IS kind of ugly).

edit: fix shrug emoji (important)