### PR TITLE
Fix Windows and Android CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - 5.15.1
+          - 5.15.2
         platform:
           - gcc_64
           - android
@@ -23,18 +23,29 @@ jobs:
           - platform: gcc_64
             os: ubuntu-latest
             target: desktop
+            make: make
+
           - platform: android
             os: ubuntu-20.04
             target: android
+            make: make
+
           - platform: msvc2019
             os: windows-2019
             target: desktop
+            make: nmake
+
           - platform: mingw81_32
             os: windows-latest
             target: desktop
+            arch: win32_mingw81
+            tools: 'tools_mingw,qt.tools.win32_mingw810'
+            make: mingw32-make
+
           - platform: clang_64
             os: macos-latest
             target: desktop
+            make: make
 
     runs-on: ${{matrix.os}}
     steps:
@@ -59,19 +70,29 @@ jobs:
       - name: Downgrade Android NDK
         if: matrix.platform == 'android'
         run: |
-           ANDROID_ROOT=/usr/local/lib/android
-           ANDROID_SDK_ROOT=${ANDROID_ROOT}/sdk
-           ANDROID_NDK_ROOT=${ANDROID_SDK_ROOT}/ndk-bundle
-           SDKMANAGER=${ANDROID_SDK_ROOT}/cmdline-tools/latest/bin/sdkmanager
-           echo "y" | $SDKMANAGER "ndk;21.4.7075529"
-           echo "y" | $SDKMANAGER "platforms;android-24"
-           ln -sfn $ANDROID_SDK_ROOT/ndk/21.4.7075529 $ANDROID_NDK_ROOT
-        
+          ANDROID_ROOT=/usr/local/lib/android
+          ANDROID_SDK_ROOT=${ANDROID_ROOT}/sdk
+          ANDROID_NDK_ROOT=${ANDROID_SDK_ROOT}/ndk-bundle
+          SDKMANAGER=${ANDROID_SDK_ROOT}/cmdline-tools/latest/bin/sdkmanager
+          echo "y" | $SDKMANAGER "ndk;21.4.7075529"
+          echo "y" | $SDKMANAGER "platforms;android-24"
+
+          # this is so stupid but i can't find anything else that works
+          rm -rf $ANDROID_HOME/ndk/25.2.9519653
+          ln -sf $ANDROID_HOME/ndk/21.4.7075529 $ANDROID_HOME/ndk/25.2.9519653
+ 
       - uses: jurplel/install-qt-action@v3
         id: qt
         with:
           version: ${{matrix.version}}
           target: ${{matrix.target}}
+          arch: ${{matrix.arch}}
+          tools: ${{matrix.tools}}
+
+      - name: Add tools to PATH (MinGW)
+        if: matrix.platform == 'mingw81_32'
+        shell: bash
+        run: echo "$RUNNER_WORKSPACE/Qt/Tools/mingw810_32/bin" >> $GITHUB_PATH
 
       - name: Configure MSVC (Windows)
         if: contains(matrix.platform, 'msvc')
@@ -86,17 +107,20 @@ jobs:
           ./get_libs.sh 1.3 1.6.37
           cd ../..
           qmake CONFIG+=install_ok QMAKE_CXXFLAGS+="-fno-sized-deallocation" QT_PLATFORM=${{matrix.platform}}
-          make
-          make INSTALL_ROOT="$QT_ROOT_DIR" install
+          ${{matrix.make}}
+          ${{matrix.make}} INSTALL_ROOT="${Qt5_DIR}" install
 
       - name: Install Windows Discord RPC
         if: contains(matrix.os, 'windows')
+        env:
+            ARCH: ${{ matrix.platform == 'msvc2019' && '64' || '32'}}
+        shell: bash
         run: |
           curl -L https://github.com/discordapp/discord-rpc/releases/download/v3.4.0/discord-rpc-win.zip -o discord_rpc.zip
           unzip discord_rpc.zip
-          cp ./discord-rpc/win32-dynamic/lib/discord-rpc.lib ./lib/
-          cp ./discord-rpc/win32-dynamic/bin/discord-rpc.dll ./bin/
-          cp ./discord-rpc/win32-dynamic/include/discord*.h ./include/
+          cp ./discord-rpc/win${ARCH}-dynamic/lib/discord-rpc.lib ./lib/
+          cp ./discord-rpc/win${ARCH}-dynamic/bin/discord-rpc.dll ./bin/
+          cp ./discord-rpc/win${ARCH}-dynamic/include/discord*.h ./include/
 
       - name: Install Linux Discord RPC
         if: matrix.platform == 'gcc_64'
@@ -118,21 +142,24 @@ jobs:
 
       - name: Install Windows BASS
         if: contains(matrix.os, 'windows')
+        env:
+          ARCH: ${{ matrix.platform == 'msvc2019' && '/x64/' || ''}}
+        shell: bash
         run: |
           curl http://www.un4seen.com/files/bass24.zip -o bass.zip
           unzip -d bass -o bass.zip
-          cp ./bass/c/bass.lib ./lib/
-          cp ./bass/bass.dll ./bin/
+          cp ./bass/c/${ARCH}bass.lib ./lib/
+          cp ./bass/${ARCH}bass.dll ./bin/
 
           curl http://www.un4seen.com/files/bassmidi24.zip -o bassmidi.zip
           unzip -d bass -o bassmidi.zip
-          cp ./bass/c/bassmidi.lib ./lib/
-          cp ./bass/bassmidi.dll ./bin/
+          cp ./bass/c/${ARCH}bassmidi.lib ./lib/
+          cp ./bass/${ARCH}bassmidi.dll ./bin/
 
           curl http://www.un4seen.com/files/bassopus24.zip -o bassopus.zip
           unzip -d bass -o bassopus.zip
-          cp ./bass/c/bassopus.lib ./lib/
-          cp ./bass/bassopus.dll ./bin/
+          cp ./bass/c/${ARCH}bassopus.lib ./lib/
+          cp ./bass/${ARCH}bassopus.dll ./bin/
 
       - name: Install Linux BASS
         if: matrix.platform == 'gcc_64'
@@ -204,7 +231,7 @@ jobs:
 
       - name: build
         run: |
-          make
+          ${{matrix.make}}
 
       - name: Deploy Windows
         if: contains(matrix.os, 'windows')
@@ -230,9 +257,9 @@ jobs:
         working-directory: ${{github.workspace}}/bin/
         shell: bash
         run: |
-          cp D:/a/AO2-Client/AO2-Client/.cache/qt/Tools/mingw810_32/bin/libgcc_s_dw2-1.dll .
-          cp D:/a/AO2-Client/AO2-Client/.cache/qt/Tools/mingw810_32/bin/libstdc++-6.dll .
-          cp D:/a/AO2-Client/AO2-Client/.cache/qt/Tools/mingw810_32/bin/libwinpthread-1.dll .
+          cp $RUNNER_WORKSPACE/Qt/Tools/mingw810_32/bin/libgcc_s_dw2-1.dll .
+          cp $RUNNER_WORKSPACE/Qt/Tools/mingw810_32/bin/libstdc++-6.dll .
+          cp $RUNNER_WORKSPACE/Qt/Tools/mingw810_32/bin/libwinpthread-1.dll .
 
       - name: Deploy Linux
         if: matrix.platform == 'gcc_64'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,13 +56,6 @@ jobs:
         with:
           python-version: '3.10'
           
-      - name: actions/cache qt
-        uses: actions/cache@master
-        id: cache
-        with:
-          path: qt/${{matrix.version}}/${{matrix.platform}}
-          key: qt-${{matrix.version}}-${{matrix.platform}}
-
       - name: Add msbuild to PATH
         if: matrix.platform == 'msvc2019'
         uses: microsoft/setup-msbuild@main
@@ -88,6 +81,8 @@ jobs:
           target: ${{matrix.target}}
           arch: ${{matrix.arch}}
           tools: ${{matrix.tools}}
+          cache: true
+          cache-key-prefix: qt
 
       - name: Add tools to PATH (MinGW)
         if: matrix.platform == 'mingw81_32'


### PR DESCRIPTION
This fixes Windows CI in a reasonable way and Android CI in a very hacky way.

The Windows CI wasn't using the right build tools for MSVC and MinGW, those have to be specified and added to PATH. Looks like a future version of the install Qt action will add the tools to PATH, but right now we have to do it ourselves. Also, only the master branch of the action uses `QT_ROOT_DIR`, the v3 branch which are using uses `Qt5_DIR` for the Qt directory, so that's something to keep in mind if it ever updates, though the install directory of QtApng doesn't seem to make a difference.

Also the action does caching by itself, so no need for the cache qt action.

As for Android... try as I might I couldn't manage to make qmake use the correct NDK version (apparently setting `ANDROID_NDK_ROOT` should do it, but for some reason it didn't work) so I just nuke the wrong version and symlink the correct one to it and it works :)