### PR TITLE
Fix-gitignore-autogen-again

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,7 +52,7 @@ cmake-build-*
 .ninja_deps
 .ninja_log
 .qt/
-Attorney_Online_autogen/
+AttorneyOnline_autogen/
 CMakeCache.txt
 CMakeFiles/
 Testing/


### PR DESCRIPTION
It is correctly AttorneyOnline_autogen. Users who pull for this will now end up having two folders, and so should take care to note that.