### PR TITLE
Add integration shell scripts for linux!

### DIFF
--- a/scripts/appimage_integrator.sh
+++ b/scripts/appimage_integrator.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+# Required to launch correctly
+#please note that this is the APPIMAGE version of this bash script, they are not cross compatible, and one will not work for the other
+
+# Move to AO's directory
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+cd "${SCRIPT_DIR}"
+
+#put into user's local library
+mkdir ~/.local/Attorney_Online
+mv -fu {.*,*} ~/.local/Attorney_Online
+
+#add .desktop file (which should allow most DE's easy access to the program
+mkdir ~/.local/share/applications
+rm ~/.local/share/applications/'Attorney Online'.desktop
+touch ~/.local/share/applications/'Attorney Online'.desktop
+#please note that the best way forward here is to have the real logo in path, but this is a temporary logo, easily replaceable.
+printf "[Desktop Entry]\nType=Application\nName=Attorney Online\nComment=The courtroom drama simulator\nExec=$(realpath ~/.local/Attorney_Online/Attorney_Online-2.11-x86_64.AppImage)\nIcon=$(realpath ~/.local/Attorney_Online)/base/themes/AOHD/placeholder.webp\nCategories=Game;" >> ~/.local/share/applications/'Attorney Online'.desktop
+
+#marking the program as executable
+chmod +x ~/.local/Attorney_Online/Attorney_Online-2.11-x86_64.AppImage
+#running the executable
+~/.local/Attorney_Online/Attorney_Online-2.11-x86_64.AppImage

--- a/scripts/appimage_integrator.sh
+++ b/scripts/appimage_integrator.sh
@@ -8,16 +8,16 @@ cd "${SCRIPT_DIR}"
 
 #put into user's local library
 mkdir ~/.local/Attorney_Online
-mv -fu {.*,*} ~/.local/Attorney_Online
+mv -f {.*,*} ~/.local/Attorney_Online
 
 #add .desktop file (which should allow most DE's easy access to the program
 mkdir ~/.local/share/applications
 rm ~/.local/share/applications/'Attorney Online'.desktop
 touch ~/.local/share/applications/'Attorney Online'.desktop
 #please note that the best way forward here is to have the real logo in path, but this is a temporary logo, easily replaceable.
-printf "[Desktop Entry]\nType=Application\nName=Attorney Online\nComment=The courtroom drama simulator\nExec=$(realpath ~/.local/Attorney_Online/Attorney_Online-2.11-x86_64.AppImage)\nIcon=$(realpath ~/.local/Attorney_Online)/base/themes/AOHD/placeholder.webp\nCategories=Game;" >> ~/.local/share/applications/'Attorney Online'.desktop
+printf "[Desktop Entry]\nType=Application\nName=Attorney Online\nComment=The courtroom drama simulator\nExec=$(realpath ~/.local/Attorney_Online/Attorney_Online-*-x86_64.AppImage)\nIcon=$(realpath ~/.local/Attorney_Online)/base/themes/AOHD/placeholder.webp\nCategories=Game;" >> ~/.local/share/applications/'Attorney Online'.desktop
 
 #marking the program as executable
-chmod +x ~/.local/Attorney_Online/Attorney_Online-2.11-x86_64.AppImage
+chmod +x ~/.local/Attorney_Online/Attorney_Online-*-x86_64.AppImage
 #running the executable
-~/.local/Attorney_Online/Attorney_Online-2.11-x86_64.AppImage
+~/.local/Attorney_Online/Attorney_Online-*-x86_64.AppImage

--- a/scripts/dynamic_integrator.sh
+++ b/scripts/dynamic_integrator.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+# Required to launch correctly
+
+# Move to AO's directory
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+cd "${SCRIPT_DIR}"
+
+#put into user's local library
+mkdir ~/.local/Attorney_Online
+mv -fu {.*,*} ~/.local/Attorney_Online
+
+#add .desktop file (which should allow most DE's easy access to the program
+mkdir ~/.local/share/applications
+rm ~/.local/share/applications/'Attorney Online'.desktop
+touch ~/.local/share/applications/'Attorney Online'.desktop
+#please note that the best way forward here is to have the real logo in path, but this is a temporary logo, easily replaceable.
+printf "[Desktop Entry]\nType=Application\nName=Attorney Online\nComment=The courtroom drama simulator\nExec=$(realpath ~/.local/Attorney_Online)/launch.sh\nIcon=$(realpath ~/.local/Attorney_Online)/base/themes/AOHD/placeholder.webp\nCategories=Game;" >> ~/.local/share/applications/'Attorney Online'.desktop
+
+#making the launch.sh (probably not necessary, but if we removed launch.sh and replaced it with this, it makes the path clear without any mud from installing)
+rm ~/.local/Attorney_Online/launch.sh
+touch ~/.local/Attorney_Online/launch.sh
+printf "#!/bin/bash\ncd $(realpath ~/.local/Attorney_Online)\nchmod +x $(realpath ~/.local/Attorney_Online/Attorney_Online)\nLD_LIBRARY_PATH=. $(realpath ~/.local/Attorney_Online/Attorney_Online)" >> ~/.local/Attorney_Online/launch.sh
+
+#running the program
+chmod +x ~/.local/Attorney_Online/launch.sh
+~/.local/Attorney_Online/launch.sh


### PR DESCRIPTION
These shell scripts (one for appimage and one for dynamic) both should: 1: Move the program files to ~/.local/Attorney_Online 2: Create a .desktop file (which is what applications on Linux use to know to be interacted with) in the ~/.local/share/applications folder (where all other user applications tend to go), with at current a temporary logo until the logo file is parsed out from the xapplication window. 3: open the application, assuming the necessary dependencies are fulfilled Dynamic required some further support due to the startup shell command working correctly when you click it manually, but struggling on the .desktop folder, so it has the additional step of recreating the current launch.sh command, which still functions if you go to the folder to click it, or if you open the program before integration to test things.

Both sh commands open AO2-Client at completion time. I hope this will help newer Linux users, or older Linux users who normally wouldn't bother, to bring AO into their normal day to day experience.

This has been tested on (by me):
Fedora 40 Workstation (Gnome)
Arch Linux KDE Plasma 6
Ubuntu Unity 24.10 aka Oracular Oriole
Debian 13 Trixie (Before it's freeze, marking date February 9th 2025)

Thank you for reading, have a wonderful day!