### PR TITLE
Fix shownames toggle not being respected in several places, clean up implementation

### DIFF
--- a/src/courtroom.h
+++ b/src/courtroom.h
@@ -252,7 +252,7 @@ public:
   // this function keeps the chatlog scrolled to the top unless there's text
   // selected
   // or the user isn't already scrolled to the top
-  void append_ic_text(QString p_text, QString p_name = QString(), QString action = QString(), int color = 0, bool selfname = false, QDateTime timestamp = QDateTime::currentDateTime(), bool ghost = false);
+  void append_ic_text(QString p_text, QString p_name = QString(), QString p_char = QString(), QString action = QString(), int color = 0, bool selfname = false, QDateTime timestamp = QDateTime::currentDateTime(), bool ghost = false);
 
   // clear sent messages that appear on the IC log but haven't been delivered
   // yet to other players

--- a/src/courtroom.h
+++ b/src/courtroom.h
@@ -409,6 +409,9 @@ private:
   // format string for aforementioned log timestamp
   QString log_timestamp_format;
 
+  // True, if the log and in-character display should use custom shownames.
+  bool custom_shownames = true;
+
   // How long in miliseconds should the objection wait before appearing.
   int objection_threshold = 1500;
 
@@ -938,8 +941,6 @@ private Q_SLOTS:
 
   void focus_ic_input();
   void on_additive_clicked();
-
-  void on_showname_enable_clicked();
 
   void on_evidence_button_clicked();
   void on_evidence_context_menu_requested(const QPoint &pos);

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -56,10 +56,6 @@ Options::Options()
 /*! Migrate old configuration keys/values to a relevant format. */
 void Options::migrate()
 {
-  if (config.contains("show_custom_shownames"))
-  {
-    config.remove("show_custom_shownames");
-  }
   if (QFile::exists(get_base_path() + "callwords.ini"))
   {
     migrateCallwords();


### PR DESCRIPTION
Closes #1079 and #853 

Also corrects the longstanding issue where turning shownames off was a permanent change to the log. Shownames can now be restored to the log even if they were switched off when the message was sent.