### PR TITLE
Fix combobox behaviour for all cases

### DIFF
--- a/resource/ui/options_dialog.ui
+++ b/resource/ui/options_dialog.ui
@@ -23,7 +23,7 @@
       <enum>Qt::NoFocus</enum>
      </property>
      <property name="currentIndex">
-      <number>4</number>
+      <number>0</number>
      </property>
      <widget class="QWidget" name="gameplay_tab">
       <attribute name="title">
@@ -39,7 +39,7 @@
           <property name="geometry">
            <rect>
             <x>0</x>
-            <y>-358</y>
+            <y>0</y>
             <width>394</width>
             <height>858</height>
            </rect>

--- a/resource/ui/options_dialog.ui
+++ b/resource/ui/options_dialog.ui
@@ -23,7 +23,7 @@
       <enum>Qt::NoFocus</enum>
      </property>
      <property name="currentIndex">
-      <number>0</number>
+      <number>4</number>
      </property>
      <widget class="QWidget" name="gameplay_tab">
       <attribute name="title">
@@ -39,9 +39,9 @@
           <property name="geometry">
            <rect>
             <x>0</x>
-            <y>0</y>
+            <y>-358</y>
             <width>394</width>
-            <height>828</height>
+            <height>858</height>
            </rect>
           </property>
           <layout class="QFormLayout" name="formLayout">
@@ -157,43 +157,7 @@
             </widget>
            </item>
            <item row="18" column="1">
-            <widget class="QComboBox" name="language_combobox">
-             <item>
-              <property name="text">
-               <string>en</string>
-              </property>
-             </item>
-             <item>
-              <property name="text">
-               <string>de</string>
-              </property>
-             </item>
-             <item>
-              <property name="text">
-               <string>es</string>
-              </property>
-             </item>
-             <item>
-              <property name="text">
-               <string>pt</string>
-              </property>
-             </item>
-             <item>
-              <property name="text">
-               <string>pl</string>
-              </property>
-             </item>
-             <item>
-              <property name="text">
-               <string>jp</string>
-              </property>
-             </item>
-             <item>
-              <property name="text">
-               <string>ru</string>
-              </property>
-             </item>
-            </widget>
+            <widget class="QComboBox" name="language_combobox"/>
            </item>
            <item row="16" column="1">
             <widget class="QLineEdit" name="ms_textbox"/>
@@ -1012,26 +976,6 @@ Default: 0.</string>
          <property name="editable">
           <bool>true</bool>
          </property>
-         <item>
-          <property name="text">
-           <string>h:mm:ss AP</string>
-          </property>
-         </item>
-         <item>
-          <property name="text">
-           <string>hh:mm:ss</string>
-          </property>
-         </item>
-         <item>
-          <property name="text">
-           <string>h:mm AP</string>
-          </property>
-         </item>
-         <item>
-          <property name="text">
-           <string>hh:mm</string>
-          </property>
-         </item>
         </widget>
        </item>
        <item row="6" column="0">

--- a/src/widgets/aooptionsdialog.cpp
+++ b/src/widgets/aooptionsdialog.cpp
@@ -35,7 +35,7 @@ void AOOptionsDialog::populateAudioDevices()
 {
   ui_audio_device_combobox->clear();
   if (needsDefaultAudioDevice()) {
-    ui_audio_device_combobox->addItem("default");
+    ui_audio_device_combobox->addItem("default", "default");
   }
 
   BASS_DEVICEINFO info;
@@ -116,7 +116,7 @@ void AOOptionsDialog::setWidgetData(QComboBox *widget, const QString &value)
 
 template <> QString AOOptionsDialog::widgetData(QComboBox *widget) const
 {
-  return widget->currentText();
+  return widget->currentData().toString();
 }
 
 template <>
@@ -398,6 +398,15 @@ void AOOptionsDialog::setupUI()
                                   &Options::setDiscordEnabled);
   registerOption<QComboBox, QString>("language_combobox", &Options::language,
                                      &Options::setLanguage);
+
+  ui_language_combobox->addItem("English", "en");
+  ui_language_combobox->addItem("Deutsch", "de");
+  ui_language_combobox->addItem("Español", "es");
+  ui_language_combobox->addItem("Português", "pt");
+  ui_language_combobox->addItem("Polski", "pl");
+  ui_language_combobox->addItem("日本語", "jp");
+  ui_language_combobox->addItem("Русский", "ru");
+
   registerOption<QComboBox, QString>("scaling_combobox",
                                      &Options::defaultScalingMode,
                                      &Options::setDefaultScalingMode);
@@ -605,6 +614,12 @@ void AOOptionsDialog::setupUI()
 
   ui_log_timestamp_format_combobox->setCurrentText(l_current_format);
 
+  ui_log_timestamp_format_combobox->addItem(l_current_format);
+  ui_log_timestamp_format_combobox->addItem("h:mm:ss AP");
+  ui_log_timestamp_format_combobox->addItem("hh:mm:ss");
+  ui_log_timestamp_format_combobox->addItem("h:mm AP");
+  ui_log_timestamp_format_combobox->addItem("hh:mm");
+
   if (!Options::getInstance().logTimestampEnabled()) {
     ui_log_timestamp_format_combobox->setDisabled(true);
   }
@@ -633,10 +648,14 @@ void AOOptionsDialog::setupUI()
 
 void AOOptionsDialog::onTimestampFormatEdited()
 {
+  const QString format = ui_log_timestamp_format_combobox->currentText();
+  const int index = ui_log_timestamp_format_combobox->currentIndex();
+
+  ui_log_timestamp_format_combobox->setItemText(index, format);
+  ui_log_timestamp_format_combobox->setItemData(index, format);
   ui_log_timestamp_format_lbl->setText(
       tr("Log timestamp format:\n") +
-      QDateTime::currentDateTime().toString(
-          ui_log_timestamp_format_combobox->currentText()));
+      QDateTime::currentDateTime().toString(format));
 }
 
 void AOOptionsDialog::timestampCbChanged(int state)


### PR DESCRIPTION
The previous fix broke the scaling option again. This should make comboboxes work for scaling, language and logging options alike, by populating them all in the source code rather than in the UI file. A nice side-effect is being able to use more user-friendly strings for languages.