### PR TITLE
Add Building, Starting

### DIFF
--- a/src/courtroom.cpp
+++ b/src/courtroom.cpp
@@ -1181,6 +1181,8 @@ void Courtroom::set_widgets()
   recess_brush = QBrush(ao_app->get_color("area_recess_color", "courtroom_design.ini"));
   rp_brush = QBrush(ao_app->get_color("area_rp_color", "courtroom_design.ini"));
   gaming_brush = QBrush(ao_app->get_color("area_gaming_color", "courtroom_design.ini"));
+  building_brush = QBrush(ao_app->get_color("area_building_color", "courtroom_design.ini"));
+  starting_brush = QBrush(ao_app->get_color("area_starting_color", "courtroom_design.ini"));
   locked_brush = QBrush(ao_app->get_color("area_locked_color", "courtroom_design.ini"));
 
   refresh_evidence();
@@ -1875,6 +1877,14 @@ void Courtroom::list_areas()
         else if (arup_statuses.at(n_area) == "GAMING")
         {
           treeItem->setBackground(1, gaming_brush);
+        }
+        else if (arup_statuses.at(n_area) == "BUILDING")
+        {
+          treeItem->setBackground(1, building_brush);
+        }
+        else if (arup_statuses.at(n_area) == "STARTING")
+        {
+          treeItem->setBackground(1, starting_brush);
         }
       }
     }

--- a/src/courtroom.h
+++ b/src/courtroom.h
@@ -599,6 +599,8 @@ private:
   QBrush recess_brush;
   QBrush rp_brush;
   QBrush gaming_brush;
+  QBrush building_brush;
+  QBrush starting_brush;
   QBrush locked_brush;
 
   AOMusicPlayer *music_player;


### PR DESCRIPTION
Adds two status, Building and starting. Client-side version.

The actual colors are defined per-theme, so all themes in the assets will be changed in accordance to this, though it is not required to actually define it, as it will still show but be colored the same as free/idle.