### PR TITLE
Fix URL corruption caused by HTML escaping

### DIFF
--- a/src/aotextarea.cpp
+++ b/src/aotextarea.cpp
@@ -27,7 +27,20 @@ void AOTextArea::addMessage(QString name, QString message, QString nameColor, QS
     message += " ";
   }
 
-  QString result = message.toHtmlEscaped().replace("\n", "<br>").replace(url_parser_regex, "<a href='\\1'>\\1</a>");
+  // Detect URLs before HTML escaping to prevent & from becoming &amp; in links
+  QString result;
+  int lastEnd = 0;
+  QRegularExpressionMatchIterator it = url_parser_regex.globalMatch(message);
+  while (it.hasNext())
+  {
+    QRegularExpressionMatch match = it.next();
+    result += message.mid(lastEnd, match.capturedStart() - lastEnd).toHtmlEscaped();
+    QString url = match.captured(1);
+    result += "<a href='" + url + "'>" + url.toHtmlEscaped() + "</a>";
+    lastEnd = match.capturedEnd();
+  }
+  result += message.mid(lastEnd).toHtmlEscaped();
+  result.replace("\n", "<br>");
 
   if (!messageColor.isEmpty())
   {

--- a/src/lobby.cpp
+++ b/src/lobby.cpp
@@ -595,7 +595,20 @@ void Lobby::set_server_description(const QString &server_description)
 {
   ui_server_description_text->clear();
   static QRegularExpression regexp_links("\\b(https?://\\S+\\.\\S+)\\b");
-  QString result = server_description.toHtmlEscaped().replace("\n", "<br>").replace(regexp_links, "<a href='\\1'>\\1</a>");
+  // Detect URLs before HTML escaping to prevent & from becoming &amp; in links
+  QString result;
+  int lastEnd = 0;
+  QRegularExpressionMatchIterator it = regexp_links.globalMatch(server_description);
+  while (it.hasNext())
+  {
+    QRegularExpressionMatch match = it.next();
+    result += server_description.mid(lastEnd, match.capturedStart() - lastEnd).toHtmlEscaped();
+    QString url = match.captured(1);
+    result += "<a href='" + url + "'>" + url.toHtmlEscaped() + "</a>";
+    lastEnd = match.capturedEnd();
+  }
+  result += server_description.mid(lastEnd).toHtmlEscaped();
+  result.replace("\n", "<br>");
   ui_server_description_text->insertHtml(result);
 }
 


### PR DESCRIPTION
URLs containing & for example discord and stuff were being corrupted because   toHtmlEscaped() was called before
 URL detection, turning & into amp. inside link hrefs.

This shit has been pissing me off for far too long.  This fix detects urls on the raw message then html escapes only the non url text. Applied to server descriptions and OOC chat. Heres a  screenshot of me building the client and testing it and yes the discord link downloaded instead of being an invalid &amp link at least. It works and functions. 
<img width="217" height="131" alt="image" src="https://github.com/user-attachments/assets/9e6cc113-672f-4570-88c4-cd53c6006aa7" />

If merged this would close this https://github.com/AttorneyOnline/AO2-Client/issues/1116 issue. Feel free to review if people want to improve this or just merge as is do what you like. It does build though.