### PR TITLE
Add streaming brush for songs in musiclist

### DIFF
--- a/src/courtroom.cpp
+++ b/src/courtroom.cpp
@@ -1707,6 +1707,7 @@ void Courtroom::list_music()
 
   QBrush found_brush(ao_app->get_color("found_song_color", f_file));
   QBrush missing_brush(ao_app->get_color("missing_song_color", f_file));
+  QBrush streaming_brush(ao_app->get_color("streaming_song_color", f_file));
 
   QTreeWidgetItem *parent = nullptr;
   for (int n_song = 0; n_song < music_list.size(); ++n_song)
@@ -1745,7 +1746,14 @@ void Courtroom::list_music()
     }
     else
     {
-      treeItem->setBackground(0, missing_brush);
+      if (i_song.endsWith(".music") || i_song.startsWith("http"))
+      {
+        treeItem->setBackground(0, streaming_brush);
+      }
+      else
+      {
+        treeItem->setBackground(0, missing_brush);
+      }
     }
 
     if (i_song_listname == i_song) // Not supposed to be a song to begin with - a category?


### PR DESCRIPTION
I simply added a fake extention (.music) so that client can understand if title of the song is a category or a song in the musiclist

This is how it should work the musiclist for streaming music (I'm using yaml and not json file )
![Screenshot 2024-05-18 124204](https://github.com/AttorneyOnline/AO2-Client/assets/170170901/f8d65423-56cf-4a99-b678-c480a1bfdaa5)
