### PR TITLE
Compiler warnings

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -29,24 +29,23 @@ int main(int argc, char *argv[])
 #endif
 
   AOApplication main_app;
-  app.setApplicationVersion(AOApplication::get_version_string());
-  app.setApplicationDisplayName(QObject::tr("Attorney Online %1").arg(app.applicationVersion()));
+  QApplication::setApplicationVersion(AOApplication::get_version_string());
+  QApplication::setApplicationDisplayName(QObject::tr("Attorney Online %1").arg(QApplication::applicationVersion()));
 
   QResource::registerResource(main_app.get_asset("themes/" + Options::getInstance().theme() + ".rcc"));
 
-  QFont main_font = app.font();
+  QFont main_font = QApplication::font();
   main_app.default_font = main_font;
 
   QFont new_font = main_font;
   int new_font_size = main_app.default_font.pointSize() * Options::getInstance().themeScalingFactor();
   new_font.setPointSize(new_font_size);
-  app.setFont(new_font);
+  QApplication::setFont(new_font);
 
-  QFontDatabase fontDatabase;
   QDirIterator it(get_base_path() + "fonts", QDirIterator::Subdirectories);
   while (it.hasNext())
   {
-    fontDatabase.addApplicationFont(it.next());
+    QFontDatabase::addApplicationFont(it.next());
   }
 
   QStringList expected_formats{"webp", "apng", "gif"};

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -70,18 +70,25 @@ int main(int argc, char *argv[])
   }
 
   QTranslator qtTranslator;
-  qtTranslator.load("qt_" + p_language, QLibraryInfo::path(QLibraryInfo::TranslationsPath));
-  app.installTranslator(&qtTranslator);
+  if (!qtTranslator.load("qt_" + p_language, QLibraryInfo::path(QLibraryInfo::TranslationsPath)))
+  {
+    qDebug() << "Failed to load translation qt_" + p_language;
+  } else {
+    QApplication::installTranslator(&qtTranslator);
+  }
 
   QTranslator appTranslator;
-  qDebug() << ":/data/translations/ao_" + p_language;
-  appTranslator.load("ao_" + p_language, ":/data/translations/");
-  app.installTranslator(&appTranslator);
+  if (!appTranslator.load("ao_" + p_language, ":/data/translations/")) {
+    qDebug() << "Failed to load translation ao_" + p_language;
+  } else {
+    QApplication::installTranslator(&appTranslator);
+    qDebug() << ":/data/translations/ao_" + p_language;
+  }
 
   main_app.construct_lobby();
   main_app.net_manager->get_server_list();
   main_app.net_manager->send_heartbeat();
   main_app.w_lobby->show();
 
-  return app.exec();
+  return QApplication::exec();
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -70,7 +70,7 @@ int main(int argc, char *argv[])
   }
 
   QTranslator qtTranslator;
-  qtTranslator.load("qt_" + p_language, QLibraryInfo::location(QLibraryInfo::TranslationsPath));
+  qtTranslator.load("qt_" + p_language, QLibraryInfo::path(QLibraryInfo::TranslationsPath));
   app.installTranslator(&qtTranslator);
 
   QTranslator appTranslator;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -71,14 +71,19 @@ int main(int argc, char *argv[])
   if (!qtTranslator.load("qt_" + p_language, QLibraryInfo::path(QLibraryInfo::TranslationsPath)))
   {
     qDebug() << "Failed to load translation qt_" + p_language;
-  } else {
+  }
+  else
+  {
     QApplication::installTranslator(&qtTranslator);
   }
 
   QTranslator appTranslator;
-  if (!appTranslator.load("ao_" + p_language, ":/data/translations/")) {
+  if (!appTranslator.load("ao_" + p_language, ":/data/translations/"))
+  {
     qDebug() << "Failed to load translation ao_" + p_language;
-  } else {
+  }
+  else
+  {
     QApplication::installTranslator(&appTranslator);
     qDebug() << ":/data/translations/ao_" + p_language;
   }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4,7 +4,6 @@
 #include "courtroom.h"
 #include "datatypes.h"
 #include "lobby.h"
-#include "networkmanager.h"
 
 #include <QDebug>
 #include <QDirIterator>

--- a/src/network/websocketconnection.cpp
+++ b/src/network/websocketconnection.cpp
@@ -11,7 +11,7 @@ WebSocketConnection::WebSocketConnection(AOApplication *ao_app, QObject *parent)
     , m_socket(new QWebSocket(QString(), QWebSocketProtocol::VersionLatest, this))
     , m_last_state(QAbstractSocket::UnconnectedState)
 {
-  connect(m_socket, QOverload<QAbstractSocket::SocketError>::of(&QWebSocket::error), this, &WebSocketConnection::onError);
+  connect(m_socket, &QWebSocket::errorOccurred, this, &WebSocketConnection::onError);
   connect(m_socket, &QWebSocket::stateChanged, this, &WebSocketConnection::onStateChanged);
   connect(m_socket, &QWebSocket::textMessageReceived, this, &WebSocketConnection::onTextMessageReceived);
 }

--- a/src/path_functions.cpp
+++ b/src/path_functions.cpp
@@ -273,9 +273,6 @@ QString AOApplication::get_config_value(QString p_identifier, QString p_config, 
     if (!path.isEmpty())
     {
       QSettings settings(path, QSettings::IniFormat);
-#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
-      settings.setIniCodec("UTF-8");
-#endif
       QVariant value = settings.value(p_identifier);
       if (value.type() == QVariant::StringList)
       {

--- a/src/path_functions.cpp
+++ b/src/path_functions.cpp
@@ -274,7 +274,7 @@ QString AOApplication::get_config_value(QString p_identifier, QString p_config, 
     {
       QSettings settings(path, QSettings::IniFormat);
       QVariant value = settings.value(p_identifier);
-      if (value.type() == QVariant::StringList)
+      if (value.typeId() == QMetaType::QStringList)
       {
         return value.toStringList().join(",");
       }

--- a/src/text_file_functions.cpp
+++ b/src/text_file_functions.cpp
@@ -160,9 +160,6 @@ QString AOApplication::read_design_ini(QString p_identifier, VPath p_design_path
 QString AOApplication::read_design_ini(QString p_identifier, QString p_design_path)
 {
   QSettings settings(p_design_path, QSettings::IniFormat);
-#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
-  settings.setIniCodec("UTF-8");
-#endif
   QVariant value = settings.value(p_identifier);
   if (value.type() == QVariant::StringList)
   {

--- a/src/text_file_functions.cpp
+++ b/src/text_file_functions.cpp
@@ -161,7 +161,7 @@ QString AOApplication::read_design_ini(QString p_identifier, QString p_design_pa
 {
   QSettings settings(p_design_path, QSettings::IniFormat);
   QVariant value = settings.value(p_identifier);
-  if (value.type() == QVariant::StringList)
+  if (value.typeId() == QMetaType::QStringList)
   {
     return value.toStringList().join(",");
   }


### PR DESCRIPTION
Fix a set of compiler warnings mostly related to deprecated calls, and remove some qt6 checks, as qt5 is no longer supported anyways.