### PR TITLE
Fix combobox options not persisting

### DIFF
--- a/src/widgets/aooptionsdialog.cpp
+++ b/src/widgets/aooptionsdialog.cpp
@@ -105,7 +105,7 @@ template <>
 void AOOptionsDialog::setWidgetData(QComboBox *widget, const QString &value)
 {
   for (auto i = 0; i < widget->count(); i++) {
-    if (widget->itemData(i) == value) {
+    if (widget->itemData(i).toString() == value) {
       widget->setCurrentIndex(i);
       return;
     }

--- a/src/widgets/aooptionsdialog.cpp
+++ b/src/widgets/aooptionsdialog.cpp
@@ -52,7 +52,6 @@ void AOOptionsDialog::setWidgetData(QCheckBox *widget, const bool &value)
 
 template <> bool AOOptionsDialog::widgetData(QCheckBox *widget) const
 {
-
   return widget->isChecked();
 }
 

--- a/src/widgets/aooptionsdialog.cpp
+++ b/src/widgets/aooptionsdialog.cpp
@@ -52,6 +52,7 @@ void AOOptionsDialog::setWidgetData(QCheckBox *widget, const bool &value)
 
 template <> bool AOOptionsDialog::widgetData(QCheckBox *widget) const
 {
+
   return widget->isChecked();
 }
 
@@ -105,7 +106,7 @@ template <>
 void AOOptionsDialog::setWidgetData(QComboBox *widget, const QString &value)
 {
   for (auto i = 0; i < widget->count(); i++) {
-    if (widget->itemText(i) == value) {
+    if (widget->itemData(i) == value) {
       widget->setCurrentIndex(i);
       return;
     }
@@ -614,11 +615,11 @@ void AOOptionsDialog::setupUI()
 
   ui_log_timestamp_format_combobox->setCurrentText(l_current_format);
 
-  ui_log_timestamp_format_combobox->addItem(l_current_format);
-  ui_log_timestamp_format_combobox->addItem("h:mm:ss AP");
-  ui_log_timestamp_format_combobox->addItem("hh:mm:ss");
-  ui_log_timestamp_format_combobox->addItem("h:mm AP");
-  ui_log_timestamp_format_combobox->addItem("hh:mm");
+  ui_log_timestamp_format_combobox->addItem(l_current_format, l_current_format);
+  ui_log_timestamp_format_combobox->addItem("h:mm:ss AP", "h:mm:ss AP");
+  ui_log_timestamp_format_combobox->addItem("hh:mm:ss", "hh:mm:ss");
+  ui_log_timestamp_format_combobox->addItem("h:mm AP", "h:mm AP");
+  ui_log_timestamp_format_combobox->addItem("hh:mm", "hh:mm");
 
   if (!Options::getInstance().logTimestampEnabled()) {
     ui_log_timestamp_format_combobox->setDisabled(true);


### PR DESCRIPTION
There was still a small issue with the comboboxes, namely that the settings menu wouldn't correctly read and set the widgets according to the `config.ini`, which would effectively reset the options each time the menu was opened.