### PR TITLE
Fix null pointer exception on motd fetch failure

### DIFF
--- a/src/lobby.cpp
+++ b/src/lobby.cpp
@@ -553,7 +553,10 @@ void Lobby::get_motd()
     {
       document = tr("Couldn't get the message of the day.");
     }
-    ui_motd_text->setHtml(document);
+    if (ui_motd_text)
+    {
+      ui_motd_text->setHtml(document);
+    }
   });
 }
 

--- a/src/lobby.h
+++ b/src/lobby.h
@@ -82,7 +82,7 @@ private:
   QPushButton *ui_refresh_button;
 
   // Serverinfo / MOTD Horizontal Row
-  QTextBrowser *ui_motd_text;
+  QPointer<QTextBrowser> ui_motd_text;
 
   QLabel *ui_server_player_count_lbl;
   QTextBrowser *ui_server_description_text;


### PR DESCRIPTION
Fixes https://github.com/AttorneyOnline/AO2-Client/issues/324, again. Hopefully forever this time.
Using a QPointer instead of a raw pointer prevents a null pointer exception as it is set to 0 when the object is destroyed instead of dangling.