### PR TITLE
Fix invalid file paths causing unexpected behavior

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -102,6 +102,7 @@ add_executable(Attorney_Online
   src/widgets/server_editor_dialog.cpp
   src/widgets/server_editor_dialog.h
   data.qrc
+  src/screenslidetimer.h src/screenslidetimer.cpp
 )
 
 set_target_properties(Attorney_Online PROPERTIES RUNTIME_OUTPUT_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/bin")

--- a/src/animationloader.cpp
+++ b/src/animationloader.cpp
@@ -25,17 +25,6 @@ void AnimationLoader::load(const QString &fileName)
   {
     return;
   }
-  else if (fileName == QObject::tr("Invalid File"))
-  {
-    // Set the image to a null pixmap if it's invalid
-    stopLoading();
-    m_size = QSize(1, 1);
-    m_frames.clear();
-    m_frames.append(AnimationFrame(QPixmap(), 0));
-    m_frame_count = 1;
-    m_loop_count = 0;
-    return;
-  }
   stopLoading();
   m_file_name = fileName;
   QImageReader *reader = new QImageReader;

--- a/src/animationloader.cpp
+++ b/src/animationloader.cpp
@@ -25,6 +25,17 @@ void AnimationLoader::load(const QString &fileName)
   {
     return;
   }
+  else if (fileName == QObject::tr("Invalid File"))
+  {
+    // Set the image to a null pixmap if it's invalid
+    stopLoading();
+    m_size = QSize(1, 1);
+    m_frames.clear();
+    m_frames.append(AnimationFrame(QPixmap(), 0));
+    m_frame_count = 1;
+    m_loop_count = 0;
+    return;
+  }
   stopLoading();
   m_file_name = fileName;
   QImageReader *reader = new QImageReader;

--- a/src/aoevidencedisplay.cpp
+++ b/src/aoevidencedisplay.cpp
@@ -52,8 +52,6 @@ void AOEvidenceDisplay::show_evidence(int p_index, QString p_evidence_image, boo
   ui_prompt_details->setIconSize(f_pixmap.rect().size());
   ui_prompt_details->resize(f_pixmap.rect().size());
   ui_prompt_details->move(icon_dimensions.x, icon_dimensions.y);
-  m_evidence_movie->setMinimumDurationPerFrame(320);
-  m_evidence_movie->setMaximumDurationPerFrame(1000);
   m_evidence_movie->setPlayOnce(true);
   m_evidence_movie->loadAndPlayAnimation(gif_name, "");
   m_sfx_player->findAndPlaySfx(ao_app->get_court_sfx("evidence_present"));

--- a/src/courtroom.cpp
+++ b/src/courtroom.cpp
@@ -1436,6 +1436,7 @@ void Courtroom::set_background(QString p_background, bool display)
     ui_vp_player_char->stopPlayback();
     ui_vp_sideplayer_char->stopPlayback();
     ui_vp_effect->stopPlayback();
+    ui_vp_effect->hide();
     ui_vp_message->hide();
     ui_vp_chatbox->setVisible(chatbox_always_show);
     // Show it if chatbox always shows
@@ -2746,6 +2747,7 @@ void Courtroom::display_character()
   ui_vp_speedlines->hide();
   ui_vp_player_char->stopPlayback();
   ui_vp_effect->stopPlayback();
+  ui_vp_effect->hide();
   // Clear all looping sfx to prevent obnoxiousness
   sfx_player->stopAllLoopingStream();
   // Hide the message and chatbox and handle the emotes

--- a/src/courtroom.cpp
+++ b/src/courtroom.cpp
@@ -514,7 +514,7 @@ Courtroom::Courtroom(AOApplication *p_ao_app)
 
   connect(ui_vp_evidence_display, &AOEvidenceDisplay::show_evidence_details, this, &Courtroom::show_evidence);
 
-  connect(transition_animation_group, &QParallelAnimationGroup::finished, this, &Courtroom::post_transition_cleanup);
+  connect(transition_animation_group, &QParallelAnimationGroup::finished, this, &Courtroom::finish_transition);
 
   set_widgets();
 
@@ -3110,13 +3110,17 @@ void Courtroom::do_transition(QString p_desk_mod, QString oldPosId, QString newP
     ui_vp_sideplayer_char->hide();
   }
 
-  transition_animation_group->start();
+  QTimer::singleShot(TRANSITION_BOOKEND_DELAY, transition_animation_group, SLOT(start()));
+}
+
+void Courtroom::finish_transition()
+{
+  transition_animation_group->clear();
+  QTimer::singleShot(TRANSITION_BOOKEND_DELAY, this, SLOT(post_transition_cleanup()));
 }
 
 void Courtroom::post_transition_cleanup()
 {
-  transition_animation_group->clear();
-
   for (kal::CharacterAnimationLayer *layer : qAsConst(ui_vp_char_list))
   {
     bool is_visible = layer->isVisible();

--- a/src/courtroom.cpp
+++ b/src/courtroom.cpp
@@ -4526,7 +4526,14 @@ void Courtroom::set_scene(bool show_desk, const QString f_side)
   QPair<QString, QRect> desk_pair = ao_app->get_pos_path(f_side, true);
 
   ui_vp_background->loadAndPlayAnimation(bg_pair.first);
-  ui_vp_desk->loadAndPlayAnimation(desk_pair.first);
+  if (file_exists(ao_app->get_image_suffix(ao_app->get_background_path(desk_pair.first))))
+  {
+    ui_vp_desk->loadAndPlayAnimation(desk_pair.first);
+  }
+  else
+  {
+    show_desk = false;
+  }
 
   double scale = double(ui_viewport->height()) / double(ui_vp_background->frameSize().height());
   QSize scaled_size = ui_vp_background->frameSize() * scale;

--- a/src/courtroom.cpp
+++ b/src/courtroom.cpp
@@ -4527,7 +4527,21 @@ void Courtroom::set_scene(bool show_desk, const QString f_side)
   QPair<QString, QRect> bg_pair = ao_app->get_pos_path(f_side);
   QPair<QString, QRect> desk_pair = ao_app->get_pos_path(f_side, true);
 
-  ui_vp_background->loadAndPlayAnimation(bg_pair.first);
+  if (file_exists(ao_app->get_image_suffix(ao_app->get_background_path(bg_pair.first))))
+  {
+    ui_vp_background->show();
+    ui_vp_background->loadAndPlayAnimation(bg_pair.first);
+  }
+  else if (file_exists(ao_app->get_image_suffix(ao_app->get_background_path("wit"))))
+  {
+    ui_vp_background->show();
+    ui_vp_background->loadAndPlayAnimation(ao_app->get_image_suffix(ao_app->get_background_path("wit")));
+  }
+  else
+  {
+    ui_vp_background->hide();
+  }
+
   if (file_exists(ao_app->get_image_suffix(ao_app->get_background_path(desk_pair.first))))
   {
     ui_vp_desk->loadAndPlayAnimation(desk_pair.first);

--- a/src/courtroom.h
+++ b/src/courtroom.h
@@ -983,5 +983,6 @@ private Q_SLOTS:
 
   // After attempting to play a transition animation, clean up the viewport
   // objects for everyone else and continue the IC processing callstack
+  void finish_transition();
   void post_transition_cleanup();
 };

--- a/src/courtroom.h
+++ b/src/courtroom.h
@@ -23,6 +23,7 @@
 #include "file_functions.h"
 #include "hardware_functions.h"
 #include "lobby.h"
+#include "screenslidetimer.h"
 #include "scrolltext.h"
 #include "widgets/aooptionsdialog.h"
 
@@ -310,9 +311,9 @@ private:
 
   int maximumMessages = 0;
 
-  QParallelAnimationGroup *screenshake_animation_group = new QParallelAnimationGroup;
+  QParallelAnimationGroup *m_screenshake_anim_group;
 
-  QParallelAnimationGroup *transition_animation_group = new QParallelAnimationGroup;
+  kal::ScreenSlideTimer *m_screenslide_timer;
 
   bool next_character_is_not_special = false; // If true, write the
                                               // next character as it is.
@@ -445,12 +446,6 @@ private:
   static const int MS_MAXIMUM = 32;
   QString m_chatmessage[MS_MAXIMUM];
   QString m_previous_chatmessage[MS_MAXIMUM];
-
-  /**
-   * @brief The amount of time to wait at the start and end of slide
-   * animations
-   */
-  static const int TRANSITION_BOOKEND_DELAY = 300;
 
   QString additive_previous;
 
@@ -983,6 +978,5 @@ private Q_SLOTS:
 
   // After attempting to play a transition animation, clean up the viewport
   // objects for everyone else and continue the IC processing callstack
-  void finish_transition();
   void post_transition_cleanup();
 };

--- a/src/screenslidetimer.cpp
+++ b/src/screenslidetimer.cpp
@@ -1,0 +1,86 @@
+#include "screenslidetimer.h"
+
+#include <QDebug>
+
+namespace kal
+{
+ScreenSlideTimer::ScreenSlideTimer(QObject *parent)
+    : QObject(parent)
+{
+  m_pause = new QTimer(this);
+  m_pause->setInterval(TRANSITION_BOOKEND_DELAY);
+  m_pause->setSingleShot(true);
+
+  m_group = new QParallelAnimationGroup(this);
+
+  connect(m_pause, &QTimer::timeout, this, &ScreenSlideTimer::startNextState);
+  connect(m_group, &QParallelAnimationGroup::finished, this, &ScreenSlideTimer::startNextState);
+}
+
+ScreenSlideTimer::~ScreenSlideTimer()
+{
+  m_group->disconnect(this);
+  m_pause->disconnect(this);
+  stop();
+}
+
+void ScreenSlideTimer::addAnimation(QAbstractAnimation *animation)
+{
+  if (m_running)
+  {
+    qWarning() << "Cannot add animations while transition is in progress";
+    return;
+  }
+  m_group->addAnimation(animation);
+}
+
+void ScreenSlideTimer::start()
+{
+  if (m_running)
+  {
+    qWarning() << "Transition already in progress";
+    return;
+  }
+  m_running = true;
+  startNextState();
+}
+
+void ScreenSlideTimer::stop()
+{
+  if (m_running)
+  {
+    m_running = false;
+    m_state = NoTransition;
+    m_group->stop();
+    m_group->clear();
+    m_pause->stop();
+  }
+}
+
+void ScreenSlideTimer::startNextState()
+{
+  switch (m_state)
+  {
+  case NoTransition:
+    m_state = PreTransition;
+    Q_EMIT started();
+    m_pause->start();
+    return;
+
+  case PreTransition:
+    m_state = GroupTransition;
+    m_group->start();
+    break;
+
+  case GroupTransition:
+    m_state = PostTransition;
+    m_pause->start();
+    break;
+
+  case PostTransition:
+    stop();
+    Q_EMIT finished();
+    break;
+  }
+}
+} // namespace kal

--- a/src/screenslidetimer.h
+++ b/src/screenslidetimer.h
@@ -1,0 +1,46 @@
+#pragma once
+
+#include <QObject>
+#include <QParallelAnimationGroup>
+#include <QTimer>
+
+namespace kal
+{
+class ScreenSlideTimer : public QObject
+{
+  Q_OBJECT
+
+public:
+  static const int TRANSITION_BOOKEND_DELAY = 300;
+
+  explicit ScreenSlideTimer(QObject *parent = nullptr);
+  virtual ~ScreenSlideTimer();
+
+  void addAnimation(QAbstractAnimation *animation);
+
+public Q_SLOTS:
+  void start();
+  void stop();
+
+Q_SIGNALS:
+  void started();
+  void finished();
+
+private:
+  enum TransitionState
+  {
+    NoTransition,
+    PreTransition,
+    GroupTransition,
+    PostTransition,
+  };
+
+  bool m_running = false;
+  TransitionState m_state = NoTransition;
+  QParallelAnimationGroup *m_group;
+  QTimer *m_pause;
+
+private Q_SLOTS:
+  void startNextState();
+};
+} // namespace kal


### PR DESCRIPTION
Before the layer refactor, invalid images would display a null pixmap. This restores that behavior.