### PR TITLE
Fix combobox behaviour in AOOptionsdialog

### DIFF
--- a/src/widgets/aooptionsdialog.cpp
+++ b/src/widgets/aooptionsdialog.cpp
@@ -116,7 +116,7 @@ void AOOptionsDialog::setWidgetData(QComboBox *widget, const QString &value)
 
 template <> QString AOOptionsDialog::widgetData(QComboBox *widget) const
 {
-  return widget->currentData().toString();
+  return widget->currentText();
 }
 
 template <>


### PR DESCRIPTION
Due to an oversight in how Comboboxes behave in some corner cases, namely the timestamp options, it would cause an empty string to be saved, causing the timestamp system to no longer function correctly.

Turns out this affected all comboboxes. How did this pass any level of testing?