### PR TITLE
Fix configure.sh silently failing when Qt is not found

### DIFF
--- a/configure.sh
+++ b/configure.sh
@@ -69,7 +69,6 @@ find_qt() {
         echo "$qt_root"
     else
         echo ""
-        return 1
     fi
 }
 


### PR DESCRIPTION
execution was never reaching the error handler because of this stray `return`