### PR TITLE
Display OOC names in playerlist even when not logged in

### DIFF
--- a/src/widgets/playerlistwidget.cpp
+++ b/src/widgets/playerlistwidget.cpp
@@ -196,5 +196,5 @@ void PlayerListWidget::updatePlayer(int playerId, bool updateIcon)
 QString PlayerListWidget::formatLabel(const PlayerData &data)
 {
   QString format = Options::getInstance().playerlistFormatString();
-  return format.replace("{id}", QString::number(data.id)).replace("{character}", data.character).replace("{displayname}", data.character_name.isEmpty() ? "No Data" : data.character_name).replace("{username}", m_is_authenticated ? data.name : "").simplified();
+  return format.replace("{id}", QString::number(data.id)).replace("{character}", data.character).replace("{displayname}", data.character_name.isEmpty() ? "No Data" : data.character_name).replace("{username}", data.name).simplified();
 }


### PR DESCRIPTION
This is not sensitive information. If it is sensitive, it's on the server to not send it to us, not for us to deliberately ignore it.