### PR TITLE
Don't do a full path lookup on every individual emote button

### DIFF
--- a/src/aoemotebutton.cpp
+++ b/src/aoemotebutton.cpp
@@ -36,15 +36,15 @@ int AOEmoteButton::id()
   return m_id;
 }
 
-void AOEmoteButton::setImage(QString character, int emoteId, bool enabled)
+void AOEmoteButton::setImage(QString character, QString path_to_buttons, int emoteId, bool enabled)
 {
   QString emotion_number = QString::number(emoteId + 1);
 
   QStringList suffixedPaths;
-  static const QStringList SUFFIX_LIST{"_off", "_on"};
+  static const QStringList SUFFIX_LIST{"_off.png", "_on.png"};
   for (const QString &suffix : SUFFIX_LIST)
   {
-    suffixedPaths.append(ao_app->get_image_suffix(ao_app->get_character_path(character, "emotions/button" + emotion_number + suffix)));
+    suffixedPaths.append(path_to_buttons + "button" + emotion_number + suffix);
   }
 
   QString image = suffixedPaths[static_cast<int>(enabled)];

--- a/src/aoemotebutton.h
+++ b/src/aoemotebutton.h
@@ -14,7 +14,7 @@ public:
 
   int id();
 
-  void setImage(QString character, int emoteId, bool enabled);
+  void setImage(QString character, QString path_to_buttons, int emoteId, bool enabled);
 
   void setSelectedImage(QString p_image);
 

--- a/src/courtroom.cpp
+++ b/src/courtroom.cpp
@@ -1888,7 +1888,7 @@ void Courtroom::list_areas()
 
 void Courtroom::debug_message_handler(QtMsgType type, const QMessageLogContext &context, const QString &msg)
 {
-#ifndef QT_DEBUG
+#ifdef QT_DEBUG
   return;
 #endif
   Q_UNUSED(context);

--- a/src/courtroom.cpp
+++ b/src/courtroom.cpp
@@ -1303,11 +1303,8 @@ void Courtroom::set_qfont(QWidget *widget, QString class_name, QFont font, QColo
   font.setBold(bold);
   widget->setFont(font);
 
-  // QString style_sheet_string = class_name + " { color: rgba(" + QString::number(f_color.red()) + ", " + QString::number(f_color.green()) + ", " + QString::number(f_color.blue()) + ", 255);}";
-  // widget->setStyleSheet(style_sheet_string);
-  QPalette palette = widget->palette();
-  palette.setColor(widget->foregroundRole(), f_color);
-  widget->setPalette(palette);
+  QString style_sheet_string = class_name + " { color: rgba(" + QString::number(f_color.red()) + ", " + QString::number(f_color.green()) + ", " + QString::number(f_color.blue()) + ", 255);}";
+  widget->setStyleSheet(style_sheet_string);
 }
 
 void Courtroom::set_stylesheet(QWidget *widget)

--- a/src/courtroom.cpp
+++ b/src/courtroom.cpp
@@ -1303,8 +1303,11 @@ void Courtroom::set_qfont(QWidget *widget, QString class_name, QFont font, QColo
   font.setBold(bold);
   widget->setFont(font);
 
-  QString style_sheet_string = class_name + " { color: rgba(" + QString::number(f_color.red()) + ", " + QString::number(f_color.green()) + ", " + QString::number(f_color.blue()) + ", 255);}";
-  widget->setStyleSheet(style_sheet_string);
+  // QString style_sheet_string = class_name + " { color: rgba(" + QString::number(f_color.red()) + ", " + QString::number(f_color.green()) + ", " + QString::number(f_color.blue()) + ", 255);}";
+  // widget->setStyleSheet(style_sheet_string);
+  QPalette palette = widget->palette();
+  palette.setColor(widget->foregroundRole(), f_color);
+  widget->setPalette(palette);
 }
 
 void Courtroom::set_stylesheet(QWidget *widget)
@@ -1533,6 +1536,7 @@ void Courtroom::update_character(int p_cid, QString char_name, bool reset_emote)
   }
 
   current_char = f_char;
+  m_character_path = ao_app->get_real_path(ao_app->get_character_path(current_char, ""), {""});
   set_side(ao_app->get_char_side(current_char));
 
   set_text_color_dropdown();
@@ -1887,7 +1891,7 @@ void Courtroom::list_areas()
 
 void Courtroom::debug_message_handler(QtMsgType type, const QMessageLogContext &context, const QString &msg)
 {
-#ifdef QT_DEBUG
+#ifndef QT_DEBUG
   return;
 #endif
   Q_UNUSED(context);

--- a/src/courtroom.h
+++ b/src/courtroom.h
@@ -516,6 +516,9 @@ private:
   QString current_misc;
   QString last_misc;
 
+  // Used to avoid unnecessary file i/o
+  QString m_character_path;
+
   // List of markdown start characters, their index is tied to the color index
   QStringList color_markdown_start_list;
 

--- a/src/emotes.cpp
+++ b/src/emotes.cpp
@@ -106,6 +106,7 @@ void Courtroom::set_emote_page()
   }
 
   int total_emotes = ao_app->get_emote_number(current_char);
+  QString path_to_buttons = m_character_path + "emotions/";
 
   ui_emote_left->hide();
   ui_emote_right->hide();
@@ -153,11 +154,11 @@ void Courtroom::set_emote_page()
 
     if (n_real_emote == current_emote)
     {
-      f_emote->setImage(current_char, n_real_emote, true);
+      f_emote->setImage(current_char, path_to_buttons, n_real_emote, true);
     }
     else
     {
-      f_emote->setImage(current_char, n_real_emote, false);
+      f_emote->setImage(current_char, path_to_buttons, n_real_emote, false);
     }
 
     f_emote->show();
@@ -190,7 +191,7 @@ void Courtroom::select_emote(int p_id)
 
   if (current_emote >= min && current_emote <= max)
   {
-    ui_emote_list.at(current_emote % max_emotes_on_page)->setImage(current_char, current_emote, false);
+    ui_emote_list.at(current_emote % max_emotes_on_page)->setImage(current_char, m_character_path + "emotions/", current_emote, false);
   }
 
   int old_emote = current_emote;
@@ -199,7 +200,7 @@ void Courtroom::select_emote(int p_id)
 
   if (current_emote >= min && current_emote <= max)
   {
-    ui_emote_list.at(current_emote % max_emotes_on_page)->setImage(current_char, current_emote, true);
+    ui_emote_list.at(current_emote % max_emotes_on_page)->setImage(current_char, m_character_path + "emotions/", current_emote, true);
   }
 
   int emote_mod = ao_app->get_emote_mod(current_char, current_emote);


### PR DESCRIPTION
This is a straight performance improvement, especially on characters with many emotes. There's potential for additional improvement here by using this `m_character_path` global in more places, but that's outside the scope of this PR.

It is absolutely insane that we were doing an entire asset lookup for every individual button.