### PR TITLE
Custom area status

### DIFF
--- a/src/aoapplication.h
+++ b/src/aoapplication.h
@@ -180,6 +180,9 @@ public:
   // Returns the color with p_identifier from p_file
   QColor get_color(QString p_identifier, QString p_file);
 
+  // Check if the color with p_identifier exists in p_file
+  QString check_status_color(QString p_identifier, QString p_file);
+
   // Returns the markup symbol used for specified p_identifier such as colors
   QString get_chat_markup(QString p_identifier, QString p_file);
 

--- a/src/courtroom.cpp
+++ b/src/courtroom.cpp
@@ -1833,6 +1833,13 @@ void Courtroom::list_areas()
         else if (arup_statuses.at(n_area) == "GAMING")
         {
           treeItem->setBackground(1, gaming_brush);
+        }        
+        else if (arup_statuses.at(n_area) != "") {
+          QString status = arup_statuses.at(n_area).toLower();
+          QString custom_status_color = "area_" + status + "_color";
+          custom_status_color = ao_app->check_status_color(custom_status_color, "courtroom_design.ini");
+          custom_status_brush = QBrush(ao_app->get_color(custom_status_color, "courtroom_design.ini"));
+          treeItem->setBackground(1, custom_status_brush);
         }
       }
     }

--- a/src/courtroom.h
+++ b/src/courtroom.h
@@ -580,6 +580,7 @@ private:
   QBrush rp_brush;
   QBrush gaming_brush;
   QBrush locked_brush;
+  QBrush custom_status_brush;
 
   AOMusicPlayer *music_player;
   AOSfxPlayer *sfx_player;

--- a/src/text_file_functions.cpp
+++ b/src/text_file_functions.cpp
@@ -273,6 +273,20 @@ QColor AOApplication::get_color(QString p_identifier, QString p_file)
   return return_color;
 }
 
+QString AOApplication::check_status_color(QString p_identifier, QString p_file)
+{
+  QString value = get_config_value(p_identifier, p_file, Options::getInstance().theme(), Options::getInstance().subTheme(), default_theme);
+  if (value.isEmpty()) 
+      return "area_free_color";
+
+  QStringList color_list = value.split(",");
+
+  if (color_list.size() < 3) 
+      return "area_free_color";
+
+  return p_identifier;
+}
+
 QString AOApplication::get_stylesheet(QString p_file)
 {
   QString path = get_asset(p_file, Options::getInstance().theme(), Options::getInstance().subTheme(), default_theme);

--- a/src/text_file_functions.cpp
+++ b/src/text_file_functions.cpp
@@ -277,12 +277,16 @@ QString AOApplication::check_status_color(QString p_identifier, QString p_file)
 {
   QString value = get_config_value(p_identifier, p_file, Options::getInstance().theme(), Options::getInstance().subTheme(), default_theme);
   if (value.isEmpty()) 
-      return "area_free_color";
+  {
+    return "area_free_color";
+  }
 
   QStringList color_list = value.split(",");
 
   if (color_list.size() < 3) 
-      return "area_free_color";
+  {
+    return "area_free_color";
+  }
 
   return p_identifier;
 }


### PR DESCRIPTION
Adding the possibility to add new brushes for custom status.

This is an example of how should it works:

you put in courtroom_design.ini   "area_aacasing_color = 0, 128, 0"

and if you set the status aacasing it will set the new status with the new brush.

If the color is not found in the courtroom_design.ini, simply it uses area_free_color