### PR TITLE
Fix incorrect error messages due to QPluginLoader

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -45,14 +45,19 @@ int main(int argc, char *argv[])
     fontDatabase.addApplicationFont(it.next());
   }
 
-  if (!QImageReader::supportedImageFormats().contains("apng"))
+  QStringList missing_formats{"webp", "apng", "gif"};
+  for (const QByteArray &i_format : QImageReader::supportedImageFormats())
   {
-    qCritical() << "QApng plugin could not be loaded. Errors may occur when loading .apng files.";
+    missing_formats.removeAll(i_format.toLower());
   }
 
-  if (!QImageReader::supportedImageFormats().contains("webp"))
+  if (!missing_formats.empty())
   {
-    qCritical() << "QWebP plugin could not be loaded. Errors may occur when loading .webp files.";
+    call_error(QString("Missing the following image formats: %1."
+                       "<br/>Please make sure the client is installed correctly."
+                       "<br/>If you are on Linux, you may need to install your distribution's image formats package, "
+                       "as detailed in the project's <a href='https://github.com/AttorneyOnline/AO2-Client'>README<a>.")
+                   .arg(missing_formats.join(", ")));
   }
 
   QString p_language = Options::getInstance().language();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -8,8 +8,8 @@
 
 #include <QDebug>
 #include <QDirIterator>
+#include <QImageReader>
 #include <QLibraryInfo>
-#include <QPluginLoader>
 #include <QResource>
 #include <QTranslator>
 
@@ -28,7 +28,6 @@ int main(int argc, char *argv[])
   }
 #endif
 
-  AOApplication::addLibraryPath(AOApplication::applicationDirPath() + "/lib");
   QResource::registerResource(main_app.get_asset("themes/" + Options::getInstance().theme() + ".rcc"));
 
   QFont main_font = main_app.font();
@@ -46,16 +45,14 @@ int main(int argc, char *argv[])
     fontDatabase.addApplicationFont(it.next());
   }
 
-  QPluginLoader apngPlugin("qapng");
-  if (!apngPlugin.load())
+  if (!QImageReader::supportedImageFormats().contains("apng"))
   {
-    qCritical() << "QApng plugin could not be loaded";
+    qCritical() << "QApng plugin could not be loaded. Errors may occur when loading .apng files.";
   }
 
-  QPluginLoader webpPlugin("qwebp");
-  if (!webpPlugin.load())
+  if (!QImageReader::supportedImageFormats().contains("webp"))
   {
-    qCritical() << "QWebp plugin could not be loaded";
+    qCritical() << "QWebP plugin could not be loaded. Errors may occur when loading .webp files.";
   }
 
   QString p_language = Options::getInstance().language();


### PR DESCRIPTION
Specifying that the plugins are under the imageformats folder is required on Linux but not on Windows, for some reason.

Also removes an extraneous addition to the library paths, prolly some old thing; and improves debugging for when the libraries fail to load.