### PR TITLE
Fix missing bounds checking for frame effect string deserialization

### DIFF
--- a/src/animationlayer.cpp
+++ b/src/animationlayer.cpp
@@ -488,7 +488,10 @@ void CharacterAnimationLayer::setFrameEffects(QStringList data)
       for (const QString &raw_effect : std::as_const(emote_effects))
       {
         QStringList frame_data = raw_effect.split("=");
-
+        if (frame_data.size() < 2)
+        {
+          continue;
+        }
         const int frame_number = frame_data.at(0).toInt();
 
         FrameEffect effect;


### PR DESCRIPTION
This doesn't cause issues in release config because at() silently fails in release configuration rather than crash with an assert failure; however this can be used to remotely crash debug clients with a malformed frame effect string. Adding bounds checking should remedy the issue (and is correct practice anyway.)