### PR TITLE
Add PreivewOffsetCheckBox

### DIFF
--- a/data/ui/options_dialog.ui
+++ b/data/ui/options_dialog.ui
@@ -41,7 +41,7 @@
             <x>0</x>
             <y>0</y>
             <width>422</width>
-            <height>902</height>
+            <height>924</height>
            </rect>
           </property>
           <layout class="QFormLayout" name="formLayout">
@@ -557,7 +557,7 @@
               <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The scaling algorithm to be used when upscaling or downscaling images.&lt;/p&gt;&lt;p&gt;Automatic: The image will be scaled based on the image's predetermined scaling algorithm.&lt;br/&gt;Pixelated: The image will be scaled using a nearest neighbor algorithm.&lt;br/&gt;Smooth: The image will be scaled using a bilinear algorithm.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
              </property>
              <property name="text">
-              <string>Image Scaling</string>
+              <string>Image Scaling:</string>
              </property>
             </widget>
            </item>
@@ -589,7 +589,7 @@
               <string>If ticked, some windows restore their last known position where they were closed.</string>
              </property>
              <property name="text">
-              <string>Restore Window Position</string>
+              <string>Restore Window Position:</string>
              </property>
             </widget>
            </item>
@@ -600,7 +600,7 @@
              </property>
             </widget>
            </item>
-           <item row="35" column="0">
+           <item row="36" column="0">
             <widget class="QLabel" name="playerlist_format_lbl">
              <property name="toolTip">
               <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;Set the format for the player list to use.&lt;br&gt;&lt;br&gt;Valid fields are:&lt;br&gt;{id} - Client ID&lt;br&gt;{displayname} - Character display name&lt;br&gt;{character} - Character folder name&lt;br&gt;{username} - Out-of-character name&lt;br&gt;(Note: Some servers may hide out-of-character names.)&lt;/body&gt;&lt;/html&gt;</string>
@@ -610,8 +610,22 @@
              </property>
             </widget>
            </item>
-           <item row="35" column="1">
+           <item row="36" column="1">
             <widget class="QLineEdit" name="playerlist_format_edit"/>
+           </item>
+           <item row="35" column="0">
+            <widget class="QLabel" name="offset_preview_lbl">
+             <property name="text">
+              <string>Offset affects Preview:</string>
+             </property>
+            </widget>
+           </item>
+           <item row="35" column="1">
+            <widget class="QCheckBox" name="offset_preview_cb">
+             <property name="text">
+              <string/>
+             </property>
+            </widget>
            </item>
           </layout>
          </widget>

--- a/src/aoemotepreview.cpp
+++ b/src/aoemotepreview.cpp
@@ -1,4 +1,5 @@
 #include "aoemotepreview.h"
+#include "options.h"
 
 AOEmotePreview::AOEmotePreview(AOApplication *ao_app, QWidget *parent)
     : QWidget(parent)
@@ -29,7 +30,10 @@ void AOEmotePreview::display(QString character, QString emote, kal::CharacterAni
   m_character = character;
   m_emote = emote;
   ui_vp_player_char->stopPlayback();
-  ui_vp_player_char->move(ui_viewport->width() * xOffset / 100, ui_viewport->height() * yOffset / 100);
+  if (Options::getInstance().offsetPreview())
+  {
+    ui_vp_player_char->move(ui_viewport->width() * xOffset / 100, ui_viewport->height() * yOffset / 100);
+  }
   ui_vp_player_char->loadCharacterEmote(character, emote, emoteType);
   ui_vp_player_char->setPlayOnce(false);
   ui_vp_player_char->setFlipped(flipped);

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -616,6 +616,16 @@ void Options::setResizeMode(RESIZE_MODE value)
   config.setValue("resize_mode", value);
 }
 
+bool Options::offsetPreview() const
+{
+  return config.value("offset_preview", true).toBool();
+}
+
+void Options::setOffsetPreview(bool value)
+{
+  config.setValue("offset_preview", value);
+}
+
 QStringList Options::callwords() const
 {
   QStringList l_callwords = config.value("callwords", QStringList{}).toStringList();

--- a/src/options.h
+++ b/src/options.h
@@ -284,6 +284,9 @@ public:
   bool restoreWindowPositionEnabled() const;
   void setRestoreWindowPositionEnabled(bool state);
 
+  bool offsetPreview() const;
+  void setOffsetPreview(bool value);
+
 private:
   /**
    * @brief QSettings object for config.ini

--- a/src/widgets/aooptionsdialog.cpp
+++ b/src/widgets/aooptionsdialog.cpp
@@ -385,6 +385,7 @@ void AOOptionsDialog::setupUI()
   FROM_UI(QCheckBox, evidence_double_click_cb);
   FROM_UI(QCheckBox, slides_cb);
   FROM_UI(QCheckBox, restoreposition_cb);
+  FROM_UI(QCheckBox, offsetpreview_cb);
   FROM_UI(QLineEdit, playerlist_format_edit);
 
   registerOption<QDoubleSpinBox, double>("theme_scaling_factor_sb", &Options::themeScalingFactor, &Options::setThemeScalingFactor);
@@ -424,6 +425,7 @@ void AOOptionsDialog::setupUI()
   registerOption<QCheckBox, bool>("evidence_double_click_cb", &Options::evidenceDoubleClickEdit, &Options::setEvidenceDoubleClickEdit);
   registerOption<QCheckBox, bool>("slides_cb", &Options::slidesEnabled, &Options::setSlidesEnabled);
   registerOption<QCheckBox, bool>("restoreposition_cb", &Options::restoreWindowPositionEnabled, &Options::setRestoreWindowPositionEnabled);
+  registerOption<QCheckBox, bool>("offset_preview_cb", &Options::offsetPreview, &Options::setOffsetPreview);
   registerOption<QLineEdit, QString>("playerlist_format_edit", &Options::playerlistFormatString, &Options::setPlayerlistFormatString);
 
   // Callwords tab. This could just be a QLineEdit, but no, we decided to allow

--- a/src/widgets/aooptionsdialog.h
+++ b/src/widgets/aooptionsdialog.h
@@ -76,6 +76,7 @@ private:
   QCheckBox *ui_category_stop_cb;
   QCheckBox *ui_sfx_on_idle_cb;
   QCheckBox *ui_restoreposition_cb;
+  QCheckBox *ui_offsetpreview_cb;
   QLineEdit *ui_playerlist_format_edit;
 
   // The callwords tab


### PR DESCRIPTION
Makes it togglable behavior. On, the emote will also be offset in preview. Off, the emote will stay centered. 

Addresses #848. Though it doesn't touch on why resizing breaks the offset, probably because it has to be recalculated(?).

Also adds ":" to the rest of the settings menu as some options were missing that in the labels for some reason.