### PR TITLE
Fix }}} bug preventing text render due to instant speed

### DIFF
--- a/src/courtroom.cpp
+++ b/src/courtroom.cpp
@@ -4486,7 +4486,7 @@ void Courtroom::chat_tick()
     msg_delay = text_crawl * message_display_mult[current_display_speed];
   }
 
-  if ((msg_delay <= 0 && tick_pos < f_message.size() - 1) || formatting_char)
+  if (!(tick_pos >= f_message.size()) && ((msg_delay <= 0 && tick_pos < f_message.size() - 1) || formatting_char))
   {
     {
       chat_tick_timer->start(0); // Don't bother rendering anything out as we're


### PR DESCRIPTION
That's just a band-aid. The real fix should be actually preparing this prior to render instead of having this stuff being done within the chat tick loop