### PR TITLE
Fix the a/b looping feature just outright not working*

### DIFF
--- a/src/aomusicplayer.cpp
+++ b/src/aomusicplayer.cpp
@@ -61,11 +61,19 @@ QString AOMusicPlayer::play(QString p_song, int channel, bool loop,
   if (loop && file_exists(d_path)) // Contains loop/etc. information file
   {
     QStringList lines = ao_app->read_file(d_path).split("\n");
+    bool seconds_mode = false;
     foreach (QString line, lines) {
       QStringList args = line.split("=");
       if (args.size() < 2)
         continue;
       QString arg = args[0].trimmed();
+      if (arg == "seconds") {
+        if (args[1].trimmed() == "true") {
+          seconds_mode = true; // Use new epic behavior
+          continue;
+        }
+        continue;
+      }
 
       float sample_rate;
       BASS_ChannelGetAttribute(newstream, BASS_ATTRIB_FREQ, &sample_rate);
@@ -77,8 +85,15 @@ QString AOMusicPlayer::play(QString p_song, int channel, bool loop,
       int num_channels = 2;
 
       // Calculate the bytes for loop_start/loop_end to use with the sync proc
-      QWORD bytes = static_cast<QWORD>(args[1].trimmed().toUInt() *
-                                       sample_size * num_channels);
+      QWORD bytes;
+      if (seconds_mode) {
+        bytes =
+            BASS_ChannelSeconds2Bytes(newstream, args[1].trimmed().toDouble());
+      }
+      else {
+        bytes = static_cast<QWORD>(args[1].trimmed().toUInt() * sample_size *
+                                   num_channels);
+      }
       if (arg == "loop_start")
         loop_start[channel] = bytes;
       else if (arg == "loop_length")


### PR DESCRIPTION
I have no idea what it is about the current music looping behavior but it just does not work. I've added a new way to define loops that does work. To use it, the file must be prefixed with `seconds=true`, or else the old behavior will be used. This is to maintain "compatibility" with servers already using the old behavior.

Loops with the new behavior are defined in seconds, with a decimal place down to the millisecond.

I'll augment the docs if/when this is merged.