### PR TITLE
Fix-gitignore-autogenpath

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,7 +52,7 @@ cmake-build-*
 .ninja_deps
 .ninja_log
 .qt/
-AttorneyOnline_autogen/
+Attorney_Online_autogen/
 CMakeCache.txt
 CMakeFiles/
 Testing/


### PR DESCRIPTION
Fixes the path to be the proper path for gitignore. From #1149.