### PR TITLE
Explicitly set sane line spacing

### DIFF
--- a/src/courtroom.cpp
+++ b/src/courtroom.cpp
@@ -3299,6 +3299,14 @@ void Courtroom::initialize_chatbox()
   ui_vp_message->move(ui_vp_message->x() + ui_vp_chatbox->x(), ui_vp_message->y() + ui_vp_chatbox->y());
   ui_vp_message->setTextInteractionFlags(Qt::NoTextInteraction);
 
+  // For some reason, line spacing is done incorrectly unless we set it here.
+  QTextCursor textCursor = ui_vp_message->textCursor();
+  QTextBlockFormat *newFormat = new QTextBlockFormat();
+  textCursor.clearSelection();
+  textCursor.select(QTextCursor::Document);
+  newFormat->setLineHeight(100, QTextBlockFormat::ProportionalHeight);
+  textCursor.setBlockFormat(*newFormat);
+
   if (ui_vp_showname->text().trimmed().isEmpty()) // Whitespace showname
   {
     ui_vp_chatbox->setImage("chatblank", p_misc);

--- a/src/courtroom.cpp
+++ b/src/courtroom.cpp
@@ -3301,11 +3301,11 @@ void Courtroom::initialize_chatbox()
 
   // For some reason, line spacing is done incorrectly unless we set it here.
   QTextCursor textCursor = ui_vp_message->textCursor();
-  QTextBlockFormat *newFormat = new QTextBlockFormat();
+  QTextBlockFormat linespacingFormat = QTextBlockFormat();
   textCursor.clearSelection();
   textCursor.select(QTextCursor::Document);
-  newFormat->setLineHeight(100, QTextBlockFormat::ProportionalHeight);
-  textCursor.setBlockFormat(*newFormat);
+  linespacingFormat.setLineHeight(100, QTextBlockFormat::ProportionalHeight);
+  textCursor.setBlockFormat(linespacingFormat);
 
   if (ui_vp_showname->text().trimmed().isEmpty()) // Whitespace showname
   {


### PR DESCRIPTION
Fixes absurdly bad line spacing on some user-provided fonts due to Qt's adherence to their values instead of using a sane default. Examples:

Before change:
![image](https://github.com/AttorneyOnline/AO2-Client/assets/32779090/979e286e-78ba-43a6-93cf-4584c4e47357)

After change:
![image](https://github.com/AttorneyOnline/AO2-Client/assets/32779090/fcc86e2a-1ceb-44f3-b4f3-8a18a1a92207)

Related to (but not an explicit solution for) https://github.com/AttorneyOnline/AO2-Client/issues/733.